### PR TITLE
Add ¯\_(ツ)_/¯ button

### DIFF
--- a/Unigram/Unigram/Controls/BubbleTextBox.cs
+++ b/Unigram/Unigram/Controls/BubbleTextBox.cs
@@ -167,6 +167,23 @@ namespace Unigram.Controls
             OnSelectionChanged();
         }
 
+        public void InsertText(string text)
+        {
+            var start = Document.Selection.StartPosition;
+            var end = Document.Selection.EndPosition;
+
+            var preceding = start > 0 && !char.IsWhiteSpace(Document.GetRange(start - 1, start).Character);
+            var trailing = !char.IsWhiteSpace(Document.GetRange(end, end + 1).Character);
+
+            var block = string.Format("{0}{1}{2}",
+                preceding ? " " : "",
+                text,
+                trailing ? " " : "");
+
+            Document.Selection.SetText(TextSetOptions.None, block);
+            Document.Selection.StartPosition = Document.Selection.EndPosition;
+        }
+
         private async void OnPaste(object sender, TextControlPasteEventArgs e)
         {
             // If the user tries to paste RTF content from any TOM control (Visual Studio, Word, Wordpad, browsers)

--- a/Unigram/Unigram/Views/DialogPage.xaml
+++ b/Unigram/Unigram/Views/DialogPage.xaml
@@ -1075,6 +1075,12 @@
                                         IsEnabled="False"
                                         Text="Contact"
                                         Tag="&#xE136;"/>
+                        <MenuFlyoutItem Style="{StaticResource IconMenuFlyoutItem}"
+                                        Visibility="Visible"
+                                        IsEnabled="True"
+                                        Text="¯\_(ツ)_/¯"
+                                        Tag="&#xE8BD;"
+                                        Click="{x:Bind SendShrug}"/>
                         <MenuFlyout.MenuFlyoutPresenterStyle>
                             <Style TargetType="MenuFlyoutPresenter">
                                 <Setter Property="Background" Value="{ThemeResource ApplicationPageBackgroundThemeBrush}" />

--- a/Unigram/Unigram/Views/DialogPage.xaml.cs
+++ b/Unigram/Unigram/Views/DialogPage.xaml.cs
@@ -184,6 +184,8 @@ namespace Unigram.Views
             }
         }
 
+        private void SendShrug() => txtMessage.InsertText("¯\\_(ツ)_/¯");
+
         private void AttachPickerFlyout_ItemClick(object sender, MediaSelectedEventArgs e)
         {
             var flyout = FlyoutBase.GetAttachedFlyout(Attach) as MenuFlyout;


### PR DESCRIPTION
This PR adds a `¯\_(ツ)_/¯` button in the attachment flyout. 

It also adds a general purpose `InsertText()` method to `BubbleTextBox` that also takes care of adding the preceding and trailing spaces when necessary.

![Screenshot](http://i.imgur.com/AKgyybE.jpg)