### PR TITLE
Add Win-ARM64 support for WebRTC

### DIFF
--- a/Libraries/webrtc/acquire.cmd
+++ b/Libraries/webrtc/acquire.cmd
@@ -62,13 +62,28 @@ if errorlevel 1 goto :error
 echo.
 echo Adding forked Telegram+UWP upstream
 call git remote add upstream https://github.com/FrayxRulez/webrtc-uwp.git
+call git remote update
+call git fetch
 call git checkout m123
 pushd build
-call git apply "%PATCH_DIR%/build/fix.patch"
+call git apply --3way --ignore-whitespace "%PATCH_DIR%/build/fix.patch"
+
+echo Checking the Architecture type
+for /f "skip=1" %%a in ('wmic cpu get architecture') do (
+    set "cpu_arch=%%a"
+    goto :woa-patch
+)
+:woa-patch
+if "%cpu_arch%"=="12" (
+    call git apply --3way --ignore-whitespace "%PATCH_DIR%/build/woa_support.patch"
+)
+
 pushd ..\third_party
-call git apply "%PATCH_DIR%/third_party/fix.patch"
-pushd libyuv
-call git apply "%PATCH_DIR%/third_party/libyuv/fix.patch"
+call git apply --3way --ignore-whitespace "%PATCH_DIR%/third_party/fix.patch"
+pushd boringssl\src
+call git apply --3way --ignore-whitespace "%PATCH_DIR%/third_party/string.patch"
+pushd ..\..\libyuv
+call git apply --3way --ignore-whitespace "%PATCH_DIR%/third_party/libyuv/fix.patch"
 goto :exit
 
 :error

--- a/Libraries/webrtc/build.cmd
+++ b/Libraries/webrtc/build.cmd
@@ -6,13 +6,21 @@ echo Setting environment variables
 set PATH=c:\depot_tools;%PATH%
 set DEPOT_TOOLS_WIN_TOOLCHAIN=0
 set GYP_MSVS_VERSION=2022
-REM c:
-REM cd c:\webrtc\src
+cd c:\webrtc\src
 if errorlevel 1 goto :error
 
 echo.
 echo Opening the developer command prompt
-call "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" -arch=amd64
+
+echo Checking the Architecture type
+for /f "skip=1" %%a in ('wmic cpu get architecture') do (
+    set "cpu_arch=%%a"
+)
+if "%cpu_arch%"=="12" (
+    call "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" -arch=arm64
+) else (
+    call "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\VsDevCmd.bat" -arch=amd64
+)
 if errorlevel 1 goto :error
 
 for %%a in (%~1) do (

--- a/Libraries/webrtc/build/woa_support.patch
+++ b/Libraries/webrtc/build/woa_support.patch
@@ -1,0 +1,55 @@
+diff --git a/toolchain/win/tool_wrapper.py b/toolchain/win/tool_wrapper.py
+index 47bbfe2a0..bd7b89d9a 100644
+--- a/toolchain/win/tool_wrapper.py
++++ b/toolchain/win/tool_wrapper.py
+@@ -151,11 +151,29 @@ class WinTool(object):
+     """Filter logo banner from invocations of asm.exe."""
+     env = self._GetEnv(arch)
+     if sys.platform == 'win32':
+-      # Windows ARM64 uses clang-cl as assembler which has '/' as path
+-      # separator, convert it to '\\' when running on Windows.
+-      args = list(args) # *args is a tuple by default, which is read-only
+-      args[0] = args[0].replace('/', '\\')
+-    # See comment in ExecLinkWrapper() for why shell=False on non-win.
++        args = list(args)  # Convert args to a list to modify
++
++        # Replace armasm64.exe with the specified clang.exe path
++        args[0] = "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/Llvm/ARM64/bin/clang.exe"
++
++        # Add necessary Clang flags for assembly
++        args.insert(1, '-c')  # Add '-c' flag to compile
++
++        # Identify and replace MSVC output flag with Clang's '-o'
++        output_arg = next((arg for arg in args if arg.startswith('/Fo')), None)
++        if output_arg:
++            output_index = args.index(output_arg)
++            output_file = output_arg[3:]  # Extract the output file path after '/Fo'
++            args[output_index] = '-o'  # Replace '/Fo' with '-o'
++            args.insert(output_index + 1, output_file.replace('\\', '/'))  # Add output file path correctly formatted
++
++        # Remove MSVC-specific flags like '/nologo'
++        args = [arg for arg in args if arg not in ['/nologo']]
++
++        # Print the command for debugging purposes
++        print("Executing command:", args)
++
++    # Execute the command using subprocess
+     popen = subprocess.Popen(args, shell=sys.platform == 'win32', env=env,
+                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+     out, _ = popen.communicate()
+diff --git a/vs_toolchain.py b/vs_toolchain.py
+index a9cd6f03d..7909abdd3 100755
+--- a/vs_toolchain.py
++++ b/vs_toolchain.py
+@@ -400,8 +400,8 @@ def CopyDlls(target_dir, configuration, target_cpu):
+   _CopyDebugger(target_dir, target_cpu)
+   if target_cpu == 'arm64':
+     target_dir = os.path.join(target_dir, 'win_clang_x64')
+-    target_cpu = 'x64'
+-    runtime_dir = x64_runtime
++    target_cpu = 'arm64'
++    runtime_dir = arm64_runtime
+     os.makedirs(target_dir, exist_ok=True)
+     _CopyRuntime(target_dir, runtime_dir, target_cpu, debug=False)
+     if configuration == 'Debug':
+

--- a/Libraries/webrtc/third_party/string.patch
+++ b/Libraries/webrtc/third_party/string.patch
@@ -1,0 +1,12 @@
+diff --git a/pki/string_util.h b/pki/string_util.h
+index 27be48594..6a0273a85 100644
+--- a/pki/string_util.h
++++ b/pki/string_util.h
+@@ -8,6 +8,7 @@
+ #include <cstdint>
+ #include <string_view>
+ #include <vector>
++#include <string>
+ 
+ #include <openssl/base.h>
+ #include <openssl/span.h>


### PR DESCRIPTION
Consolidated changes into a single `arm64_support.patch`. Updated `acquire.cmd` to detect architecture and apply the patch accordingly.

**tool_wrapper.py:**

- Modified to replace `armasm64.exe` with `clang.exe` for ARM64 assembly.
- Added necessary flags for Clang compilation and adjusted the output flag handling to match Clang's format.

**vs_toolchain.py:**

- Updated to correctly handle ARM64 runtime files during the build process

**string_util.h:** 
- Added changes to one of the header files for required string handling.

These changes ensure successful compilation of  WebRTC on Windows on ARM devices.