### PR TITLE
Use two way binding for folder navigation

### DIFF
--- a/Unigram/Unigram/Views/MainPage.xaml
+++ b/Unigram/Unigram/Views/MainPage.xaml
@@ -501,7 +501,7 @@
                                             <x:Double x:Key="NavigationViewTopPaneHeight">40</x:Double>
                                         </ScrollViewer.Resources>
                                         <Grid x:Name="ChatTabsView">
-                                            <microsoft:NavigationView PaneDisplayMode="Top" MenuItemsSource="{x:Bind ViewModel.Filters}" SelectedItem="{x:Bind ViewModel.SelectedFilter, Mode=OneWay}" ItemInvoked="NavigationView_ItemInvoked" IsBackButtonVisible="Collapsed" IsBackEnabled="False" IsSettingsVisible="False">
+                                            <microsoft:NavigationView PaneDisplayMode="Top" MenuItemsSource="{x:Bind ViewModel.Filters}" SelectedItem="{x:Bind ViewModel.SelectedFilter, Mode=TwoWay}" IsBackButtonVisible="Collapsed" IsBackEnabled="False" IsSettingsVisible="False">
                                                 <microsoft:NavigationView.MenuItemTemplate>
                                                     <DataTemplate x:DataType="td:ChatListFilter">
                                                         <microsoft:NavigationViewItem

--- a/Unigram/Unigram/Views/MainPage.xaml.cs
+++ b/Unigram/Unigram/Views/MainPage.xaml.cs
@@ -2744,14 +2744,5 @@ namespace Unigram.Views
 
             return null;
         }
-
-
-        private void NavigationView_ItemInvoked(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs args)
-        {
-            if (args.InvokedItemContainer.DataContext is ChatListFolder filter)
-            {
-                SetFilter(filter.Id == Constants.ChatListFilterAll ? null : filter);
-            }
-        }
     }
 }


### PR DESCRIPTION
Seems to be more efficient and works better on old Windows 10 versions.