### PR TITLE
Improve displaying of date in DateHeader

### DIFF
--- a/Unigram/Unigram/Converters/Converter.cs
+++ b/Unigram/Unigram/Converters/Converter.cs
@@ -52,8 +52,9 @@ namespace Unigram.Converters
         {
             var now = System.DateTime.Now;
 
-            var difference = Math.Abs(date.Month - now.Month + 12 * (date.Year - now.Year));
-            if (difference >= 12)
+            //var difference = Math.Abs(date.Month - now.Month + 12 * (date.Year - now.Year));
+            //if (difference >= 12)
+            if (date.Year != now.Year)
             {
                 return MonthFullYear.Format(date);
             }
@@ -65,8 +66,9 @@ namespace Unigram.Converters
         {
             var now = System.DateTime.Now;
 
-            var difference = Math.Abs(date.Month - now.Month + 12 * (date.Year - now.Year));
-            if (difference >= 12)
+            //var difference = Math.Abs(date.Month - now.Month + 12 * (date.Year - now.Year));
+            //if (difference >= 12)
+            if (date.Year != now.Year)
             {
                 return DayMonthFullYear.Format(date);
             }


### PR DESCRIPTION
It is sometimes not so easy to identify in which year message was created and this behaviour can be observed in other services and is more user friendly