### PR TITLE
Fix crash when opening the gallery

### DIFF
--- a/Telegram/Controls/Gallery/GalleryWindow.xaml.cs
+++ b/Telegram/Controls/Gallery/GalleryWindow.xaml.cs
@@ -699,6 +699,12 @@ namespace Telegram.Controls.Gallery
 
         private string ConvertOf(GalleryMedia item, int index, int count)
         {
+            // Bindings.Update runs on Load, before SelectedItem has been set.
+            if (item == null)
+            {
+                return string.Empty;
+            }
+
             if (item.IsPersonal)
             {
                 return Strings.CustomAvatarTooltip;


### PR DESCRIPTION
### Crash

```
NullReferenceException: Object reference not set to an instance of an object.
```

Reported by crash telemetry on 12.9.0.0.

```
0  Telegram.Controls.Gallery.GalleryWindow.ConvertOf
   Telegram/Controls/Gallery/GalleryWindow.xaml.cs:702
1  GalleryWindow_obj1_Bindings.Invoke_M_ConvertOf_413110846
2  GalleryWindow_obj1_Bindings.CompleteUpdate
3  GalleryWindow_obj1_Bindings.Update
4  Telegram.Controls.Gallery.GalleryWindow.Load
   Telegram/Controls/Gallery/GalleryWindow.xaml.cs:793
5  Telegram.Controls.Gallery.GalleryWindow.ShowAsyncInternal
   Telegram/Controls/Gallery/GalleryWindow.xaml.cs:442
```

### Cause

`ConvertOf` is a function binding:

```xml
<TextBlock Text="{x:Bind ConvertOf(ViewModel.SelectedItem, ViewModel.Position, ViewModel.TotalItems), Mode=OneWay}" />
```

and it dereferences its first argument straight away:

```csharp
private string ConvertOf(GalleryMedia item, int index, int count)
{
    if (item.IsPersonal)
```

`Load` calls `Bindings.Update()`, which evaluates every binding once, including this one —
before `ViewModel.SelectedItem` has been assigned. The stack shows exactly that path, so
the first evaluation on open runs with a null item.

`ConvertCaption`, a few lines below in the same file, already guards its input
(`string.IsNullOrEmpty(text?.Text)`); this one was just missed.

### Fix

Return an empty string when there is no item yet. The binding re-evaluates as soon as
`SelectedItem` is set, so the label fills in normally.

### Verification

Not built or run — a UWP/.NET Native build is not available in the environment this was
prepared in. The edited file was checked with Roslyn (`CSharpSyntaxTree.ParseText`) and
parses with no syntax errors; that confirms syntax only, not type checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)