### PR TITLE
System keyboard auto hide on ReplyKeyboardMarkup

### DIFF
--- a/Unigram/Unigram/Controls/ReplyMarkupPanel.cs
+++ b/Unigram/Unigram/Controls/ReplyMarkupPanel.cs
@@ -92,6 +92,7 @@ namespace Unigram.Controls
                     Height = _keyboardHeight;
                     scroll.MaxHeight = double.PositiveInfinity;
                 }
+                InputPane.GetForCurrentView().TryHide();
             }
             else if (ReplyMarkup is TLReplyKeyboardHide && !inline && Parent is ScrollViewer scroll2)
             {

--- a/Unigram/Unigram/Controls/ReplyMarkupPanel.cs
+++ b/Unigram/Unigram/Controls/ReplyMarkupPanel.cs
@@ -92,7 +92,6 @@ namespace Unigram.Controls
                     Height = _keyboardHeight;
                     scroll.MaxHeight = double.PositiveInfinity;
                 }
-                InputPane.GetForCurrentView().TryHide();
             }
             else if (ReplyMarkup is TLReplyKeyboardHide && !inline && Parent is ScrollViewer scroll2)
             {

--- a/Unigram/Unigram/ViewModels/DialogViewModel.Handle.cs
+++ b/Unigram/Unigram/ViewModels/DialogViewModel.Handle.cs
@@ -16,6 +16,7 @@ using Unigram.Converters;
 using Unigram.Services;
 using Windows.System.Profile;
 using Windows.UI.Notifications;
+using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 
 namespace Unigram.ViewModels
@@ -590,6 +591,12 @@ namespace Unigram.ViewModels
                         if (user != null && user.IsBot)
                         {
                             SetReplyMarkup(message);
+                            if (message.ReplyMarkup is TLReplyKeyboardMarkup)
+                            {
+                                ListField.Focus(FocusState.Programmatic);
+                                InputPane.GetForCurrentView().TryHide();
+                               
+                            }
                         }
                     }
 

--- a/Unigram/Unigram/ViewModels/DialogViewModel.Handle.cs
+++ b/Unigram/Unigram/ViewModels/DialogViewModel.Handle.cs
@@ -591,11 +591,10 @@ namespace Unigram.ViewModels
                         if (user != null && user.IsBot)
                         {
                             SetReplyMarkup(message);
+
                             if (message.ReplyMarkup is TLReplyKeyboardMarkup)
                             {
-                                ListField.Focus(FocusState.Programmatic);
                                 InputPane.GetForCurrentView().TryHide();
-                               
                             }
                         }
                     }


### PR DESCRIPTION
When you send a message with a system keyboard if the
response has a ReplyKeyboardMarkup (bot keyboard)
then the syskeyboard will auto hide