### PR TITLE
Fix to last message hidden under bot keyboard

### DIFF
--- a/Unigram/Unigram/Controls/BubbleListView.cs
+++ b/Unigram/Unigram/Controls/BubbleListView.cs
@@ -70,7 +70,7 @@ namespace Unigram.Controls
                     await ViewModel.LoadPreviousSliceAsync();
                 }
 
-                await ViewModel.LoadNextSliceAsync();
+                await ViewModel.LoadNextSliceAsync(false, ItemsStack.LastVisibleIndex == ItemsStack.LastCacheIndex);
             }
         }
 
@@ -84,7 +84,7 @@ namespace Unigram.Controls
             {
                 if (ViewModel.IsFirstSliceLoaded == false)
                 {
-                    await ViewModel.LoadPreviousSliceAsync(true);
+                    await ViewModel.LoadPreviousSliceAsync(true, ItemsStack.LastVisibleIndex == ItemsStack.LastCacheIndex);
                 }
             }
         }

--- a/Unigram/Unigram/ViewModels/DialogViewModel.cs
+++ b/Unigram/Unigram/ViewModels/DialogViewModel.cs
@@ -581,7 +581,7 @@ namespace Unigram.ViewModels
             IsLoading = false;
         }
 
-        public async Task LoadPreviousSliceAsync(bool force = false)
+        public async Task LoadPreviousSliceAsync(bool force = false, bool last = false)
         {
             if (_isLoadingNextSlice || _isLoadingPreviousSlice || _peer == null)
             {
@@ -590,7 +590,14 @@ namespace Unigram.ViewModels
 
             _isLoadingPreviousSlice = true;
             IsLoading = true;
-            UpdatingScrollMode = force ? UpdatingScrollMode.ForceKeepItemsInView : UpdatingScrollMode.KeepItemsInView;
+            if (last)
+            {
+                UpdatingScrollMode = force ? UpdatingScrollMode.ForceKeepLastItemInView : UpdatingScrollMode.KeepLastItemInView;
+            }
+            else
+            {
+                UpdatingScrollMode = force ? UpdatingScrollMode.ForceKeepItemsInView : UpdatingScrollMode.KeepItemsInView;
+            }
 
             Debug.WriteLine("DialogViewModel: LoadPreviousSliceAsync");
 


### PR DESCRIPTION
The bot keyboard forced a resize of the scrollview: in that case
the scrollview was set to KeepItemsInView and so last messages were
hidden. Now an additional params tells the scrollview to go in
KeepLastItemInView in case the last message of the chat is shown.