### PR TITLE
Fix crash activating the app as a share target before its window is created

### DIFF
--- a/Telegram/Navigation/BootStrapper.cs
+++ b/Telegram/Navigation/BootStrapper.cs
@@ -124,6 +124,23 @@ namespace Telegram.Navigation
 
         private WindowContext CreateWindowWrapper(Window window)
         {
+            // WindowContext's constructor assigns the thread-static Current, so building a second
+            // one for a view that already has one replaces it, and whatever was attached to the
+            // first - the frame, most importantly - is silently orphaned. Activation can run
+            // before OnWindowCreated, so the context may already exist by the time we get here.
+            var context = WindowContext.Current;
+            if (context != null)
+            {
+                if (context.CoreWindow == window.CoreWindow)
+                {
+                    Logger.Info("Window context already exists, reusing it");
+                    return context;
+                }
+
+                Logger.Warning("Window context belongs to a different window, replacing it");
+            }
+
+            Logger.Info("Creating the window context");
             return new WindowContext(window);
         }
 
@@ -637,9 +654,28 @@ namespace Telegram.Navigation
 
             CallOnInitialize(false, e);
 
-            if (WindowContext.Current.Content == null)
+            // Activation can arrive before OnWindowCreated has run - share target activation
+            // appears to race it - which leaves the view with a window but no context, and
+            // InternalActivated calls in here regardless because it only tests
+            // WindowContext.Current?.Content. Build the context early rather than dereference
+            // null; CreateWindowWrapper reuses whatever already exists, so the OnWindowCreated
+            // that follows will not replace this one.
+            var context = WindowContext.Current;
+            if (context == null)
             {
-                WindowContext.Current.Content = CreateRootElement(e, WindowContext.Current);
+                if (Window.Current == null)
+                {
+                    Logger.Error($"Activated with no window at all, cannot initialize the frame. Kind: {e.Kind}");
+                    return;
+                }
+
+                Logger.Warning($"Activated before OnWindowCreated, creating the window context early. Kind: {e.Kind}");
+                context = CreateWindowWrapper(Window.Current);
+            }
+
+            if (context.Content == null)
+            {
+                context.Content = CreateRootElement(e, context);
             }
             else
             {


### PR DESCRIPTION
Supersedes #3319, which was withdrawn: it created the missing `WindowContext` without making creation idempotent, so the one built during activation was later replaced by `OnWindowCreated` and the frame attached to it silently orphaned.

## The crash

`NullReferenceException`, reported by crash telemetry on 12.8.1 — every instance through `OnShareTargetActivated`, so the app dies as it is being opened to receive a share.

Symbolicated stack (9/9 frames resolved):

```
BootStrapper.InitializeFrame        BootStrapper.cs:640
BootStrapper.InternalActivated      BootStrapper.cs:222
BootStrapper.OnShareTargetActivated BootStrapper.cs:197
```

Line 640 is `if (WindowContext.Current.Content == null)`, so `WindowContext.Current` is null.

## Cause

Share target activation races window creation: the view has a `Window`, but `OnWindowCreated` — which is what reaches `CreateWindowWrapper` and therefore the `WindowContext` constructor — has not run yet.

The only caller already allows for it:

```csharp
if (WindowContext.Current?.Content == null)
{
    InitializeFrame(e);
}
```

The null-conditional makes "no context" indistinguishable from "no content", so the branch is taken and `InitializeFrame` is called in exactly the case where there is nothing to dereference. The getter is aware too — it logs `Environment.StackTrace` when `_current` is null, beside commented-out code that would have constructed one.

## Fix

Two parts, and the first is the load-bearing one.

**Make `CreateWindowWrapper` idempotent.** `WindowContext`'s constructor assigns the thread-static `Current`, so constructing a second one for a view that already has one replaces it and silently orphans whatever was attached to the first — including the frame. It now returns the existing context, compared by window rather than assumed; a context belonging to a *different* window is still replaced, as before.

**Build the context early when activation gets there first.** This is only safe because of the above: the `OnWindowCreated` that follows reuses the context rather than replacing it.

Where there is no `Window.Current` either there is nothing to build against, so it logs and returns.

**Logging** on each path — reusing, creating, replacing, activating early, and activating with no window at all — since this is a race that only shows up in the field, and the log tail is the only way to see which way it went.

## Testing

Verified against the 12.8.1 tree (`a26c2396f6`, "Bump version to 12.8.1", since no `v12.8.1` tag was pushed); `InitializeFrame` and `CreateWindowWrapper` are unchanged on current `develop`. Syntax verified with Roslyn.

**Not compiled or run** — no UWP/.NET Native build environment here. Needs a build, a check that sharing into the app opens correctly, and a check that a normal cold launch still creates exactly one context (the new log lines make that visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-code -->