### PR TITLE
Enabled option to save media from GalleryView fullscreen mode

### DIFF
--- a/Unigram/Unigram/Controls/Views/GalleryView.xaml
+++ b/Unigram/Unigram/Controls/Views/GalleryView.xaml
@@ -175,7 +175,8 @@
                             <MenuFlyoutItem Command="{x:Bind ViewModel.DeleteCommand}"
                                             Visibility="{x:Bind (Visibility)ViewModel.CanDelete}"
                                             Text="Delete"/>
-                            <MenuFlyoutItem Visibility="{x:Bind (Visibility)ViewModel.CanSave}"
+                            <MenuFlyoutItem Command="{x:Bind ViewModel.SaveCommand}"
+                                            Visibility="{x:Bind (Visibility)ViewModel.CanSave}"
                                             Text="Save file as..." />
                             <MenuFlyoutItem Command="{x:Bind ViewModel.OpenWithCommand}"
                                             Visibility="{x:Bind (Visibility)ViewModel.CanOpenWith}"

--- a/Unigram/Unigram/Helpers/TLFileHelper.cs
+++ b/Unigram/Unigram/Helpers/TLFileHelper.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Telegram.Api.Helpers;
+using Telegram.Api.TL;
+using Unigram.Converters;
+using Windows.Storage.Pickers;
+
+namespace Unigram.Helpers
+{
+    public static class TLFileHelper
+    {
+        public static async Task SavePhotoAsync(TLPhotoSize photoSize, int date)
+        {
+            var location = photoSize.Location;
+            var fileName = string.Format("{0}_{1}_{2}.jpg", location.VolumeId, location.LocalId, location.Secret);
+            if (File.Exists(FileUtils.GetTempFileName(fileName)))
+            {
+                var picker = new FileSavePicker();
+                picker.FileTypeChoices.Add("JPEG Image", new[] { ".jpg" });
+                picker.SuggestedStartLocation = PickerLocationId.PicturesLibrary;
+                picker.SuggestedFileName = BindConvert.Current.DateTime(date).ToString("photo_yyyyMMdd_HH_mm_ss") + ".jpg";
+
+                var file = await picker.PickSaveFileAsync();
+                if (file != null)
+                {
+                    var result = await FileUtils.GetTempFileAsync(fileName);
+                    await result.CopyAndReplaceAsync(file);
+                }
+            }
+        }
+
+        public static async Task SaveDocumentAsync(TLDocument document, int date)
+        {
+            var fileName = document.GetFileName();
+            if (File.Exists(FileUtils.GetTempFileName(fileName)))
+            {
+                var extension = document.GetFileExtension();
+
+                var picker = new FileSavePicker();
+                picker.FileTypeChoices.Add($"{extension.TrimStart('.').ToUpper()} File", new[] { document.GetFileExtension() });
+                picker.SuggestedStartLocation = PickerLocationId.Downloads;
+                picker.SuggestedFileName = BindConvert.Current.DateTime(date).ToString("photo_yyyyMMdd_HH_mm_ss") + extension;
+
+                var fileNameAttribute = document.Attributes.OfType<TLDocumentAttributeFilename>().FirstOrDefault();
+                if (fileNameAttribute != null)
+                {
+                    picker.SuggestedFileName = fileNameAttribute.FileName;
+                }
+
+                var file = await picker.PickSaveFileAsync();
+                if (file != null)
+                {
+                    var result = await FileUtils.GetTempFileAsync(fileName);
+                    await result.CopyAndReplaceAsync(file);
+                }
+            }
+        }
+    }
+}

--- a/Unigram/Unigram/Unigram.csproj
+++ b/Unigram/Unigram/Unigram.csproj
@@ -273,6 +273,7 @@
     <Compile Include="Converters\StickerToEmojiConverter.cs" />
     <Compile Include="Converters\UsernameConverter.cs" />
     <Compile Include="Converters\VenueToGlyphConverter.cs" />
+    <Compile Include="Helpers\TLFileHelper.cs" />
     <Compile Include="Models\Country.cs" />
     <Compile Include="Models\StorageDocument.cs" />
     <Compile Include="Models\StorageMedia.cs" />

--- a/Unigram/Unigram/ViewModels/DialogViewModel.Messages.cs
+++ b/Unigram/Unigram/ViewModels/DialogViewModel.Messages.cs
@@ -16,6 +16,7 @@ using Unigram.Common;
 using Unigram.Controls;
 using Unigram.Controls.Views;
 using Unigram.Converters;
+using Unigram.Helpers;
 using Unigram.Native;
 using Unigram.Services;
 using Unigram.Views;
@@ -1301,60 +1302,13 @@ namespace Unigram.ViewModels
             var photo = message.GetPhoto();
             if (photo?.Full is TLPhotoSize photoSize)
             {
-                await SavePhotoAsync(photoSize, message.Date);
+                await TLFileHelper.SavePhotoAsync(photoSize, message.Date);
             }
 
             var document = message.GetDocument();
             if (document != null)
             {
-                await SaveDocumentAsync(document, message.Date);
-            }
-        }
-
-        private async Task SavePhotoAsync(TLPhotoSize photoSize, int date)
-        {
-            var location = photoSize.Location;
-            var fileName = string.Format("{0}_{1}_{2}.jpg", location.VolumeId, location.LocalId, location.Secret);
-            if (File.Exists(FileUtils.GetTempFileName(fileName)))
-            {
-                var picker = new FileSavePicker();
-                picker.FileTypeChoices.Add("JPEG Image", new[] { ".jpg" });
-                picker.SuggestedStartLocation = PickerLocationId.PicturesLibrary;
-                picker.SuggestedFileName = BindConvert.Current.DateTime(date).ToString("photo_yyyyMMdd_HH_mm_ss") + ".jpg";
-
-                var file = await picker.PickSaveFileAsync();
-                if (file != null)
-                {
-                    var result = await FileUtils.GetTempFileAsync(fileName);
-                    await result.CopyAndReplaceAsync(file);
-                }
-            }
-        }
-
-        private async Task SaveDocumentAsync(TLDocument document, int date)
-        {
-            var fileName = document.GetFileName();
-            if (File.Exists(FileUtils.GetTempFileName(fileName)))
-            {
-                var extension = document.GetFileExtension();
-
-                var picker = new FileSavePicker();
-                picker.FileTypeChoices.Add($"{extension.TrimStart('.').ToUpper()} File", new[] { document.GetFileExtension() });
-                picker.SuggestedStartLocation = PickerLocationId.Downloads;
-                picker.SuggestedFileName = BindConvert.Current.DateTime(date).ToString("photo_yyyyMMdd_HH_mm_ss") + extension;
-
-                var fileNameAttribute = document.Attributes.OfType<TLDocumentAttributeFilename>().FirstOrDefault();
-                if (fileNameAttribute != null)
-                {
-                    picker.SuggestedFileName = fileNameAttribute.FileName;
-                }
-
-                var file = await picker.PickSaveFileAsync();
-                if (file != null)
-                {
-                    var result = await FileUtils.GetTempFileAsync(fileName);
-                    await result.CopyAndReplaceAsync(file);
-                }
+                await TLFileHelper.SaveDocumentAsync(document, message.Date);
             }
         }
 

--- a/Unigram/Unigram/ViewModels/GalleryViewModelBase.cs
+++ b/Unigram/Unigram/ViewModels/GalleryViewModelBase.cs
@@ -16,9 +16,11 @@ using Unigram.Common;
 using Unigram.Controls.Views;
 using Unigram.Converters;
 using Unigram.Core.Common;
+using Unigram.Helpers;
 using Unigram.ViewModels.Chats;
 using Unigram.ViewModels.Users;
 using Windows.Storage;
+using Windows.Storage.Pickers;
 using Windows.System;
 
 namespace Unigram.ViewModels
@@ -31,6 +33,7 @@ namespace Unigram.ViewModels
             StickersCommand = new RelayCommand(StickersExecute);
             GotoCommand = new RelayCommand(GotoExecute);
             DeleteCommand = new RelayCommand(DeleteExecute);
+            SaveCommand = new RelayCommand(SaveExecute);
             OpenWithCommand = new RelayCommand(OpenWithExecute);
         }
 
@@ -136,7 +139,7 @@ namespace Unigram.ViewModels
         {
             get
             {
-                return false;
+                return true;
             }
         }
 
@@ -199,34 +202,25 @@ namespace Unigram.ViewModels
         {
         }
 
+        public RelayCommand SaveCommand { get; }
+        protected virtual async void SaveExecute()
+        {
+            var value = GetTLObjectFromSelectedGalleryItem();
+
+            if (value is TLPhoto photo && photo.Full is TLPhotoSize photoSize)
+            {
+                await TLFileHelper.SavePhotoAsync(photoSize, photo.Date);
+            }
+            else if (value is TLDocument document)
+            {
+                await TLFileHelper.SaveDocumentAsync(document, document.Date);
+            }
+        }
+
         public RelayCommand OpenWithCommand { get; }
         protected virtual async void OpenWithExecute()
         {
-            object value = null;
-
-            if (SelectedItem is GalleryMessageItem messageItem)
-            {
-                if (messageItem.Message.Media is TLMessageMediaPhoto photoMedia)
-                {
-                    value = photoMedia.Photo;
-                }
-                else if (messageItem.Message.Media is TLMessageMediaDocument documentMedia && documentMedia.Document is TLDocument document)
-                {
-                    value = document;
-                }
-            }
-            else if (SelectedItem is GalleryMessageServiceItem serviceItem && serviceItem.Message.Action is TLMessageActionChatEditPhoto chatEditPhotoAction)
-            {
-                value = chatEditPhotoAction.Photo;
-            }
-            else if (SelectedItem is GalleryPhotoItem photoItem)
-            {
-                value = photoItem.Photo;
-            }
-            else if (SelectedItem is GalleryDocumentItem documentItem)
-            {
-                value = documentItem.Document;
-            }
+            var value = GetTLObjectFromSelectedGalleryItem();
 
             if (value is TLPhoto photo && photo.Full is TLPhotoSize photoSize)
             {
@@ -262,6 +256,39 @@ namespace Unigram.ViewModels
 
             // Open that file
             //await Windows.System.Launcher.LaunchFileAsync(*INSERT FILE HERE*);
+        }
+
+        private object GetTLObjectFromSelectedGalleryItem()
+        {
+            if (SelectedItem is GalleryMessageItem messageItem)
+            {
+                if (messageItem.Message.Media is TLMessageMediaPhoto photoMedia)
+                {
+                    return photoMedia.Photo;
+                }
+
+                if (messageItem.Message.Media is TLMessageMediaDocument documentMedia && documentMedia.Document is TLDocument document)
+                {
+                    return document;
+                }
+            }
+
+            if (SelectedItem is GalleryMessageServiceItem serviceItem && serviceItem.Message.Action is TLMessageActionChatEditPhoto chatEditPhotoAction)
+            {
+                return chatEditPhotoAction.Photo;
+            }
+
+            if (SelectedItem is GalleryPhotoItem photoItem)
+            {
+                return photoItem.Photo;
+            }
+
+            if (SelectedItem is GalleryDocumentItem documentItem)
+            {
+                return documentItem.Document;
+            }
+
+            return null;
         }
     }
 


### PR DESCRIPTION
Now user can only save displayed files with two steps ("Open With" > select a supported app > save from that app) or right click/long pressing on file from chat view. 

This PR enable a dedicated option to save previewed file with a FileSavePicker.