### PR TITLE
Keep the log tail in a ring buffer

### DIFF
--- a/Telegram/Logger.cs
+++ b/Telegram/Logger.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) Fela Ameghino 2015-2026
 //
 // Distributed under the GNU General Public License v3.0. (See accompanying
@@ -6,11 +6,11 @@
 //
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
+using System.Text;
 using Telegram.Native;
 using Telegram.Services;
 using Telegram.Td;
@@ -69,7 +69,13 @@ namespace Telegram
             Log(LogLevel.Info, message, member, filePath, line);
         }
 
-        private static readonly List<string> _lastCalls = new();
+        // Ships with every crash report, so the size trades how much history a report
+        // carries against how large every report gets.
+        private const int TailCapacity = 200;
+
+        private static readonly string[] _lastCalls = new string[TailCapacity];
+        private static int _lastCallsHead;
+        private static int _lastCallsCount;
         private static readonly object _lock = new();
 
         [SuppressUnmanagedCodeSecurity]
@@ -112,11 +118,14 @@ namespace Telegram
 
             lock (_lock)
             {
-                _lastCalls.Add(entry);
+                // Overwrite the oldest slot instead of shifting the window down, which
+                // copied every retained entry on each call once the window was full.
+                _lastCalls[_lastCallsHead] = entry;
+                _lastCallsHead = (_lastCallsHead + 1) % TailCapacity;
 
-                if (_lastCalls.Count > 50)
+                if (_lastCallsCount < TailCapacity)
                 {
-                    _lastCalls.RemoveAt(0);
+                    _lastCallsCount++;
                 }
             }
 
@@ -139,17 +148,31 @@ namespace Telegram
 
         public static unsafe string Dump()
         {
+            // We use UtcNow instead of Now because Now is expensive.
+            long diff = 116444736000000000;
+            long time = 0;
+
+            GetSystemTimeAsFileTime(&time);
+
+            var builder = new StringBuilder();
+
             lock (_lock)
             {
-                // We use UtcNow instead of Now because Now is expensive.
-                long diff = 116444736000000000;
-                long time = 0;
+                // Once the window has wrapped, the slot due to be written next is the oldest.
+                var start = _lastCallsCount < TailCapacity ? 0 : _lastCallsHead;
 
-                GetSystemTimeAsFileTime(&time);
-
-                _lastCalls.Add(string.Format("[{0:F3}] Bump", (time - diff) / 10_000_000d));
-                return string.Join('\n', _lastCalls);
+                for (int i = 0; i < _lastCallsCount; i++)
+                {
+                    builder.Append(_lastCalls[(start + i) % TailCapacity]);
+                    builder.Append('\n');
+                }
             }
+
+            // Marks when the report was taken. Appended to the output rather than stored as
+            // an entry, so that dumping neither evicts a line nor leaves a trail of markers
+            // in the next dump.
+            builder.AppendFormat("[{0:F3}] Bump", (time - diff) / 10_000_000d);
+            return builder.ToString();
         }
     }
 


### PR DESCRIPTION
The in-memory window that ships with every crash report had three problems.

### It shifted the whole window on every call

```csharp
_lastCalls.Add(entry);

if (_lastCalls.Count > 50)
{
    _lastCalls.RemoveAt(0);
}
```

`RemoveAt(0)` on a `List<string>` moves every remaining element down one slot, so once the
window was full each log call copied the entire retained set. Logging sits on hot paths, and
this is the sort of thing that gets worse precisely when a burst of logging makes it matter.

Now a fixed array with a head index: writing an entry overwrites one slot.

### Dump mutated the buffer

```csharp
_lastCalls.Add(string.Format("[{0:F3}] Bump", ...));
return string.Join('\n', _lastCalls);
```

The marker was stored as an entry, so taking a dump evicted a real line, and a second dump
carried the first marker along as though it had been logged. `Dump` now appends the marker to
its output and leaves the buffer untouched, which also makes it safe to call more than once.

### The size was an inline 50

Fifty entries is well under a second of ordinary logging, so a report often shows only the
final moments. It is now a named `TailCapacity` constant at 200.

200 rather than something larger because, without de-duplication, no fixed window survives a
genuine storm — a source repeating a line thousands of times a second will blow through any
size, and that is better solved where the line is written. 200 covers ordinary activity plus a
modest burst while keeping the per-report payload to roughly 25 KB of text. The ring buffer
makes the number cheap to revisit: raising it now costs memory only, not time per call.

### Notes

Iteration starts at the oldest entry — once the window has wrapped, that is the slot due to be
written next — so the output order is unchanged.

One thing deliberately left alone: the timestamps are formatted with the current culture, so
reports from some locales use a decimal comma. That makes the tail slightly awkward to parse,
but changing it would alter the format of every log line, which does not belong in this change.

### Verification

Not built or run — a UWP/.NET Native build is not available in the environment this was
prepared in. The edited file was checked with Roslyn (`CSharpSyntaxTree.ParseText`) and parses
with no syntax errors; that confirms syntax only, not type checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)