### PR TITLE
Fix crash when MessageSelector loads before its content is realized

### DIFF
--- a/Telegram/Controls/Messages/MessageSelector.xaml.cs
+++ b/Telegram/Controls/Messages/MessageSelector.xaml.cs
@@ -61,18 +61,62 @@ namespace Telegram.Controls.Messages
 
         private TextSelectionManager _textSelectionManager;
 
-        public bool HasSelection => _textSelectionManager.HasSelection;
+        public bool HasSelection => _textSelectionManager?.HasSelection ?? false;
 
-        public void CopySelectionToClipboard() => _textSelectionManager.CopySelectionToClipboard();
+        public void CopySelectionToClipboard() => _textSelectionManager?.CopySelectionToClipboard();
 
-        public FormattedText GetSelectedText() => _textSelectionManager.GetSelectedText();
-        public FormattedText GetSelectedSourceText(out int position) => _textSelectionManager.GetSelectedSourceText(out position);
+        public FormattedText GetSelectedText() => _textSelectionManager?.GetSelectedText();
+
+        public FormattedText GetSelectedSourceText(out int position)
+        {
+            if (_textSelectionManager == null)
+            {
+                position = 0;
+                return null;
+            }
+
+            return _textSelectionManager.GetSelectedSourceText(out position);
+        }
+
+        // The manager needs the content element, which isn't guaranteed to be there yet when
+        // Loaded fires: a container can be connected before it has been given any content.
+        // Building the manager then threw ArgumentNullException(root) out of the Loaded handler
+        // and took the app down, so attach whenever a content element is actually present -
+        // on load, and again whenever the content itself changes.
+        //
+        // IsConnected is required: only OnUnloaded and OnContentChanged detach the manager, so
+        // attaching while disconnected would leave the pointer handlers on the content forever,
+        // and through them root this control for the rest of the session.
+        private void EnsureTextSelectionManager()
+        {
+            if (_textSelectionManager == null && IsConnected && Content is UIElement root)
+            {
+                _textSelectionManager = new TextSelectionManager(this, root);
+            }
+        }
+
+        protected override void OnContentChanged(object oldContent, object newContent)
+        {
+            base.OnContentChanged(oldContent, newContent);
+
+            // The manager's pointer handlers live on the previous content element, so they have
+            // to come off before attaching to the new one - otherwise they outlive the element
+            // they were added to and the manager keeps reporting selection for content that is
+            // no longer displayed.
+            if (_textSelectionManager != null)
+            {
+                _textSelectionManager.Detach();
+                _textSelectionManager = null;
+            }
+
+            EnsureTextSelectionManager();
+        }
 
         public bool IsTrackerEnabled { get; set; } = true;
 
         protected override void OnLoaded()
         {
-            _textSelectionManager ??= new TextSelectionManager(this, ContentTemplateRoot);
+            EnsureTextSelectionManager();
 
             if (_trackerOwner == null && RootGrid != null && IsTrackerEnabled && (SettingsService.Current.SwipeToReply || SettingsService.Current.SwipeToShare))
             {


### PR DESCRIPTION
## The crash

`ArgumentNullException: Value cannot be null. Parameter name: root`, reported by crash telemetry on 12.8.2 (X64).

Symbolicated stack (6/6 frames resolved):

```
TextSelectionManager..ctor          TextSelectionManager.cs:93
MessageSelector.OnLoaded            MessageSelector.xaml.cs:87
ToggleButtonEx.OnChanged            FrameworkElementEx.cs:73
RoutedEventHandler.Invoke
```

## Cause

`OnLoaded` built the manager unconditionally:

```csharp
_textSelectionManager ??= new TextSelectionManager(this, ContentTemplateRoot);
```

and `TextSelectionManager` rejects a null root:

```csharp
_root = root ?? throw new ArgumentNullException(nameof(root));
```

When a container is connected before it has been given content, that root is null, so the constructor throws out of a `Loaded` handler — unhandled, and the app goes down.

`ContentTemplateRoot` was also the wrong property to read: the control is always handed a `UIElement` directly and is never initialized through a `ContentTemplate`.

The reported log tails put this under heavy UI churn (chat navigation with `SendFilesPopup` opening repeatedly), which is exactly when layout lags behind connection.

## Fix

Attach whenever a content element is actually present: on load, and again from `OnContentChanged` whenever the content itself changes.

- **`OnContentChanged` detaches first.** The manager's pointer handlers live on the previous content element, so they come off before attaching to the new one — otherwise they outlive the element they were added to, and the manager keeps reporting selection for content that is no longer displayed.
- **`IsConnected` check.** Only `OnUnloaded` and `OnContentChanged` detach the manager. Attaching while disconnected would leave the pointer handlers on the content permanently and, through them, root the control for the rest of the session. `IsConnected` is set before `OnLoaded` and cleared before `OnUnloaded` (verified in `FrameworkElementEx.h`), so it is correct at every call site.
- **Accessors.** `HasSelection`, `CopySelectionToClipboard`, `GetSelectedText` and `GetSelectedSourceText` dereferenced the manager unconditionally, which would have turned this window into a `NullReferenceException` instead. They are now null-safe.

Nothing is added to the layout path.

## Testing

Reviewed against the 12.8.2 release tree (`fb77686119`, where the crash was reported) and applied to current `develop`, where the code is unchanged. Syntax verified with Roslyn.

**Not compiled or run** — I don't have a working UWP/.NET Native build environment here, so the change needs a build and a manual check that text selection still attaches normally before merging.

Worth a second look at build time: `OnContentChanged` comes from `ContentControl`, and the existing overrides of it in this repo are all on plain framework types rather than through a C++/WinRT `…Ex` base. `MessageSelector` already overrides `OnApplyTemplate`, `OnToggle`, the pointer virtuals and `ArrangeOverride` through `ToggleButtonEx`, so the composition chain should expose this one too — but I could not confirm it without a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)