### PR TITLE
Fix AccessViolationException on Settings->Data Usage

### DIFF
--- a/Unigram/Unigram/Views/Settings/SettingsNetworkPage.xaml
+++ b/Unigram/Unigram/Views/Settings/SettingsNetworkPage.xaml
@@ -26,26 +26,22 @@
             <RowDefinition Height="Auto" />
             <RowDefinition />
         </Grid.RowDefinitions>
-        <controls:PageHeader Text="{CustomResource NetworkUsage}"/>
+        <controls:PageHeader 
+            Text="{CustomResource NetworkUsage}"
+            Grid.Row="0"/>
 
         <microsoft:NavigationView
             x:Name="Header"
+            PaneDisplayMode="Top"
             MenuItemsSource="{x:Bind ViewModel.Items}"
             SelectedItem="{x:Bind ViewModel.SelectedItem, Mode=TwoWay}"
-            IsBackEnabled="True"
-            OverflowLabelMode="NoLabel"
-            PaneDisplayMode="Top"
-            IsSettingsVisible="False"
-            IsBackButtonVisible="Visible"
-            BackRequested="Header_BackRequested"
-            Grid.RowSpan="2">
-            
+            IsBackButtonVisible="Collapsed" IsBackEnabled="False" IsSettingsVisible="False"
+            Grid.Row="1">
             <ScrollViewer
                 x:Name="ScrollingHost"
                 Background="{ThemeResource PageBackgroundDarkBrush}"
                 VerticalScrollBarVisibility="Auto"
-                VerticalScrollMode="Auto"
-                Grid.Row="1">
+                VerticalScrollMode="Auto">
                 <StackPanel>
                     <ItemsControl ItemsSource="{x:Bind ViewModel.SelectedItem, Mode=OneWay}">
                         <ItemsControl.ItemTemplateSelector>
@@ -57,7 +53,7 @@
                                             <controls:BadgeButton
                                                 Content="{CustomResource BytesSent}"
                                                 Badge="{x:Bind SentBytes, Converter={StaticResource FileSizeConverter}}"/>
-                                            
+
                                             <controls:BadgeButton
                                                 Content="{CustomResource BytesReceived}"
                                                 Badge="{x:Bind ReceivedBytes, Converter={StaticResource FileSizeConverter}}"/>
@@ -71,11 +67,11 @@
                                             <controls:BadgeButton
                                                 Content="{CustomResource BytesSent}"
                                                 Badge="{x:Bind SentBytes, Converter={StaticResource FileSizeConverter}}"/>
-                                        
+
                                             <controls:BadgeButton
                                                 Content="{CustomResource BytesReceived}"
                                                 Badge="{x:Bind ReceivedBytes, Converter={StaticResource FileSizeConverter}}"/>
-                                        
+
                                             <controls:BadgeButton
                                                 Content="{CustomResource CallsTotalTime}"
                                                 Badge="{x:Bind Duration}"/>

--- a/Unigram/Unigram/Views/Settings/SettingsNetworkPage.xaml.cs
+++ b/Unigram/Unigram/Views/Settings/SettingsNetworkPage.xaml.cs
@@ -1,19 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Unigram.Converters;
 using Unigram.ViewModels.Settings;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
 
 namespace Unigram.Views.Settings
 {
@@ -25,14 +13,6 @@ namespace Unigram.Views.Settings
         {
             InitializeComponent();
             DataContext = TLContainer.Current.Resolve<SettingsNetworkViewModel>();
-        }
-
-        private void Header_BackRequested(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewBackRequestedEventArgs args)
-        {
-            if (Frame.CanGoBack)
-            {
-                Frame.GoBack();
-            }
         }
 
         #region Binding


### PR DESCRIPTION
These changes prevent throwing the exception on runtime for me. Hopefully for you too. :)

It also contains a small design change: It finally shows the header and below that the navigation view.