### PR TITLE
Only log the voip ready state when it changes

### DIFF
--- a/Telegram/Services/Calls/VoipCall.cs
+++ b/Telegram/Services/Calls/VoipCall.cs
@@ -504,12 +504,12 @@ namespace Telegram.Services.Calls
                 SoundEffects.Stop();
             }
 
-            Logger.Info(state);
-
             lock (_stateLock)
             {
                 if (_state != VoipState.Ready || _readyState != state)
                 {
+                    Logger.Info(state);
+
                     UpdateConnectionState(state, _signalBarsUpdatedArgs.Count);
 
                     if (state == VoipReadyState.Established)


### PR DESCRIPTION
`VoipCall.OnStateUpdated` logs before the guard that ignores an unchanged state:

```csharp
Logger.Info(state);

lock (_stateLock)
{
    if (_state != VoipState.Ready || _readyState != state)
    {
        UpdateConnectionState(state, _signalBarsUpdatedArgs.Count);
        ...
    }
}
```

When the manager repeats a state, everything below the log is correctly skipped but the
line is still written. In one crash report the entire log window was identical
`OnStateUpdated / Failed` entries, all stamped at the same millisecond — so the report
carried no record of anything that happened before, which is precisely what a crash log
exists for.

`OnSignalBarsUpdated`, immediately below, already logs from inside its own change guard:

```csharp
if (_signalBarsUpdatedArgs.Count != count)
{
    Logger.Info(count);
    ...
}
```

This makes `OnStateUpdated` match. The repeated call still does no work; it just no longer
displaces the log.

### Verification

Not built or run — a UWP/.NET Native build is not available in the environment this was
prepared in. The edited file was checked with Roslyn (`CSharpSyntaxTree.ParseText`) and
parses with no syntax errors; that confirms syntax only, not type checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)