### PR TITLE
Don't animate a deferred template part from SettingsButton's Disabled state

### DIFF
--- a/Telegram/Themes/Generic.xaml
+++ b/Telegram/Themes/Generic.xaml
@@ -5865,11 +5865,13 @@
                                           Grid.Column="1"
                                           Grid.ColumnSpan="2" />
 
-                        <!--  Not x:Load="False", unlike the other optional parts: the Disabled state animates
-                              this one, and a Storyboard.TargetName that resolves to a part which has not been
-                              realized throws E_INVALIDARG out of the measure pass that applies the template.
-                              Collapsed costs one unmeasured ContentPresenter per button instead.  -->
+                        <!--  Deferred with Lazy rather than x:Load, unlike the other optional parts: this one is
+                              a Storyboard.TargetName in the Disabled state, and x:Load leaves the target
+                              unresolvable until something realizes it, which throws E_INVALIDARG out of the
+                              measure pass that applies the template. Lazy realizes on reference instead, which
+                              is what the stock TextBox template relies on for HeaderContentPresenter.  -->
                         <ContentPresenter x:Name="DescriptionPresenter"
+                                          x:DeferLoadStrategy="Lazy"
                                           Visibility="Collapsed"
                                           FontSize="12"
                                           FontFamily="{ThemeResource ContentControlThemeFontFamily}"

--- a/Telegram/Themes/Generic.xaml
+++ b/Telegram/Themes/Generic.xaml
@@ -5818,11 +5818,10 @@
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlForegroundBaseLowBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
-                                                                       Storyboard.TargetName="DescriptionPresenter">
-                                            <DiscreteObjectKeyFrame KeyTime="0"
-                                                                    Value="{ThemeResource SystemControlForegroundBaseLowBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
+                                        <!--  DescriptionPresenter must NOT be animated here: it is x:Load="False" and
+                                              only realized when Description is set, and a Storyboard.TargetName that
+                                              cannot be resolved throws E_INVALIDARG out of the measure pass that
+                                              applies the template. It already draws in a disabled-looking brush.  -->
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>

--- a/Telegram/Themes/Generic.xaml
+++ b/Telegram/Themes/Generic.xaml
@@ -5818,10 +5818,11 @@
                                             <DiscreteObjectKeyFrame KeyTime="0"
                                                                     Value="{ThemeResource SystemControlForegroundBaseLowBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <!--  DescriptionPresenter must NOT be animated here: it is x:Load="False" and
-                                              only realized when Description is set, and a Storyboard.TargetName that
-                                              cannot be resolved throws E_INVALIDARG out of the measure pass that
-                                              applies the template. It already draws in a disabled-looking brush.  -->
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
+                                                                       Storyboard.TargetName="DescriptionPresenter">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="{ThemeResource SystemControlForegroundBaseLowBrush}" />
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
@@ -5864,8 +5865,12 @@
                                           Grid.Column="1"
                                           Grid.ColumnSpan="2" />
 
+                        <!--  Not x:Load="False", unlike the other optional parts: the Disabled state animates
+                              this one, and a Storyboard.TargetName that resolves to a part which has not been
+                              realized throws E_INVALIDARG out of the measure pass that applies the template.
+                              Collapsed costs one unmeasured ContentPresenter per button instead.  -->
                         <ContentPresenter x:Name="DescriptionPresenter"
-                                          x:Load="False"
+                                          Visibility="Collapsed"
                                           FontSize="12"
                                           FontFamily="{ThemeResource ContentControlThemeFontFamily}"
                                           Foreground="{ThemeResource SystemControlDisabledChromeDisabledLowBrush}"


### PR DESCRIPTION
**ArgumentException: Value does not fall within the expected range**, reported by crash telemetry on 12.4.1, 12.7.1, 12.7.4, 12.8.1, 12.9 and 12.9.1. Same stack in every one of them:

```
   0  McgMarshal.ThrowOnExternalCallFailed
   3  Windows.UI.Xaml.FrameworkElement.MeasureOverride(Size)          <- SettingsButton
   9  Windows.UI.Xaml.FrameworkElement.MeasureOverride(Size)          <- SettingsExpander
  15  Telegram.Controls.HeaderedControlPanel.MeasureOverride          HeaderedControl.cs:254
  21  Telegram.Controls.HeaderedControl.MeasureOverride               HeaderedControl.cs:144
  27  Telegram.Controls.SettingsPanel.MeasureOverride                 SettingsPanel.cs:41
```

## Diagnosis

`SettingsButton`'s `Disabled` visual state animates `Foreground` on three template parts. One of them, `DescriptionPresenter`, was `x:Load="False"` and only realized by `OnApplyTemplate` when `Description` is non-empty:

```csharp
if (ComputedIsDescriptionVisible)
{
    DescriptionPresenter = GetTemplateChild(nameof(DescriptionPresenter)) as UIElement;
    ...
}
```

A `Storyboard` whose `TargetName` cannot be resolved fails with `E_INVALIDARG`. The initial visual state is applied while the template is being applied, which XAML does inside the control's `Measure`, so the exception unwinds out through every enclosing `MeasureOverride`. That is why the stacks anchor on `HeaderedControlPanel` and `SettingsPanel` — the frames name the panels the exception passed through, not the control that raised it.

It needs the button to be **disabled before its template is applied**, which happens when the disabled state is inherited rather than set on the button itself. On Settings → Power saving the `HeaderedControl` carries `IsEnabled`, so its `SettingsExpander`s are born disabled, and their `ActionButton` has no `Description`:

```xml
<controls:HeaderedControl IsEnabled="{x:Bind ViewModel.IsAutoDisabled, Mode=OneWay}">
    <controls:SettingsExpander>   <!-- no Description -->
```

`IsAutoDisabled` is false while Windows energy saver is active, so only users on battery power with the saver on ever reach it — which is why it does not reproduce locally unless `IsAutoDisabled` is forced to return false.

Two things corroborate it:

- Settings → **Data and storage** has the same inherited-disabled `SettingsExpander`s, but sets `Description`, so the part is realized and the target resolves. Users navigate through that page moments before crashing on Power saving.
- Settings → **Advanced** has a `SettingsButton` with no `Description` and a bound `IsEnabled`, but it is created enabled and only disabled afterwards by the binding, so the state change happens outside the template-application measure.

## What changes

`DescriptionPresenter` is deferred with `x:DeferLoadStrategy="Lazy"` + `Visibility="Collapsed"` instead of `x:Load="False"`. `Lazy` realizes the element when something references it, including a visual state, so the storyboard target resolves without the part being materialized up front — which is how the stock `TextBox` template defers `HeaderContentPresenter`. The visual state is untouched, so the disabled appearance is unchanged.

Two earlier attempts on this branch are in the history: removing the key frame (fixed the crash, but the description then kept its own brush while the title dimmed, which looks wrong wherever `Description` is set), and dropping the deferral outright (correct, but paid for a `ContentPresenter` on every button). `Premium` and `Chevron` keep `x:Load`, since nothing animates them.

I checked the rest of the app for the same shape: this was the only `Storyboard.TargetName` in any template pointing at an `x:Load="False"` element. The `VisualState.Setters` that target deferred parts (`RecentChoosers` in the message reaction templates) are left alone — those resolve differently and do not throw, as reactions demonstrate every day.

## Build status

**Not built** — there is no UWP/.NET Native build environment on the machine this was written on. The file was checked for XML well-formedness.
