### PR TITLE
Fixed app crash on TLReplyKeyboardHide

### DIFF
--- a/Unigram/Unigram/Controls/ReplyMarkupPanel.cs
+++ b/Unigram/Unigram/Controls/ReplyMarkupPanel.cs
@@ -95,7 +95,7 @@ namespace Unigram.Controls
             }
             else if (ReplyMarkup is TLReplyKeyboardHide && !inline && Parent is ScrollViewer scroll2)
             {
-                Height = double.NaN;
+                Height = 0;
                 scroll2.MaxHeight = double.PositiveInfinity;
             }
         }


### PR DESCRIPTION
The ReplyMarkupPanel was setting height to auto on TLReplyKeyboardHide.
This was causing trouble calculating height for the grid scrollbar
and caused Layout Cycle Error Detected message. Now has been set to zero.