### PR TITLE
Fixed webview bouncing in ArticlePage

### DIFF
--- a/Unigram/Unigram/Assets/Webviews/injected.js
+++ b/Unigram/Unigram/Assets/Webviews/injected.js
@@ -1,0 +1,8 @@
+﻿document.body.style.overflow = 'hidden';
+document.body.style.msContentZooming = 'none';
+document.body.style.touchAction = 'none';
+document.body.style.msTouchAction = 'none';
+document.body.style.msContentZoomLimitMax = '100%';
+
+viewport = document.querySelector("meta[name=viewport]");
+viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0');

--- a/Unigram/Unigram/Unigram.csproj
+++ b/Unigram/Unigram/Unigram.csproj
@@ -495,6 +495,9 @@
     <Content Include="Assets\Mockups\UserIcons\user_batman.png" />
     <None Include="Package.StoreAssociation.xml" />
     <Content Include="Assets\Noise.jpg" />
+    <Content Include="Assets\Webviews\injected.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="VoiceCommands\VoiceCommands.xml" />
     <Content Include="Properties\Default.rd.xml" />
   </ItemGroup>


### PR DESCRIPTION
This change injects some JavaScript in the webviews embedded in Instant View articles, with the purpose of disabling their bouncing.