### PR TITLE
Bot keyboard not resizing

### DIFF
--- a/Unigram/Unigram/Controls/ReplyMarkupPanel.cs
+++ b/Unigram/Unigram/Controls/ReplyMarkupPanel.cs
@@ -82,7 +82,7 @@ namespace Unigram.Controls
             if (ReplyMarkup is TLReplyKeyboardMarkup && !inline && Parent is ScrollViewer scroll)
             {
                 var keyboard = ReplyMarkup as TLReplyKeyboardMarkup;
-                if (keyboard.IsResize && double.IsNaN(Height))
+                if (keyboard.IsResize)
                 {
                     Height = double.NaN;
                     scroll.MaxHeight = _keyboardHeight;

--- a/Unigram/Unigram/Controls/ReplyMarkupPanel.cs
+++ b/Unigram/Unigram/Controls/ReplyMarkupPanel.cs
@@ -87,10 +87,10 @@ namespace Unigram.Controls
                     Height = double.NaN;
                     scroll.MaxHeight = _keyboardHeight;
                 }
-                else if (keyboard.IsResize == false && double.IsNaN(Height) && Parent is ScrollViewer scroll1)
+                else
                 {
                     Height = _keyboardHeight;
-                    scroll1.MaxHeight = double.PositiveInfinity;
+                    scroll.MaxHeight = double.PositiveInfinity;
                 }
             }
             else if (ReplyMarkup is TLReplyKeyboardHide && !inline && Parent is ScrollViewer scroll2)


### PR DESCRIPTION
The bot keyboard don't resize when a previous keyboard with resize
false set the height to system keyboard height. Removed the control of
the height, so the keyboard isResize true will be correctly resized.