### PR TITLE
Fix WebRTC build instructions to mention using VS 2022 build tools

### DIFF
--- a/Documentation/Build-instructions.md
+++ b/Documentation/Build-instructions.md
@@ -122,7 +122,7 @@ For reference, this is the list of VLC plugins currently needed by Unigram to pr
 
 ### WebRTC
 Unigram uses WebRTC for calls and video chats. Since WebRTC doesn't currently support UWP, you must use our fork to build it.
-1. Click on Start Menu → Visual Studio 2019 → x64 Native Tools Command Prompt for VS 2022.
+1. Click on Start Menu → Visual Studio 2022 → x64 Native Tools Command Prompt for VS 2022.
 2. Navigate to .\Unigram\Libraries\webrtc
 3. Execute `.\acquire.cmd`. This will clone WebRTC source code to `C:\webrtc`, and it will take a while (~1.5h)
 4. Execute `.\build.cmd "$arch$" "$config$"`. Replace `$arch$` with either `x64`, `win32` or `arm64` depending on your build target. `$config$` can be set to either `release` or `debug`.


### PR DESCRIPTION
According to the main build script (https://github.com/UnigramDev/Unigram/blob/develop/Libraries/webrtc/build.cmd#L8-L15) the correct visual studio version to use is visual studio 2022. Fix an obvious typo in the build instructions for WinRTC/WebRTC.

This fixes #3106 