### PR TITLE
Exception fix for page switching

### DIFF
--- a/Unigram/Unigram/Views/MainPage.xaml.cs
+++ b/Unigram/Unigram/Views/MainPage.xaml.cs
@@ -245,7 +245,7 @@ namespace Unigram.Views
                 Execute.BeginOnUIThread(async () =>
                 {
                     ViewModel.Dialogs.LoadFirstSlice();
-                    await ViewModel.Contacts.getTLContacts();
+                    //await ViewModel.Contacts.getTLContacts(); 
                     await ViewModel.Contacts.GetSelfAsync();
                 });
             }


### PR DESCRIPTION
If you go to settings page or about page (in full mode) and then go back (via arrow) then you got a exception