### PR TITLE
Log why the video swap chain failed, and don't crash when it does

### DIFF
--- a/Telegram.Native/Media/AsyncMediaPlayer.cpp
+++ b/Telegram.Native/Media/AsyncMediaPlayer.cpp
@@ -40,12 +40,23 @@ namespace winrt::Telegram::Native::Media::implementation
             m_context = AsyncMediaPlayerSwapChain(true);
         }
 
-        if (m_context)
+        // A swap chain that failed to come up is not a reason to fail construction: players are
+        // created from XAML Loaded handlers, so throwing here is an unhandled exception, and the
+        // Direct3D device can legitimately be unavailable while the display driver is resetting.
+        // Play audio only instead -- AsyncMediaPlayerSwapChain::Create logs why it failed.
+        bool video = true;
+
+        if (m_context && m_context.IsLoaded())
         {
             for (const auto& opt : m_context.SwapChainOptions())
             {
                 argsStorage.push_back(winrt::to_string(opt));
             }
+        }
+        else if (m_context)
+        {
+            LOGGER_ERROR(L"swap chain unavailable, playing without video");
+            video = false;
         }
 
         argsStorage.push_back("--aout=winstore");
@@ -62,7 +73,7 @@ namespace winrt::Telegram::Native::Media::implementation
             argsStorage.push_back("--no-audio");
         }
 
-        if ((mode & AsyncMediaPlayerMode::Video) == AsyncMediaPlayerMode::None)
+        if ((mode & AsyncMediaPlayerMode::Video) == AsyncMediaPlayerMode::None || !video)
         {
             argsStorage.push_back("--no-video");
         }

--- a/Telegram.Native/Media/AsyncMediaPlayerSwapChain.cpp
+++ b/Telegram.Native/Media/AsyncMediaPlayerSwapChain.cpp
@@ -7,6 +7,7 @@
 #include <winrt/Windows.UI.Xaml.Media.h>
 #include <windows.ui.xaml.media.dxinterop.h>
 
+#include <format>
 #include <sstream>
 #include <iomanip>
 #include <stdexcept>
@@ -67,7 +68,9 @@ namespace winrt::Telegram::Native::Media::implementation
     {
         if (!m_loaded)
         {
-            throw std::runtime_error("You must wait for the VideoView to be loaded before calling GetSwapChainOptions()");
+            // Not a lifecycle mistake, whatever the message inherited from LibVLCSharp said: the
+            // only way to get here is Create() having failed, and it logs which call went wrong.
+            throw std::runtime_error("The Direct3D swap chain is not available");
         }
 
         IVector<hstring> options = winrt::single_threaded_vector<hstring>();
@@ -91,6 +94,12 @@ namespace winrt::Telegram::Native::Media::implementation
 
         winrt::com_ptr<IDXGIFactory2> dxgiFactory;
 
+        // Every call below is into the display driver and any of them can fail while the driver is
+        // resetting. The HRESULT on its own doesn't say which one did, and the whole function used
+        // to fail silently, so the failure only surfaced later as an unrelated-looking error from
+        // SwapChainOptions. Name the stage as we go and log it.
+        const wchar_t* stage = L"CreateDXGIFactory2";
+
         try
         {
             UINT creationFlags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
@@ -110,7 +119,10 @@ namespace winrt::Telegram::Native::Media::implementation
             winrt::check_hresult(CreateDXGIFactory2(0, IID_PPV_ARGS(dxgiFactory.put())));
 #endif
 
+            stage = L"D3D11CreateDevice";
+
             m_d3d11Device = nullptr;
+            m_deviceContext = nullptr;
             UINT adapterIndex = 0;
 
             winrt::com_ptr<IDXGIAdapter1> adapter;
@@ -133,6 +145,11 @@ namespace winrt::Telegram::Native::Media::implementation
                     break;
                 }
 
+                // put() overwrites without releasing, so anything a failed attempt left behind has
+                // to go before the next adapter is tried.
+                m_d3d11Device = nullptr;
+                m_deviceContext = nullptr;
+
                 adapter = nullptr;
                 adapterIndex++;
             }
@@ -141,6 +158,8 @@ namespace winrt::Telegram::Native::Media::implementation
             {
                 throw std::runtime_error("Could not create Direct3D11 device: No compatible adapter found.");
             }
+
+            stage = L"IDXGIDevice1";
 
             winrt::com_ptr<IDXGIDevice1> device;
             winrt::check_hresult(m_d3d11Device->QueryInterface(IID_PPV_ARGS(device.put())));
@@ -159,6 +178,8 @@ namespace winrt::Telegram::Native::Media::implementation
             swapChainDesc.Flags = 0;
             swapChainDesc.AlphaMode = DXGI_ALPHA_MODE_PREMULTIPLIED;
 
+            stage = L"CreateSwapChainForComposition";
+
             winrt::check_hresult(dxgiFactory->CreateSwapChainForComposition(
                 m_d3d11Device.get(),
                 &swapChainDesc,
@@ -167,8 +188,12 @@ namespace winrt::Telegram::Native::Media::implementation
 
             device->SetMaximumFrameLatency(1);
 
+            stage = L"IDXGIDevice3";
+
             // This is necessary so we can call Trim() on suspend
             winrt::check_hresult(device->QueryInterface(IID_PPV_ARGS(m_device3.put())));
+
+            stage = L"IDXGISwapChain2";
 
             winrt::check_hresult(m_swapChain->QueryInterface(IID_PPV_ARGS(m_swapChain2.put())));
 
@@ -186,11 +211,20 @@ namespace winrt::Telegram::Native::Media::implementation
 
             return true;
         }
+        catch (winrt::hresult_error const& ex)
+        {
+            LOGGER_ERROR(L"{} failed: 0x{:08X}, {}", stage, static_cast<uint32_t>(ex.code()), ex.message().c_str());
+            Close();
+        }
+        catch (std::exception const& ex)
+        {
+            LOGGER_ERROR(L"{} failed: {}", stage, winrt::to_hstring(ex.what()).c_str());
+            Close();
+        }
         catch (...)
         {
+            LOGGER_ERROR(L"{} failed", stage);
             Close();
-            // TODO: Add logging
-            // Telegram::Logger::Error(ex.ToString());
         }
 
         return false;


### PR DESCRIPTION
**Exception: Unspecified error — "You must wait for the VideoView to be loaded before calling GetSwapChainOptions()"**, reported by crash telemetry on 12.8.1 and 12.9.

```
   1  winrt::hresult_error::originate+0x2f
  ...
  11  winrt::impl::produce<...AsyncMediaPlayerSwapChain...>::get_SwapChainOptions+0x2a
  12  winrt::impl::consume_...IAsyncMediaPlayerSwapChain...>::SwapChainOptions+0x4b
  13  winrt::Telegram::Native::Media::implementation::AsyncMediaPlayer::AsyncMediaPlayer+0x3f6
      Telegram.Native\Media\AsyncMediaPlayer.cpp:40
  14  winrt::impl::produce<...AsyncMediaPlayerFactory>::CreateInstance+0x65
  ...
  19  Telegram::Controls::NativeVideoPlayer.OnConnected+0x196
      Telegram\Controls\NativeVideoPlayer.xaml.cs:49
  ...
  44  CEventManager::RaiseLoadedEventForObject+0x89
  45  CEventManager::RaiseLoadedEvent+0xe3
```

## Diagnosis

The message is inherited from LibVLCSharp and is misleading: it describes a lifecycle mistake this code cannot make. Nothing waits for a `VideoView` here.

What actually happens is that `AsyncMediaPlayerSwapChain::Create()` fails. Its entire body is wrapped in `catch (...) { Close(); /* TODO: Add logging */ }`, so the Direct3D failure is swallowed, `m_loaded` stays false, and the failure only surfaces on the *next* line of the `AsyncMediaPlayer` constructor, where `SwapChainOptions()` throws. Which of `CreateDXGIFactory2`, `D3D11CreateDevice`, `CreateSwapChainForComposition` or the three `QueryInterface` calls failed — and with what `HRESULT` — was never recorded, so the reports cannot say.

That throw then crosses a XAML `Loaded` handler and becomes an unhandled exception. All three construction sites are on that path: `NativeVideoPlayer.OnConnected`, `StoryContent.InitializeVideo` and `PlaybackService.Create`. The log tails put the great majority of these right after the gallery overlay opens.

Notably `PlaceholderImageHelper` has a crash of its own where `D3D11CreateDevice` faults inside the display driver during a device reset, which is the same class of condition seen from the other side.

## What changes

- `Create()` names each stage as it goes and logs the stage, the `HRESULT` and the message on failure. This is the point of the change: the next report will say which driver call failed.
- The thrown message says what actually happened rather than blaming a `VideoView`.
- The player no longer fails construction over it. A Direct3D device can legitimately be unavailable while the display driver is resetting, and there is nothing the caller could do about it, so when the swap chain is not loaded the player is built with `--no-video` instead. Audio still plays, and the failure is in the log rather than in an unhandled exception. This does not hide the bug — before this change the failure was invisible; now it is logged with its cause.
- `m_d3d11Device`/`m_deviceContext` are released between adapter attempts. `winrt::com_ptr::put()` overwrites without releasing, so a failed attempt could strand a device.

## Build status

**Not built** — there is no UWP/.NET Native build environment on the machine this was written on. The changes are C++/WinRT and were not compiled.
