### PR TITLE
Never report a negative desired height from SettingsPanel

### DIFF
--- a/Telegram/Controls/SettingsPanel.cs
+++ b/Telegram/Controls/SettingsPanel.cs
@@ -5,6 +5,7 @@
 // file LICENSE or copy at https://www.gnu.org/licenses/gpl-3.0.txt)
 //
 
+using System;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -48,7 +49,10 @@ namespace Telegram.Controls
 
             if (IsHeader)
             {
-                return new Size(availableSize.Width, accumulated - 16);
+                // The -16 drops the trailing gap after the last child. With IsFooter the
+                // accumulator starts at 0, so a panel with nothing visible has no gap to
+                // drop and would report -16, which XAML rejects as a desired size.
+                return new Size(availableSize.Width, Math.Max(0, accumulated - 16));
             }
             else
             {


### PR DESCRIPTION
### Problem

`SettingsPanel.MeasureOverride` can return a negative height:

```csharp
var accumulated = IsFooter ? 0 : 64d;
...
if (IsHeader)
{
    return new Size(availableSize.Width, accumulated - 16);
}
```

The `- 16` removes the trailing gap that follows the last child. When `IsFooter` is set the
accumulator starts at `0` instead of `64`, and children only contribute when their
`DesiredSize.Height` is greater than zero — so a panel whose children are all collapsed
accumulates nothing, and the result is `-16`.

XAML rejects a negative desired size with `E_INVALIDARG`, surfacing as
`ArgumentException: Value does not fall within the expected range.`

The combination is reachable: `IsHeader` and `IsFooter` are set together on the same
`SettingsPanel` in `ShareGroupCallPopup.xaml`, `ChatInviteLinkInfoPopup.xaml` and twice in
`FolderPage.xaml`.

### Fix

Clamp at zero — with nothing visible there is no trailing gap to remove. `ArrangeOverride`
uses the same accumulator but only as a Y offset and returns `finalSize`, so it is unaffected
and left alone.

### Scope

This is a latent defect found while reading the layout code, not a diagnosed crash: no
reported stack currently points at this line. I'd rather flag that than imply it fixes a
specific report.

### Verification

Not built or run — a UWP/.NET Native build is not available in the environment this was
prepared in. The edited file was checked with Roslyn (`CSharpSyntaxTree.ParseText`) and
parses with no syntax errors; that confirms syntax only, not type checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)