### PR TITLE
Fix crash when the default audio device changes during playback

### DIFF
--- a/Telegram.Native/Media/AsyncMediaPlayer.cpp
+++ b/Telegram.Native/Media/AsyncMediaPlayer.cpp
@@ -101,7 +101,15 @@ namespace winrt::Telegram::Native::Media::implementation
     {
         if (AudioDeviceRole::Default == args.Role())
         {
-            Set(libvlc_audio_output_set, winrt::to_string(args.Id()).c_str());
+            // Set() captures its arguments by value and runs them later on the worker thread,
+            // so a const char* is copied as a pointer and not as characters. The temporary
+            // string from to_string dies at the end of this statement, leaving libvlc to read
+            // freed memory once the work item is finally dequeued. Own the string in the
+            // capture so it outlives the queue.
+            Write([this, id = winrt::to_string(args.Id())]
+                {
+                    libvlc_audio_output_set(m_player, id.c_str());
+                });
         }
     }
 


### PR DESCRIPTION
## The crash

`VLCException: ACCESS_VIOLATION`, fatal, reported by crash telemetry on 12.8.1.

Symbolicated stack (15/15 frames resolved):

```
strcmp+0x43
module_exists+0x59                 vlc/src/modules/modules.c:419
libvlc_audio_output_set+0x29       vlc/lib/audio.c:128
AsyncMediaPlayer::Work+0x226       Telegram.Native/Media/AsyncMediaPlayer.h:453
std::thread::_Invoke<...>
```

`Work` is the player's worker pump, so the call came from a queued work item.

## Cause

```cpp
Set(libvlc_audio_output_set, winrt::to_string(args.Id()).c_str());
```

`Set` forwards its arguments into a lambda that `Write` queues for the worker thread:

```cpp
template <typename Func, typename... Args>
void Set(Func func, Args&&... args)
{
    Write([this, func, args...] {
        func(m_player, args...);
    });
}
```

`args...` is captured **by value**, but the argument here is a `const char*` — so it copies the pointer, not the characters. The temporary `std::string` returned by `winrt::to_string` is destroyed at the end of the `Set(...)` statement, and the work item runs afterwards on another thread. libvlc then reads freed memory.

The stack corroborates it exactly: the fault is in `strcmp`, called from `module_exists`, which is `libvlc_audio_output_set` comparing the device name against known module names. Reading a freed string is precisely what that looks like.

## Fix

Own the string in the capture, matching the `Write` call sites already in this file (lines 343, 369, 557):

```cpp
Write([this, id = winrt::to_string(args.Id())]
    {
        libvlc_audio_output_set(m_player, id.c_str());
    });
```

## Notes

**Trigger.** This fires whenever the system default audio render device changes while a player is alive — headphones in or out, a Bluetooth device connecting, a call starting. That is why it is common despite needing a device change.

**Only instance.** The other two `.c_str()` uses in this file are safe: one builds `argv` for `libvlc_new` synchronously, the other is a named local consumed on the same line inside the worker lambda.

**Worth considering separately:** `Set` will silently accept any pointer argument and outlive it. A `static_assert` rejecting `const char*` would make this class of bug impossible rather than fixed once. I have not included it — it would reject string literals too, which are safe — but say the word and I will.

## Testing

Verified against the 12.8.1 tree (`a26c2396f6`); unchanged on current `develop`.

**Not compiled or run** — this is C++/WinRT and I have no working native toolchain here (the local VS is missing the v145 toolset these projects ask for), so I could not even syntax-check it, unlike the C# changes. Needs a build and a check that switching the default audio device mid-playback still routes audio correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-code -->