### PR TITLE
Update CallCell.xaml

### DIFF
--- a/Unigram/Unigram/Controls/Cells/CallCell.xaml
+++ b/Unigram/Unigram/Controls/Cells/CallCell.xaml
@@ -16,7 +16,7 @@
                 <VisualStateGroup>
                     <VisualState x:Name="Missed">
                         <VisualState.Setters>
-                            <Setter Target="DisplayLabel.Foreground" Value="{ThemeResource MessageCallMissedForegroundBrush}"/>
+                            <Setter Target="TypeLabel.Foreground" Value="{ThemeResource MessageCallMissedForegroundBrush}"/>
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Default"/>


### PR DESCRIPTION
Red for missed calls applies to "missed calls" texture rather than the caller name.

Got inspired by @larsschellhas suggestion in an old ticket (https://github.com/UnigramDev/Unigram/issues/590)