### PR TITLE
Fixes #319 and stickers height glitch

### DIFF
--- a/Unigram/Unigram/Views/DialogPage.xaml.cs
+++ b/Unigram/Unigram/Views/DialogPage.xaml.cs
@@ -292,6 +292,7 @@ namespace Unigram.Views
             StickersPanel.Height = args.OccludedRect.Height;
             ReplyMarkupPanel.MaxHeight = args.OccludedRect.Height;
             //ReplyMarkupViewer.MaxHeight = args.OccludedRect.Height;
+            StickersPanel.Visibility = Visibility.Collapsed;
 
             _lastKnownKeyboardHeight = Math.Max(260, args.OccludedRect.Height);
 
@@ -660,6 +661,7 @@ namespace Unigram.Views
 
                 StickersPanel.Visibility = Visibility.Visible;
                 StickersPanel.Refresh();
+                _lastKnownKeyboardHeight = StickersPanel.Height;
 
                 ViewModel.OpenStickersCommand.Execute(null);
             }


### PR DESCRIPTION
This fixes https://github.com/UnigramDev/Unigram/issues/319 (stiker panel not collapsed after using system keyboard) and the sticker panel size on resize. 