### PR TITLE
Fix crash when copying an empty selection or an absent note

### DIFF
--- a/Telegram/Common/MessageHelper.cs
+++ b/Telegram/Common/MessageHelper.cs
@@ -160,6 +160,14 @@ namespace Telegram.Common
 
         public static async void CopyText(XamlRoot xamlRoot, FormattedText text)
         {
+            // Callers pass a selection or an optional field: GetSelectedText returns null with
+            // nothing selected, and UserFullInfo.Note is null when there is no note. Copying
+            // nothing is a no-op, and this method is async void, so a throw here kills the app.
+            if (string.IsNullOrEmpty(text?.Text))
+            {
+                return;
+            }
+
             var dataPackage = new DataPackage();
             dataPackage.SetText(text.Text);
 


### PR DESCRIPTION
### Crash

```
NullReferenceException: Object reference not set to an instance of an object.
```

Reported by crash telemetry on 12.9.0.0.

```
0  Telegram.Common.MessageHelper.<CopyText>d__3.MoveNext
   Telegram/Common/MessageHelper.cs:164
1  System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw
2  System.Runtime.CompilerServices.AsyncMethodBuilderCore.<>c.<ThrowAsync>b__7_0
3  System.Threading.WinRTSynchronizationContext.Invoker.InvokeCore
```

### Cause

`MessageHelper.cs:164` is the first statement of the `FormattedText` overload:

```csharp
public static async void CopyText(XamlRoot xamlRoot, FormattedText text)
{
    var dataPackage = new DataPackage();
    dataPackage.SetText(text.Text);
```

Several callers pass a value that is legitimately null:

- `TextSelectionManager.cs:541` — `GetSelectedText()` opens with
  `if (_selectedRanges.Count == 0) return null;`
- `BlockQuote.cs:71` — `block.GetSelectedText(0, block.ContentLength)`
- `ProfileHeader.xaml.cs:1460` — `fullInfo.Note`, which is null whenever the contact has no
  note

Because the method is `async void`, the exception is posted to the dispatcher via
`ThrowAsync` and terminates the app rather than being catchable.

### Which caller?

The stack cannot say. `async void` means frame 0 is the state machine's `MoveNext` and the
caller's frame is already gone, so all three remain candidates — which is also why the fix
goes in `CopyText` rather than at one call site. The semantics are identical everywhere:
there is nothing to copy, so do nothing. Guarding one call site would leave the same crash
reachable from the other two.

### Fix

Return early when there is no text. Nothing is written to the clipboard and no "copied" toast
is shown, which is the correct outcome for an empty selection.

### Note

The `async void` signature is the reason this was fatal rather than a swallowed no-op. Changing
it would touch every call site, so it is out of scope here, but it is worth knowing that this
whole family of handlers converts an ordinary bug into a process kill.

### Verification

Not built or run — a UWP/.NET Native build is not available in the environment this was
prepared in. The edited file was checked with Roslyn (`CSharpSyntaxTree.ParseText`) and parses
with no syntax errors; that confirms syntax only, not type checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)