### PR TITLE
Fixed spelling mistake in VOIP call mediator toast notification

### DIFF
--- a/Unigram/Unigram.Tasks/VoIPCallTask.cs
+++ b/Unigram/Unigram.Tasks/VoIPCallTask.cs
@@ -161,7 +161,7 @@ namespace Unigram.Tasks
             }
             else
             {
-                VoIPCallTask.Log("Mediator initialized", "Disconnetting app service");
+                VoIPCallTask.Log("Mediator initialized", "Disconnecting app service");
 
                 if (_connection != null)
                 {


### PR DESCRIPTION
Found a spelling mistake in the VOIPCallTask mediator toast notification. This PR just corrects it, to spare my OCD. 👍 