### PR TITLE
Fix the expander never collapsing its content

### DIFF
--- a/Telegram/Controls/SettingsExpander.cs
+++ b/Telegram/Controls/SettingsExpander.cs
@@ -81,7 +81,9 @@ namespace Telegram.Controls
                 ExpandedChanged?.Invoke(this, EventArgs.Empty);
             }
 
-            var tracker = _tracker++;
+            // Pre-increment: the batch below compares this against _tracker to ignore its own
+            // completion once a newer toggle has started. Post-increment never matches.
+            var tracker = ++_tracker;
 
             _expanded = newValue;
             ActionButton.ChevronGlyph = IsExpanded ? Icons.ChevronUp16 : Icons.ChevronDown16;


### PR DESCRIPTION
### Problem

`SettingsExpander.OnExpandedChanged` guards the scoped batch's completion against a newer
toggle:

```csharp
var tracker = _tracker++;
...
batch.Completed += (s, args) =>
{
    if (_tracker == tracker)
    {
        PopupRoot.Visibility = _expanded ? Visibility.Visible : Visibility.Collapsed;
    }
};
```

`_tracker++` returns the value *before* the increment, so by the time the handler runs the
comparison is `(n + 1) == n`. It is never true, and the body never executes — on any toggle,
not just a superseded one.

That handler is the only thing that applies `Visibility.Collapsed`, and `PopupRoot.Visibility`
is set to `Visible` unconditionally a few lines above:

```csharp
PopupHost.Height = newValue ? double.NaN : 0;
PopupRoot.Margin = new Thickness(0, 0, 0, newValue ? 0 : -PopupRoot.ActualHeight);
PopupRoot.Visibility = Visibility.Visible;
```

So a collapsed expander keeps its content `Visible` in the tree, still measured and arranged
on every pass, hidden only by `Height = 0` on the host and a negative bottom margin.

### Fix

Pre-increment, so `tracker` identifies *this* run:

```csharp
var tracker = ++_tracker;
```

The guard then means what it was written to mean — apply the final visibility unless a newer
toggle has started since this batch began. The stale-completion case it was added for still
works, because a subsequent toggle bumps `_tracker` past the captured value.

### History

The guard arrived in `a3a98e6d31` together with the switch from the captured `newValue` to the
`_expanded` field, which is what makes the intent unambiguous. The later `c67940f5e6` ("Fix
expander layout cycle") removed a `SizeChanged` handler that rewrote the same margin, and is
unrelated to this.

### Verification

Not built or run — a UWP/.NET Native build is not available in the environment this was
prepared in. The edited file was checked with Roslyn (`CSharpSyntaxTree.ParseText`) and parses
with no syntax errors; that confirms syntax only, not type checking. Worth a visual check that
collapsing still animates rather than snapping, since the collapse now ends in a real
visibility change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)