### PR TITLE
Fix for camera picker issue #455

### DIFF
--- a/Unigram/Unigram/ViewModels/DialogViewModel.Media.cs
+++ b/Unigram/Unigram/ViewModels/DialogViewModel.Media.cs
@@ -614,6 +614,11 @@ namespace Unigram.ViewModels
         public async void SendMediaExecute(ObservableCollection<StorageMedia> media, StorageMedia selectedItem)
         {
             var storages = media;
+            if (!media.Contains(selectedItem))
+            {
+                storages.Insert(0, selectedItem);
+            }
+
             if (storages != null && storages.Count > 0)
             {
                 var dialog = new SendMediaView { ViewModel = this, Items = storages, SelectedItem = selectedItem, IsTTLEnabled = _peer is TLInputPeerUser };


### PR DESCRIPTION
As described by issue #455 , if user tries to take photos/videos with Capture UI system task and confirm selected captured media, SendMediaView doesn't show the captured media as available share option because it doesn't load the updated media collection, excluding last file.

This PR fixes it by adding captured media to SendMediaView's media collection in right position