### PR TITLE
Fix crash when sending non-text content with ephemeral bot commands

### DIFF
--- a/Telegram/ViewModels/DialogViewModel.cs
+++ b/Telegram/ViewModels/DialogViewModel.cs
@@ -3204,7 +3204,7 @@ namespace Telegram.ViewModels
                     _ => null
                 };
 
-                if (caption.Text.StartsWith("/"))
+                if (caption?.Text.StartsWith("/") is true)
                 {
                     var split = caption.Text[1..].Split(' ');
                     split = split[0].Split('@');


### PR DESCRIPTION
### Crash

```
NullReferenceException: Object reference not set to an instance of an object.
```

Reported by crash telemetry on 12.9.0.0 (X64).

```
0  Telegram.ViewModels.DialogViewModel.CreateSendMessage
   Telegram/ViewModels/DialogViewModel.cs:3196
1  Telegram.ViewModels.ComposeViewModel.<SendMessageAsync>d__50.MoveNext
   Telegram/ViewModels/ComposeViewModel.cs:818
   ...
6  Telegram.ViewModels.ComposeViewModel.<SendSticker>d__17.MoveNext
   Telegram/ViewModels/ComposeViewModel.cs:90
```

### Cause

`CreateSendMessage` builds `caption` from the outgoing content, and the `switch`
deliberately yields `null` for everything that is not an `InputMessageText`:

```csharp
var caption = inputMessageContent switch
{
    InputMessageText text => text.Text,
    _ => null
};

if (caption.Text.StartsWith("/"))
```

The next line then dereferences it unconditionally. Any non-text send — a sticker in
the reported stacks, but equally a photo, video or file — reaches this with `caption`
null and throws.

The block is only entered when `HasEphemeralBotCommands` is `true`, which is why this
affects a subset of chats rather than every send.

### Fix

Skip the `/command@bot` lookup when there is no text to inspect, which is what the
`null` arm of the `switch` already intends. One-line change; the body of the `if` is
unchanged and still runs for text messages.

### Verification

Not built or run — a UWP/.NET Native build is not available in the environment this was
prepared in. The edited file was checked with Roslyn (`CSharpSyntaxTree.ParseText`) and
parses with no syntax errors; that confirms syntax only, not type checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)