### PR TITLE
Fix crash opening the context menu on a partially selected message

### DIFF
--- a/Telegram/Views/ChatView.xaml.cs
+++ b/Telegram/Views/ChatView.xaml.cs
@@ -3197,13 +3197,22 @@ namespace Telegram.Views
                 }
                 else if (element is MessageBubble { Parent: MessageSelector parent } && parent.HasSelection)
                 {
-                    quote = new MessageQuote
+                    // HasSelection only reports that a selection is shown; the source text behind
+                    // it can still be unavailable, in which case GetSelectedSourceText returns
+                    // null. Everything below already treats a null quote as "no quote", so leave
+                    // it unset instead of dereferencing it.
+                    var selected = parent.GetSelectedSourceText(out selectionStart);
+                    if (selected != null)
                     {
-                        Message = message,
-                        Quote = parent.GetSelectedSourceText(out selectionStart),
-                        Position = selectionStart
-                    };
-                    selectionEnd = selectionStart + quote.Quote.Text.Length;
+                        quote = new MessageQuote
+                        {
+                            Message = message,
+                            Quote = selected,
+                            Position = selectionStart
+                        };
+
+                        selectionEnd = selectionStart + selected.Text.Length;
+                    }
                 }
 
                 if (message.Content is MessageGift gift && ViewModel.ClientService.TryGetUser(chat, out User user))


### PR DESCRIPTION
## The crash

`NullReferenceException`, reported by crash telemetry on 12.8.2 (X64).

Symbolicated stack (9/9 frames resolved):

```
ChatView.<Message_ContextRequested>d__179.MoveNext    ChatView.xaml.cs:3219
ExceptionDispatchInfo.Throw
AsyncMethodBuilderCore.<>c.<ThrowAsync>b__7_0
```

Line 3219 is `selectionEnd = selectionStart + quote.Quote.Text.Length;`.

## Cause

`Message_ContextRequested` builds the quote and dereferences it in the same breath:

```csharp
else if (element is MessageBubble { Parent: MessageSelector parent } && parent.HasSelection)
{
    quote = new MessageQuote
    {
        Quote = parent.GetSelectedSourceText(out selectionStart),
        ...
    };
    selectionEnd = selectionStart + quote.Quote.Text.Length;
}
```

`HasSelection` only reports that a selection is currently *shown*. It's a plain flag, tracked separately from the ranges the text is actually derived from, so it can be `true` while `GetSelectedSourceText` returns null. That method has three null returns:

```csharp
if (_selectedRanges.Count == 0) return null;
...
if (to <= from) return null;
...
return _selectedRanges[0].Item.GetSourceText(from, to);   // itself null when _text is null
```

Since the handler is `async void`, the resulting `NullReferenceException` is unhandled and takes the app down.

## Fix

Take the selected text first and only build the quote when there is one.

Everything downstream already treats a null quote as "no quote" — the very next block reads `if (quote != null && MessageQuote_Loaded(...))` and falls back to a plain reply — so leaving it unset is the behaviour the caller already expects. The user sees the normal context menu without the "quote selected part" entry, instead of losing the app.

This only makes the call site agree with what the API can actually return. The flag and the ranges are still tracked separately inside `TextSelectionManager`, which is worth revisiting on its own — if `HasSelection` is meant to guarantee retrievable text, the fix belongs there instead and I'm happy to redo it that way.

## Testing

Verified against the 12.8.2 release tree (`fb77686119`, where the crash was reported); the code is unchanged on current `develop`. Syntax verified with Roslyn.

**Not compiled or run** — no UWP/.NET Native build environment here, so this needs a build and a manual check that quoting a partial selection still works before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-code -->