### PR TITLE
Adjust to new namespace in string references

### DIFF
--- a/Unigram/Unigram.Native.Media/MediaCapturePreview.h
+++ b/Unigram/Unigram.Native.Media/MediaCapturePreview.h
@@ -32,7 +32,7 @@ namespace Unigram
 			{
 				friend class MediaCapturePreviewStreamSink;
 
-				InspectableClass(L"Unigram.Native.MediaCapturePreviewSourceMediaSink", BaseTrust);
+				InspectableClass(L"Unigram.Native.Media.MediaCapturePreviewSourceMediaSink", BaseTrust);
 
 			public:
 				MediaCapturePreviewMediaSink();
@@ -88,7 +88,7 @@ namespace Unigram
 			{
 				friend class MediaCapturePreviewMediaStream;
 
-				InspectableClass(L"Unigram.Native.MediaCapturePreviewSourceMediaSource", BaseTrust);
+				InspectableClass(L"Unigram.Native.Media.MediaCapturePreviewSourceMediaSource", BaseTrust);
 
 			public:
 				MediaCapturePreviewMediaSource();

--- a/Unigram/Unigram.Native.Media/Opus/OpusByteStreamHandler.h
+++ b/Unigram/Unigram.Native.Media/Opus/OpusByteStreamHandler.h
@@ -12,7 +12,7 @@ namespace Unigram
 
 			class OpusByteStreamHandler WrlSealed : public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, ByteStreamHandler>
 			{
-				InspectableClass(L"Unigram.Native.OpusByteStreamHandler", TrustLevel::BaseTrust);
+				InspectableClass(L"Unigram.Native.Media.OpusByteStreamHandler", TrustLevel::BaseTrust);
 
 			protected:
 				virtual QWORD GetMaxNumberOfBytesRequiredForResolution() noexcept override;

--- a/Unigram/Unigram.Native.Media/Opus/OpusMediaSink.h
+++ b/Unigram/Unigram.Native.Media/Opus/OpusMediaSink.h
@@ -15,7 +15,7 @@ namespace Unigram
 			{
 				friend class OpusStreamSink;
 
-				InspectableClass(L"Unigram.Native.OpusMediaSink", TrustLevel::BaseTrust);
+				InspectableClass(L"Unigram.Native.Media.OpusMediaSink", TrustLevel::BaseTrust);
 
 			public:
 				STDMETHODIMP RuntimeClassInitialize(_In_ OpusOutputByteStream* opusStream);

--- a/Unigram/Unigram.Native.Media/Opus/OpusMediaSource.h
+++ b/Unigram/Unigram.Native.Media/Opus/OpusMediaSource.h
@@ -18,7 +18,7 @@ namespace Unigram
 			{
 				friend class OpusMediaStream;
 
-				InspectableClass(L"Unigram.Native.OpusMediaSource", TrustLevel::BaseTrust);
+				InspectableClass(L"Unigram.Native.Media.OpusMediaSource", TrustLevel::BaseTrust);
 
 			public:
 				OpusMediaSource();

--- a/Unigram/Unigram/App.xaml.cs
+++ b/Unigram/Unigram/App.xaml.cs
@@ -81,8 +81,8 @@ namespace Unigram
                 if (!string.Equals(AnalyticsInfo.VersionInfo.DeviceFamily, "Windows.Desktop"))
                 {
                     _mediaExtensionManager = new MediaExtensionManager();
-                    _mediaExtensionManager.RegisterByteStreamHandler("Unigram.Native.OpusByteStreamHandler", ".ogg", "audio/ogg");
-                    _mediaExtensionManager.RegisterByteStreamHandler("Unigram.Native.OpusByteStreamHandler", ".oga", "audio/ogg");
+                    _mediaExtensionManager.RegisterByteStreamHandler("Unigram.Native.Media.OpusByteStreamHandler", ".ogg", "audio/ogg");
+                    _mediaExtensionManager.RegisterByteStreamHandler("Unigram.Native.Media.OpusByteStreamHandler", ".oga", "audio/ogg");
                 }
             }
             catch

--- a/Unigram/Unigram/Package.appxmanifest
+++ b/Unigram/Unigram/Package.appxmanifest
@@ -102,14 +102,8 @@
   <Extensions>
     <Extension Category="windows.activatableClass.inProcessServer">
       <InProcessServer>
-        <Path>Unigram.Native.dll</Path>
-        <ActivatableClass ActivatableClassId="Unigram.Native.GIFByteStreamHandler" ThreadingModel="both" />
-      </InProcessServer>
-    </Extension>
-    <Extension Category="windows.activatableClass.inProcessServer">
-      <InProcessServer>
-        <Path>Unigram.Native.dll</Path>
-        <ActivatableClass ActivatableClassId="Unigram.Native.OpusByteStreamHandler" ThreadingModel="both" />
+        <Path>Unigram.Native.Media.dll</Path>
+        <ActivatableClass ActivatableClassId="Unigram.Native.Media.OpusByteStreamHandler" ThreadingModel="both" />
       </InProcessServer>
     </Extension>
   </Extensions>


### PR DESCRIPTION
- Unigram.Native -> Unigram.Native.Media
- Remove old GIFByteStreamHandler reference

I'm not sure about "MediaCapturePreviewSourceMediaSink" and "MediaCapturePreviewSourceMediaSource" as I cannot find them. Happy for your feedback to adjust the PR. :)