### PR TITLE
Issue #273 fix

### DIFF
--- a/Unigram/Unigram/Common/IncrementalCollection.cs
+++ b/Unigram/Unigram/Common/IncrementalCollection.cs
@@ -53,6 +53,7 @@ namespace Unigram.Common
 
         public IAsyncOperation<LoadMoreItemsResult> LoadMoreItemsAsync(uint count)
         {
+            System.Diagnostics.Debug.WriteLine("LoadMoreItemsAsync called");
             //var dispatcher = Window.Current.Dispatcher;
 
             //return Task.Run(async () =>
@@ -108,10 +109,14 @@ namespace Unigram.Common
 
         protected virtual void Merge(IList<T> result)
         {
+            System.Diagnostics.Debug.WriteLine("This count: " + this.Count + ", result count: " + result.Count);
+            this.AddRange(result);
+            /*this.AddRange(result.Except(this));
             foreach (T item in result)
-            {
+            {   
                 this.Add(item);
             }
+            System.Diagnostics.Debug.WriteLine("This count: " + this.Count + ", result count: " + result.Count);*/
         }
 
         public new event PropertyChangedEventHandler PropertyChanged;


### PR DESCRIPTION
Hi!
Before my fixes, new items (such as screen shots) were added by following algorithm:
1. Clear all items from the list
2. Add items that OnContentsChanged received.
In some cases, you could take a screen shot with opened attach flyout and all recent images may gone. Or they could be added with ugly blinking effect, as shown in #273 .

I've managed to solve both problems. Now there is synchronized HashSet in MediaLibraryConnection which stores ids for all shown pictures, so we can add only new items to this grid, which also leads to nice animations of insertion.

Potential problem: I don't process a case when OnContentsChanged() received due to photos removal.

Sorry if I did something in a wrong way, C# is not my primary language :(
