### PR TITLE
Ship tdjson symbols in the appxsym

### DIFF
--- a/Telegram/Telegram.csproj
+++ b/Telegram/Telegram.csproj
@@ -4733,6 +4733,10 @@
   <ItemGroup>
     <AdditionalFiles Include="$(ProjectDir)\..\Libraries\tdjson\td_api.tl" />
     <ReferenceCopyLocalPaths Include="$(ProjectDir)\..\Libraries\tdjson\$(Platform)\tdjson.dll" />
+    <!-- tdjson comes in as a copy-local path rather than a Reference, so RAR never runs its
+         related-file discovery and the .pdb has to be named explicitly. Without it the appxsym
+         carries no tdjson symbols and every crash inside TDLib is unresolvable. -->
+    <ReferenceCopyLocalPaths Include="$(ProjectDir)\..\Libraries\tdjson\$(Platform)\tdjson.pdb" />
     <ReferenceCopyLocalPaths Include="$(ProjectDir)\..\Libraries\tdjson\$(Platform)\libcrypto-3$(OpenSSLPlatform).dll" />
     <ReferenceCopyLocalPaths Include="$(ProjectDir)\..\Libraries\tdjson\$(Platform)\libssl-3$(OpenSSLPlatform).dll" />
     <ReferenceCopyLocalPaths Include="$(ProjectDir)\..\Libraries\tdjson\$(Platform)\zlib1.dll" />


### PR DESCRIPTION
Crashes inside TDLib currently cannot be symbolicated, because no tdjson PDB is shipped with
any build. `RLottie.pdb` is, which makes the difference look arbitrary — it isn't.

`RLottie` is a real reference:

```xml
<Reference Include="RLottie">
  <HintPath>...\Libraries\rlottie\$(Platform)\RLottie.winmd</HintPath>
  <Implementation>RLottie.dll</Implementation>
</Reference>
```

so `ResolveAssemblyReference` resolves it and then looks beside the resolved file for related
files — same base name, extension in `AllowedReferenceRelatedFileExtensions`, which defaults to
`.pdb;.xml` — and adds `RLottie.pdb` to `ReferenceCopyLocalPaths` on its own. Nothing in the
project asks for it by name.

`tdjson.dll` is put directly into `ReferenceCopyLocalPaths`, which is an *output* of reference
resolution, not an input to it. RAR never sees the file, the related-file discovery never runs,
and `tdjson.pdb` is never looked for. This was inherited rather than introduced: the
`Telegram.Td.UWP` package's own `build/native/Telegram.Td.UWP.targets` did exactly the same four
copy-local entries and also omitted the PDB, and moving off the package copied that verbatim.

The fix is to name the file. `$(Platform)` covers both architectures — the PDB is present for
x64 and ARM64.

Why this is enough, from `Microsoft.AppxPackage.Targets`:

- `_ComputeAppxPackagePayload` builds the payload from `_PackagingOutputsWithoutRedundantCopyLocalItems`, so copy-local items are included.
- `PDBPayload` is `AppxPackagePayload` filtered to `'%(Extension)'=='.pdb'` (line 3062), and that is what `GenerateAppxSymbolPackage` consumes.
- `.pdb` items are then removed from `AppxPackagePayload` (line 3066), so symbols go into the `.appxsym` and not into the shipped `.appx`.

So the installed app does not grow. The `.appxupload` does — `tdjson.pdb` is ~330 MB per
architecture before compression, against RLottie's ~41 MB — which is the deliberate trade for
being able to read TDLib frames in crash reports.

Not built or run: a .NET Native build was not available here. Verified by reading the packaging
targets, and by confirming the file parses as XML and keeps its UTF-8 BOM and CRLF endings.
