### PR TITLE
Fixed ArgumentException when trying to show a context menu on first pixel (X or Y axis) of selected element/area

### DIFF
--- a/Unigram/Unigram/Controls/Messages/MessageBubbleBase.cs
+++ b/Unigram/Unigram/Controls/Messages/MessageBubbleBase.cs
@@ -323,6 +323,11 @@ namespace Unigram.Controls.Messages
         {
             if (args.TryGetPosition(sender, out Point point))
             {
+                if (point.X < 0 || point.Y < 0)
+                {
+                    point = new Point(Math.Max(point.X, 0), Math.Max(point.Y, 0));
+                }
+
                 var text = sender as RichTextBlock;
                 var hyperlink = text.GetHyperlinkFromPoint(point);
                 if (hyperlink != null && hyperlink.NavigateUri != null)

--- a/Unigram/Unigram/Views/Channels/ChannelDetailsPage.xaml.cs
+++ b/Unigram/Unigram/Views/Channels/ChannelDetailsPage.xaml.cs
@@ -108,6 +108,11 @@ namespace Unigram.Views.Channels
 
             if (menu.Items.Count > 0 && args.TryGetPosition(sender, out Point point))
             {
+                if (point.X < 0 || point.Y < 0)
+                {
+                    point = new Point(Math.Max(point.X, 0), Math.Max(point.Y, 0));
+                }
+
                 menu.ShowAt(sender, point);
             }
         }

--- a/Unigram/Unigram/Views/DialogPage.xaml.cs
+++ b/Unigram/Unigram/Views/DialogPage.xaml.cs
@@ -747,6 +747,11 @@ namespace Unigram.Views
 
             if (menu.Items.Count > 0 && args.TryGetPosition(sender, out Point point))
             {
+                if (point.X < 0 || point.Y < 0)
+                {
+                    point = new Point(Math.Max(point.X, 0), Math.Max(point.Y, 0));
+                }
+
                 menu.ShowAt(sender, point);
             }
         }

--- a/Unigram/Unigram/Views/MainPage.xaml.cs
+++ b/Unigram/Unigram/Views/MainPage.xaml.cs
@@ -679,6 +679,11 @@ namespace Unigram.Views
 
             if (menu.Items.Count > 0 && args.TryGetPosition(sender, out Point point))
             {
+                if (point.X < 0 || point.Y < 0)
+                {
+                    point = new Point(Math.Max(point.X, 0), Math.Max(point.Y, 0));
+                }
+
                 menu.ShowAt(sender, point);
             }
         }


### PR DESCRIPTION
When user try to open a context menu (like chats options) on first pixel of X and/or Y axis, expecially with a physical mouse, Unigram shows a message with an ArgumentException... Not anymore with this fix on Point instance (that could have negative axis's values)