### PR TITLE
Fix NullReferenceException when the chat list loads before its template

### DIFF
--- a/Telegram/Controls/ChatListListView.cs
+++ b/Telegram/Controls/ChatListListView.cs
@@ -49,6 +49,7 @@ namespace Telegram.Controls
 
         private ScrollViewer ScrollViewer;
         private Border Ghost;
+        private ItemsPresenter ItemsPresenter;
 
         public ChatListListView()
         {
@@ -184,8 +185,14 @@ namespace Telegram.Controls
         {
             ScrollViewer = GetTemplateChild(nameof(ScrollViewer)) as ScrollViewer;
             Ghost = GetTemplateChild(nameof(Ghost)) as Border;
+            ItemsPresenter = GetTemplateChild(nameof(ItemsPresenter)) as ItemsPresenter;
 
             base.OnApplyTemplate();
+
+            // Loaded does not imply the template has been applied: a control that is in the tree
+            // but never measured raises it with the template parts still null. Whichever of the
+            // two arrives second does the setup.
+            TryInitialize();
         }
 
         public bool TryGetChatAndCell(long chatId, out Chat chat, out ChatCell cell)
@@ -353,28 +360,36 @@ namespace Telegram.Controls
         private InteractionTracker _tracker;
         private VisualInteractionSource _interactionSource;
 
-        private void OnLoaded(object sender, RoutedEventArgs e)
+        private void TryInitialize()
         {
-            if (_trackerOwner == null)
+            if (_trackerOwner != null || ItemsPresenter == null || !IsConnected)
             {
-                _visual = ElementComposition.GetElementVisual(ScrollViewer.ContentTemplateRoot);
-
-                _redirect = _visual.Compositor.CreateSpriteVisual();
-                _redirect.RelativeSizeAdjustment = Vector2.One;
-
-                _hitTest = _visual.Compositor.CreateSpriteVisual();
-                _hitTest.Brush = _visual.Compositor.CreateColorBrush(Colors.Transparent);
-                _hitTest.RelativeSizeAdjustment = Vector2.One;
-
-                _container = _visual.Compositor.CreateContainerVisual();
-                _container.Children.InsertAtBottom(_hitTest);
-                _container.RelativeSizeAdjustment = Vector2.One;
-
-                ElementCompositionPreview.SetElementChildVisual(Ghost, _redirect);
-                ElementCompositionPreview.SetElementChildVisual(this, _container);
-                ConfigureInteractionTracker();
+                return;
             }
 
+            _visual = ElementComposition.GetElementVisual(ItemsPresenter);
+
+            _redirect = _visual.Compositor.CreateSpriteVisual();
+            _redirect.RelativeSizeAdjustment = Vector2.One;
+
+            _hitTest = _visual.Compositor.CreateSpriteVisual();
+            _hitTest.Brush = _visual.Compositor.CreateColorBrush(Colors.Transparent);
+            _hitTest.RelativeSizeAdjustment = Vector2.One;
+
+            _container = _visual.Compositor.CreateContainerVisual();
+            _container.Children.InsertAtBottom(_hitTest);
+            _container.RelativeSizeAdjustment = Vector2.One;
+
+            ElementCompositionPreview.SetElementChildVisual(Ghost, _redirect);
+            ElementCompositionPreview.SetElementChildVisual(this, _container);
+            ConfigureInteractionTracker();
+
+            // OnLoaded may already have run and found nothing to subscribe to.
+            AttachTracker();
+        }
+
+        private void AttachTracker()
+        {
             if (_trackerOwner != null)
             {
                 _trackerOwner.ValuesChanged += OnValuesChanged;
@@ -382,6 +397,19 @@ namespace Telegram.Controls
                 _trackerOwner.InteractingStateEntered += OnInteractingStateEntered;
                 _trackerOwner.IdleStateEntered += OnIdleStateEntered;
                 _trackerOwner.CustomAnimationStateEntered += OnCustomAnimationStateEntered;
+            }
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            if (_trackerOwner == null)
+            {
+                // Subscribes as well, if the template got here first.
+                TryInitialize();
+            }
+            else
+            {
+                AttachTracker();
             }
 
             if (_itemsSource == null)

--- a/Telegram/Themes/Generic.xaml
+++ b/Telegram/Themes/Generic.xaml
@@ -1008,7 +1008,8 @@
                                       BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
                                       CanContentRenderOutsideBounds="{TemplateBinding ScrollViewer.CanContentRenderOutsideBounds}"
                                       AutomationProperties.AccessibilityView="Raw">
-                            <ItemsPresenter Header="{TemplateBinding Header}"
+                            <ItemsPresenter x:Name="ItemsPresenter"
+                                            Header="{TemplateBinding Header}"
                                             HeaderTemplate="{TemplateBinding HeaderTemplate}"
                                             HeaderTransitions="{TemplateBinding HeaderTransitions}"
                                             Footer="{TemplateBinding Footer}"


### PR DESCRIPTION
Reported by crash telemetry on 12.9.1.0.

```
NullReferenceException: Object reference not set to an instance of an object.

0  Telegram.Controls.ChatListListView.OnLoaded          ChatListListView.cs:360
1  Windows.UI.Xaml.RoutedEventHandler.Invoke
2  Telegram.Controls.*Ex.OnChanged                      FrameworkElementEx.cs
3  Windows.UI.Xaml.RoutedEventHandler.Invoke
```

```csharp
_visual = ElementComposition.GetElementVisual(ScrollViewer.ContentTemplateRoot);   // :360
```

The null is `ScrollViewer`, not `ContentTemplateRoot` — `ElementComposition.GetElementVisual`
handles a null argument explicitly, logging an `ArgumentNullException` and calling through, so a
null content root would have produced a log entry rather than an NRE here.

`ScrollViewer` is assigned in exactly one place, `OnApplyTemplate`. That runs on the first measure
pass, so a control that is in the live tree but never measured — collapsed ancestor, zero-size
host — raises `Loaded` with the template parts still null. In the reported session the same
condition shows up 15 seconds earlier in a sibling control, which survives it only because it
guards:

```
[…][ChatHistoryView.cs:391][ScrollToItem] ScrollingHost == null
```

## The change

The element the handler actually wants is the `ItemsPresenter` the control template already
declares inside the ScrollViewer, which is what `ContentTemplateRoot` resolves to. Naming it and
reading it with `GetTemplateChild`, like `ScrollViewer` and `Ghost` already are, makes it
available as soon as the template is applied, with no dependency on the ScrollViewer's
ContentPresenter having realized. `_visual` therefore targets the same element as before.

Setup moves into `TryInitialize`, called from both `OnApplyTemplate` and `Loaded`, so whichever
arrives second does the work.

A bare early-return would have stopped the crash and left `_trackerOwner` null for the rest of the
session, taking the interaction tracker and the swipe-between-folders carousel with it. The
subscriptions are split into `AttachTracker` so that the path where the template arrives last still
attaches — `Loaded` has already run by then and found nothing to attach to — without
double-subscribing when both triggers fire. `OnUnloaded` is unchanged and still holds the matching
`-=`.

## Note for whoever reads the raw stack

Frame 2 symbolicates as `ContentDialogEx.OnChanged` at `FrameworkElementEx.cs:455`, and both
halves are misleading. That file contains six byte-identical `OnChanged` bodies
(`ToggleButtonEx2`, `UserControlEx`, `PageEx`, `ContentDialogEx`, `ListViewEx`, `ListViewItemEx`),
so the linker folded them; the symbol kept one class's name and the line landed in another's copy.
Line 455 is `ListViewItemEx`'s `_disconnected?.Invoke`, which points at the unload path.
`ChatListListView : TopNavView : ListViewEx`, and `OnLoaded` is only ever subscribed to
`Connected`, so what ran is `ListViewEx.OnChanged` and its `_connected?.Invoke`.

## Verification

Not built or run — a .NET Native build was not available here. Verified by reading, plus the XAML
still parses and both files keep their existing encoding and CRLF endings. Worth exercising the
swipe-between-folders gesture once when it is built, since that is the feature the initialization
path drives.
