### PR TITLE
Fix crash populating autocomplete rows from a mismatched template

### DIFF
--- a/Telegram/Views/ChatView.xaml.cs
+++ b/Telegram/Views/ChatView.xaml.cs
@@ -5159,13 +5159,19 @@ namespace Telegram.Views
             }
             else if (args.Item is QuickReplyShortcut shortcut)
             {
-                var content = args.ItemContainer.ContentTemplateRoot as Grid;
-
-                var photo = content.Children[0] as ProfilePicture;
-                var title = content.Children[1] as TextBlock;
-
-                var command = title.Inlines[0] as Run;
-                var description = title.Inlines[1] as Run;
+                // The list picks its template per item type, so a recycled container can still be
+                // showing the previous type's tree when this fires. Match the shape instead of
+                // indexing into it blindly.
+                if (args.ItemContainer.ContentTemplateRoot is not Grid content
+                    || content.Children.Count < 2
+                    || content.Children[0] is not ProfilePicture photo
+                    || content.Children[1] is not TextBlock title
+                    || title.Inlines.Count < 2
+                    || title.Inlines[0] is not Run command
+                    || title.Inlines[1] is not Run description)
+                {
+                    return;
+                }
 
                 command.Text = $"/{shortcut.Name} ";
                 description.Text = Locale.Declension(Strings.R.messages, shortcut.MessageCount);
@@ -5177,13 +5183,17 @@ namespace Telegram.Views
             }
             else if (args.Item is User user)
             {
-                var content = args.ItemContainer.ContentTemplateRoot as Grid;
-
-                var photo = content.Children[0] as ProfilePicture;
-                var title = content.Children[1] as TextBlock;
-
-                var name = title.Inlines[0] as Run;
-                var username = title.Inlines[1] as Run;
+                // Same shape as the shortcut branch above, and the same recycling hazard.
+                if (args.ItemContainer.ContentTemplateRoot is not Grid content
+                    || content.Children.Count < 2
+                    || content.Children[0] is not ProfilePicture photo
+                    || content.Children[1] is not TextBlock title
+                    || title.Inlines.Count < 2
+                    || title.Inlines[0] is not Run name
+                    || title.Inlines[1] is not Run username)
+                {
+                    return;
+                }
 
                 name.Text = user.FullName();
 


### PR DESCRIPTION
## The crash

`NullReferenceException`, fatal, reported by crash telemetry on 12.8.2 (X64).

Symbolicated stack (10/10 frames resolved):

```
ChatView.Autocomplete_ContainerContentChanging   ChatView.xaml.cs:5201
TextChangedEventHandler.Invoke
...
FrameworkElement.MeasureOverride
```

Line 5201 is `description.Text = Locale.Declension(...)` in the `QuickReplyShortcut` branch.

## Cause

The handler walks the container's visual tree assuming it matches `args.Item`:

```csharp
var content = args.ItemContainer.ContentTemplateRoot as Grid;

var photo = content.Children[0] as ProfilePicture;
var title = content.Children[1] as TextBlock;

var command = title.Inlines[0] as Run;
var description = title.Inlines[1] as Run;
```

The list is declared with `ItemTemplateSelector="{StaticResource AutocompleteTemplate}"`, so containers are recycled across item types whose templates differ — `BotCommandFullInfo` puts its text in direct `Grid` children, `QuickReplyShortcut` and `User` put theirs in `TextBlock.Inlines`. When a container is reused, `ContentTemplateRoot` can still be the previous type's tree at the moment this fires.

Every step above is an `as` cast dereferenced on the next line, so any mismatch is an NRE inside an event handler — nothing catches it.

`args.InRecycleQueue` was already handled; this is the other half of the same problem, where the container is live but not yet re-templated.

## Fix

Match the expected shape and bail out when it isn't there:

```csharp
if (args.ItemContainer.ContentTemplateRoot is not Grid content
    || content.Children.Count < 2
    || content.Children[0] is not ProfilePicture photo
    || content.Children[1] is not TextBlock title
    || title.Inlines.Count < 2
    || title.Inlines[0] is not Run command
    || title.Inlines[1] is not Run description)
{
    return;
}
```

Applied to the reported branch and to the `User` branch, which is structurally identical and carries the same latent fault.

**Two things worth your judgement:**

1. **Scope.** The remaining branches (`BotCommandFullInfo`, `hashtag`, `Sticker`, `EmojiData`) index container children the same way and share the pattern, but have no reported crashes. I left them so the diff stays reviewable rather than rewriting the whole handler — say the word and I'll extend it.
2. **Bailing out.** If the container really is mid-retemplate, returning means that row isn't populated on this pass. That should be corrected when the handler runs again against the right template, but you'll know better than I do whether there's a path where it isn't — in which case the row would render stale rather than crash.

## Testing

Verified against the 12.8.2 release tree (`fb77686119`, where the crash was reported); the code is unchanged on current `develop`. Syntax verified with Roslyn.

**Not compiled or run** — no UWP/.NET Native build environment here, so this needs a build and a check that bot-command, quick-reply and user autocomplete rows all still populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-code -->