### PR TITLE
Correct CheckedForeground for Mono Formatting Button

### DIFF
--- a/Unigram/Unigram/Controls/Chats/ChatTextFormatting.xaml
+++ b/Unigram/Unigram/Controls/Chats/ChatTextFormatting.xaml
@@ -65,7 +65,7 @@
             AllowFocusOnInteraction="False"
             CheckedGlyph="&#xE943;"
             UncheckedGlyph="&#xE943;"
-            CheckedForeground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+            CheckedForeground="{ThemeResource TelegramBackgroundAccentBrush}"
             IsOneWay="False"
             FontSize="16"/>
 


### PR DESCRIPTION
The formatting button for "Mono" does not get highlighted when on. This change corrects it.