### PR TITLE
Fix crash on new Camery flyout

### DIFF
--- a/Unigram/Unigram/ViewModels/DialogViewModel.Media.cs
+++ b/Unigram/Unigram/ViewModels/DialogViewModel.Media.cs
@@ -419,7 +419,7 @@ namespace Unigram.ViewModels
                 storages.Add(storage);
             }
 
-            SendMediaExecute(storages, null);
+            SendMediaExecute(storages, storage);
         }
 
         public RelayCommand SendMediaCommand { get; }
@@ -463,7 +463,7 @@ namespace Unigram.ViewModels
 
             var formattedText = GetFormattedText(true);
 
-            if (selectedItem.Caption is null)
+            if (selectedItem != null && selectedItem.Caption is null)
             {
                 selectedItem.Caption = formattedText
                     .Substring(0, CacheService.Options.MessageCaptionLengthMax);


### PR DESCRIPTION
TL;DR: I guess it is easier to grasp the code changes than to read my text.


`public async void SendMediaExecute(ObservableCollection<StorageMedia> media, StorageMedia selectedItem)`
crashes, when the second parameter is null. That happens when I use the new camera flyout because of `SendMediaExecute(storages, null);`

I fixed both problems, so in case another call of SendMediaExecute gets null that (I guess it is impossible in your code with `>0 sorages[0]: null`), but you never know. In that case, only clicking the TTL button would crash, as the selected media would be null...