### PR TITLE
Fix crash activating the app as a share target without a window context

### DIFF
--- a/Telegram/Navigation/BootStrapper.cs
+++ b/Telegram/Navigation/BootStrapper.cs
@@ -637,9 +637,26 @@ namespace Telegram.Navigation
 
             CallOnInitialize(false, e);
 
-            if (WindowContext.Current.Content == null)
+            // The context is normally built by OnWindowCreated, but it is thread-static and gets
+            // cleared when a view's dispatcher shuts down, so an activation arriving on a view
+            // that has been through that leaves us with none. InternalActivated already allows
+            // for it (it tests WindowContext.Current?.Content) and calls in here regardless, so
+            // build one instead of dereferencing null.
+            var context = WindowContext.Current;
+            if (context == null)
             {
-                WindowContext.Current.Content = CreateRootElement(e, WindowContext.Current);
+                if (Window.Current == null)
+                {
+                    Logger.Error("No window to initialize the frame with");
+                    return;
+                }
+
+                context = CreateWindowWrapper(Window.Current);
+            }
+
+            if (context.Content == null)
+            {
+                context.Content = CreateRootElement(e, context);
             }
             else
             {


### PR DESCRIPTION
## The crash

`NullReferenceException`, reported by crash telemetry on 12.8.1 — every instance arriving through `OnShareTargetActivated`, i.e. the app dies as it is being opened to receive a share.

Symbolicated stack (9/9 frames resolved):

```
BootStrapper.InitializeFrame        BootStrapper.cs:640
BootStrapper.InternalActivated      BootStrapper.cs:222
BootStrapper.OnShareTargetActivated BootStrapper.cs:197
```

Line 640 is `if (WindowContext.Current.Content == null)`, so `WindowContext.Current` is null.

## Cause

`WindowContext._current` is `[ThreadStatic]`. It is assigned by the `WindowContext` constructor — reached via `OnWindowCreated` → `CreateWindowWrapper` — and cleared again in `OnShutdownCompleted` when the view's dispatcher shuts down:

```csharp
private void OnShutdownCompleted(DispatcherQueue sender, object args)
{
    sender.ShutdownCompleted -= OnShutdownCompleted;
    _current = null;
```

An activation that lands on a view which has been through that shutdown finds no context, and `InitializeFrame` dereferences it before the app has a window.

The only caller already allows for it:

```csharp
if (WindowContext.Current?.Content == null)
{
    InitializeFrame(e);
}
```

The null-conditional makes "no context" indistinguishable from "no content", so the branch is taken and `InitializeFrame` is called in exactly the case where there is nothing to dereference. The getter is aware too — it logs `Environment.StackTrace` when `_current` is null, next to commented-out code that would have constructed one.

## Fix

Build the context rather than assuming it, which is what `OnWindowCreated` would have done:

```csharp
var context = WindowContext.Current;
if (context == null)
{
    if (Window.Current == null)
    {
        Logger.Error("No window to initialize the frame with");
        return;
    }

    context = CreateWindowWrapper(Window.Current);
}
```

This leaves the frame genuinely initialized rather than merely not crashing, so the share activation still gets a usable window. A plain null-guard would have turned the crash into a blank window instead.

`WindowContext`'s constructor assigns `_current`, so `WindowContext.Current` is valid for the remainder of activation.

**What I could not verify:** the exact sequence that leaves a view without a context. The shutdown path above is the only place `_current` is cleared and it fits the evidence, but I have no repro, so it is inference from the code rather than an observed ordering. If you know share-target activation reaches this on a genuinely fresh view, the fix is still correct but the reasoning in this description is not.

## Testing

Verified against the 12.8.1 tree (`a26c2396f6`, "Bump version to 12.8.1", since no `v12.8.1` tag was pushed); `InitializeFrame` is byte-identical on current `develop`. Syntax verified with Roslyn.

**Not compiled or run** — no UWP/.NET Native build environment here. Needs a build and a check that sharing into the app still opens correctly, and that normal launch is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-code -->