### PR TITLE
Don't recreate the Direct3D device from the device-lost callback

### DIFF
--- a/Telegram.Native/PlaceholderImageHelper.cpp
+++ b/Telegram.Native/PlaceholderImageHelper.cpp
@@ -11,6 +11,7 @@
 
 #include <zlib.h>
 
+#include <format>
 #include <numbers>
 
 #include <src\webp\decode.h>
@@ -1011,6 +1012,11 @@ namespace winrt::Telegram::Native::implementation
         HRESULT result;
         UINT creationFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
 
+        // The removed device has to go before a new one is created: com_ptr::put() overwrites the
+        // pointer without releasing it, so recreating over a live device strands it and everything
+        // the display driver holds behind it.
+        m_d3dDevice = nullptr;
+
         winrt::com_ptr<ID3D11DeviceContext> context;
         if (FAILED(D3D11CreateDevice(nullptr,               // specify null to use the default adapter
             D3D_DRIVER_TYPE_HARDWARE, 0,
@@ -1023,6 +1029,11 @@ namespace winrt::Telegram::Native::implementation
             context.put()									// returns the device immediate context
         )))
         {
+            // A failed D3D11CreateDevice can still have written the out parameters, and put()
+            // would overwrite them.
+            m_d3dDevice = nullptr;
+            context = nullptr;
+
             // Try again using WARP (software rendering)
             ReturnIfFailed(result, D3D11CreateDevice(nullptr,
                 D3D_DRIVER_TYPE_WARP, 0,
@@ -1074,11 +1085,15 @@ namespace winrt::Telegram::Native::implementation
         return S_OK;
     }
 
-    void PlaceholderImageHelper::OnDirect3DDeviceLost(DeviceLostHelper const* /* sender */, DeviceLostEventArgs const& args)
+    void PlaceholderImageHelper::OnDirect3DDeviceLost(DeviceLostHelper const* /* sender */, DeviceLostEventArgs const& /* args */)
     {
-        std::lock_guard const guard(m_criticalSection);
-
-        CreateDeviceResources();
+        // Deliberately does not recreate the device here. This runs on the threadpool callback for
+        // the device-removed event, so the display driver is still tearing itself down, and calling
+        // D3D11CreateDevice at that moment faults inside the vendor user-mode driver.
+        //
+        // PlaceholderHelper asks HandleDeviceLost() on every access to the singleton, so the device
+        // is rebuilt from the UI thread the next time it is actually needed.
+        LOGGER_ERROR(L"Direct3D device lost");
     }
 
     HRESULT PlaceholderImageHelper::CreateTextFormat(double fontSize)

--- a/Telegram.Native/PlaceholderImageHelper.h
+++ b/Telegram.Native/PlaceholderImageHelper.h
@@ -179,11 +179,18 @@ namespace winrt::Telegram::Native::implementation
 
         ~DeviceLostHelper()
         {
-            // Cancel any pending wait and drain in-flight callbacks before the helper dies, so a
-            // device-lost callback can't run RaiseDeviceLostEvent on a destroyed object. Safe to
-            // wait here because the destructor never runs on the threadpool callback thread
-            // (unlike StopWatchingCurrentDevice, which OnDeviceLost re-enters and so must not
-            // wait on itself).
+            Shutdown();
+        }
+
+        // Cancels any pending wait and drains in-flight callbacks, so a device-lost callback can't
+        // run RaiseDeviceLostEvent on an object that is going away. CloseThreadpoolWait on its own
+        // does not wait for a callback that is already running, which is why StopWatchingCurrentDevice
+        // is not enough on a teardown path.
+        //
+        // Must not be called from the callback itself -- that is what StopWatchingCurrentDevice is
+        // for, since waiting there would be waiting on ourselves.
+        void Shutdown()
+        {
             if (m_onDeviceLostHandler)
             {
                 ::SetThreadpoolWait(m_onDeviceLostHandler, nullptr, nullptr);
@@ -232,9 +239,10 @@ namespace winrt::Telegram::Native::implementation
                 // QI For the ID3D11Device4 interface.
                 auto d3dDevice{ m_dxgiDevice.as<::ID3D11Device4>() };
 
-                // Unregister from the device lost event.
-                ::CloseThreadpoolWait(m_onDeviceLostHandler);
+                // Unregister before closing the wait: the other order leaves a window where the
+                // event can still be signalled against a wait object we have already closed.
                 d3dDevice->UnregisterDeviceRemoved(m_cookie);
+                ::CloseThreadpoolWait(m_onDeviceLostHandler);
 
                 // Clear member variables.
                 m_onDeviceLostHandler = nullptr;
@@ -287,17 +295,22 @@ namespace winrt::Telegram::Native::implementation
         // Explicit dispose is needed because otherwise XamlRoot may get deleted before deconstructor is invoked
         void Close()
         {
+            // Shutdown, not StopWatchingCurrentDevice: a device-lost callback that is already
+            // running holds a raw pointer to this object and would outlive it otherwise.
+            m_deviceLostHelper.Shutdown();
+
             m_nineGridCache.clear();
             m_svgCacheList.clear();
             m_svgCacheIndex.clear();
-            m_deviceLostHelper.StopWatchingCurrentDevice();
         }
 
         HRESULT HandleDeviceLost()
         {
             std::lock_guard const guard(m_criticalSection);
 
-            if (FAILED(m_d3dDevice->GetDeviceRemovedReason()))
+            // The device is null when a previous attempt to create one failed, which happens while
+            // the display driver is still resetting.
+            if (m_d3dDevice == nullptr || FAILED(m_d3dDevice->GetDeviceRemovedReason()))
             {
                 return CreateDeviceResources();
             }


### PR DESCRIPTION
**NativeException: ACCESS_VIOLATION**, reported by crash telemetry on 12.9.

Three crash signatures, one bug. Two of them are this stack, on two different Intel user-mode drivers (`igd10iumd64` and `igd10um64xe`):

```
   9  RtlEnterCriticalSection+0x4d
  10  igd10um64xe+0x24852d  <no symbols>
  ...
  19  NDXGI::CDevice::CreateDriverInstance+0x271
  20  CDevice::CreateDriverInstance+0xa2
  ...
  32  D3D11CoreCreateDevice+0x40f
  33  D3D11CreateDeviceAndSwapChainImpl+0x2a3
  34  D3D11CreateDeviceAndSwapChain+0x9e
  35  D3D11CreateDeviceImpl+0x5c
  36  D3D11CreateDevice+0x86
  37  winrt::Telegram::Native::implementation::PlaceholderImageHelper::CreateDeviceResources+0x87
      Telegram.Native\PlaceholderImageHelper.cpp:1015
  38  winrt::Telegram::Native::implementation::PlaceholderImageHelper::OnDirect3DDeviceLost+0x5c
      Telegram.Native\PlaceholderImageHelper.cpp:1081
  39  winrt::Telegram::Native::implementation::DeviceLostHelper::OnDeviceLost+0x59
      Telegram.Native\PlaceholderImageHelper.h:265
  40  TppExecuteWaitCallback+0x4cd
  41  TppWorkerThread+0x599
```

The third is the same subsystem, faulting one frame higher:

```
  10  winrt::Telegram::Native::implementation::DeviceLostHelper::OnDeviceLost+0x49
      Telegram.Native\PlaceholderImageHelper.h:265
  11  TppExecuteWaitCallback+0xae
  12  TppWorkerThread+0x448
```

## Diagnosis

`DeviceLostHelper` registers for `RegisterDeviceRemovedEvent`, and `OnDirect3DDeviceLost` called `CreateDeviceResources()` **straight from the threadpool wait callback**. That runs while the display driver is still tearing itself down, and `D3D11CreateDevice` at that moment faults inside the vendor UMD — in its own critical section, during `CreateDriverInstance`. Two different Intel driver families produce the identical stack, so this is not one bad driver build.

Recreating there is also redundant: `PlaceholderHelper.Foreground`/`.Background` call `HandleDeviceLost()` on every access to the singleton, which checks `GetDeviceRemovedReason()` and rebuilds on the UI thread. That path is the one that was already doing the work safely.

The third signature is the lifetime half of the same code. `PlaceholderImageHelper::Close()` called `StopWatchingCurrentDevice()`, which closes the threadpool wait but does **not** wait for a callback that is already running — so the callback went on to `RaiseDeviceLostEvent` (`PlaceholderImageHelper.h:265`) on an object that was being destroyed. `~DeviceLostHelper` does contain a proper drain, but it was dead code: `Close()` had already cleared `m_onDeviceLostHandler`, which is the handle the drain checks.

## What changes

- `OnDirect3DDeviceLost` no longer recreates anything; it logs and returns. The device is rebuilt lazily by the existing `HandleDeviceLost()` path, from the UI thread, the next time it is needed. `HandleDeviceLost` now tolerates a null device, which is the state left behind when creation failed.
- The drain moves out of `~DeviceLostHelper` into a `Shutdown()` method, and `Close()` calls it instead of `StopWatchingCurrentDevice()`. It stays idempotent, so the destructor path is unaffected.
- `StopWatchingCurrentDevice` unregisters the device-removed event before closing the wait, rather than after.
- `CreateDeviceResources` releases `m_d3d11Device` before calling `D3D11CreateDevice`. `winrt::com_ptr::put()` overwrites without releasing (it only asserts in debug), so recreating over the removed device stranded it and everything the driver held behind it. Same between the hardware and WARP attempts.

## Build status

**Not built** — there is no UWP/.NET Native build environment on the machine this was written on. The changes are C++/WinRT and were not compiled.
