### PR TITLE
Fix crash when rendering the wallpaper preview bubbles

### DIFF
--- a/Telegram/Controls/FormattedTextBlock.cs
+++ b/Telegram/Controls/FormattedTextBlock.cs
@@ -984,7 +984,15 @@ namespace Telegram.Controls
 
                     if (_fontSize != prevFontSize)
                     {
-                        direct.SetDoubleProperty(_fastRun, XamlPropertyIndex.TextElement_FontSize, _fontSize);
+                        // 0 means "inherit", as in GetOrCreateRun — XAML rejects it as a FontSize.
+                        if (_fontSize > 0)
+                        {
+                            direct.SetDoubleProperty(_fastRun, XamlPropertyIndex.TextElement_FontSize, _fontSize);
+                        }
+                        else
+                        {
+                            direct.ClearProperty(_fastRun, XamlPropertyIndex.TextElement_FontSize);
+                        }
                     }
 
                     direct.SetStringProperty(_fastRun, XamlPropertyIndex.Run_Text, styled.Paragraphs[rangeStart].Text);

--- a/Telegram/Controls/FormattedTextBlock.cs
+++ b/Telegram/Controls/FormattedTextBlock.cs
@@ -984,15 +984,9 @@ namespace Telegram.Controls
 
                     if (_fontSize != prevFontSize)
                     {
-                        // 0 means "inherit", as in GetOrCreateRun — XAML rejects it as a FontSize.
-                        if (_fontSize > 0)
-                        {
-                            direct.SetDoubleProperty(_fastRun, XamlPropertyIndex.TextElement_FontSize, _fontSize);
-                        }
-                        else
-                        {
-                            direct.ClearProperty(_fastRun, XamlPropertyIndex.TextElement_FontSize);
-                        }
+                        // fontSize, not _fontSize: the latter is the raw value, which AutoFontSize
+                        // resolves to the theme size above. XAML rejects the raw 0.
+                        direct.SetDoubleProperty(_fastRun, XamlPropertyIndex.TextElement_FontSize, fontSize);
                     }
 
                     direct.SetStringProperty(_fastRun, XamlPropertyIndex.Run_Text, styled.Paragraphs[rangeStart].Text);


### PR DESCRIPTION
### Crash

```
ArgumentException: Value does not fall within the expected range.
```

Reported by crash telemetry on 12.9.0.0, as three groups sharing one anchor.

```
2  Windows.UI.Xaml.Core.Direct.IXamlDirect.SetDoubleProperty
3  Telegram.Controls.FormattedTextBlock.SetText
   Telegram/Controls/FormattedTextBlock.cs:986
4  Telegram.Controls.Messages.MessageTextBlock.SetText
   Telegram/Controls/Messages/MessageTextBlock.cs:202
```

Reached two ways — from the wallpaper picker:

```
5  MessageBubble.Mockup                     MessageBubble.xaml.cs:3183
6  BackgroundPopup.UpdateBackground
7  BackgroundViewModel.set_SelectedPattern
```

and from an ordinary message in the chat:

```
5  MessageBubble.UpdateMessageText          MessageBubble.xaml.cs:2184
6  MessageBubble.UpdateMessageContent       MessageBubble.xaml.cs:1839
7  MessageBubble.UpdateMessage
```

### Cause

`SetText` keeps the raw argument in `_fontSize`, then resolves it:

```csharp
_fontSize = fontSize;
...
if (AutoFontSize && fontSize == 0)
{
    fontSize = Theme.Current.MessageFontSize;
}
```

The slow path passes the resolved `fontSize` to `GetOrCreateRun`. The plain-run fast path
instead reads `_fontSize` back:

```csharp
if (_fontSize != prevFontSize)
{
    direct.SetDoubleProperty(_fastRun, XamlPropertyIndex.TextElement_FontSize, _fontSize);
}
```

Every `SetText` overload declares `double fontSize = 0`, and callers that don't specify a size
rely on `AutoFontSize` to resolve it. The fast path bypasses that resolution and writes the
raw `0`, which XAML rejects with `E_INVALIDARG`. The guard is on *change*, so it is the
transition from a real size to `0` that performs the invalid write.

### Fix

Write the resolved `fontSize`, matching what the slow path already passes to `GetOrCreateRun`.

The first commit here guarded the value and cleared the property instead; that stops the crash
but inherits the parent's size rather than applying the theme size, so it is replaced by the
one-word fix in the follow-up commit.

### Verification

Not built or run — a UWP/.NET Native build is not available in the environment this was
prepared in. The edited file was checked with Roslyn (`CSharpSyntaxTree.ParseText`) and
parses with no syntax errors; that confirms syntax only, not type checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)