### PR TITLE
Log unhandled XAML exceptions before swallowing them

### DIFF
--- a/Telegram/Common/WatchDog.cs
+++ b/Telegram/Common/WatchDog.cs
@@ -287,6 +287,11 @@ namespace Telegram
         [HandleProcessCorruptedStateExceptions, SecurityCritical]
         private static void OnUnhandledException(object sender, Windows.UI.Xaml.UnhandledExceptionEventArgs args)
         {
+            // A managed exception thrown inside a XAML callback comes back to whoever called into
+            // XAML as a failure HRESULT, so the crash reads as a bare COMException with no app frame
+            // beneath it. Handled below discards the original, and this is the last point it exists.
+            Logger.Error(args.Exception);
+
             args.Handled = args.Exception is not LayoutCycleException
                 && args.Exception.HResult != unchecked((int)0x8001010A);
 


### PR DESCRIPTION
`WatchDog.OnUnhandledException` sets `args.Handled = true` and returns without recording the
exception anywhere — no `ProcessException`, no `Logger`, only a `MessagePopup` gated behind a
debug-only diagnostics setting. Every managed exception that reaches it is discarded.

That matters more than it looks, because of where those exceptions come from. When app code
throws inside a callback XAML invokes — a `SelectionChanged` handler, `ContainerContentChanging`,
a binding evaluated during a collection reset — XAML raises `UnhandledException`, we mark it
handled, and XAML then returns a failure HRESULT to whichever call it was servicing. The caller
is what gets reported, so the crash arrives as a bare `COMException: External component has thrown
an exception.` with `E_FAIL`, no inner exception, and no app frame beneath the interop stubs.
The exception that actually caused it no longer exists by then.

The family that exposed this is a `Clear()` on the chat list's items collection, reported by crash
telemetry on 12.9.1.0 and 12.8.1.0. The whole stack below the failure is framework interop:

```
   0  McgMarshal.ThrowOnExternalCallFailed
   1  __Interop.ComCallHelpers.Call
   2  NotifyCollectionChangedEventHandler__Impl.Invoke
   4  NotifyCollectionChangedEventHandler.InvokeMulticastThunk
   6  ObservableCollection`1.OnCollectionChanged
   7  ObservableCollection`1.ClearItems
   8  Telegram.ViewModels.ChatListViewModel.ItemsCollection.ReloadAsync   ChatListViewModel.cs:641
   9  Telegram.ViewModels.MainViewModel.set_SelectedFolder                MainViewModel.cs:365
```

Frame 2 is XAML's own native `CollectionChanged` listener returning failure. There is nothing in
the report that says why, and reading the code cannot narrow it either — it is equally consistent
with XAML failing internally and with one of our own callbacks throwing and being converted on the
way back out. Those need different fixes, so guessing between them is not worth doing.

This change logs the exception before anything else in the handler, ahead of the
`NotSupportedException` early return so that path is covered too. `Logger.Error` takes one
ring-buffer slot and `string.Format` calls `ToString()`, so the type, message and stack trace all
land in the log tail that ships with the next report. It deliberately does not call
`Logger.Exception`, which would also file a crash report and change telemetry volume — this is
log-only.

No behaviour change: `Handled` is still set exactly as before, and nothing is rethrown.

Not built or run — a .NET Native build was not available here, and the change was verified by
reading only.
