### PR TITLE
Keep the originating description when an unhandled error is a bare E_FAIL

### DIFF
--- a/Telegram.Native/NativeUtils.cpp
+++ b/Telegram.Native/NativeUtils.cpp
@@ -286,7 +286,10 @@ namespace winrt::Telegram::Native::implementation
         //winrt::com_ptr<ILanguageExceptionErrorInfo2> info2;
         //winrt::com_ptr<IUnknown> language;
         winrt::com_ptr<IRestrictedErrorInfoContext> context;
-        STOWED_EXCEPTION_INFORMATION_V2* stowed;
+        STOWED_EXCEPTION_INFORMATION_V2* stowed = nullptr;
+
+        // Declared up here because CleanupIfFailed is a goto and cannot jump over an initialization.
+        hstring description;
 
         CleanupIfFailed(result, GetRestrictedErrorInfo(info.put()));
         //CleanupIfFailed(result, info->QueryInterface(info2.put()));
@@ -305,24 +308,56 @@ namespace winrt::Telegram::Native::implementation
 
         CleanupIfFailed(result, SetRestrictedErrorInfo(info.get()));
 
-        // TODO: Currently unused, we still propagate the managed exception and we get details from there
-        // Would be fine to use this method, but strings are a little messed up:
-        // "description" contains the exception message
-        // "restrictedDescription" contains the exception message + stack trace
-        //HRESULT error;
-        //BSTR description, restrictedDescription, capabilitySid;
-        //info->GetErrorDetails(&description, &error, &restrictedDescription, &capabilitySid);
+        // For a large family of failures the propagated managed exception is a bare E_FAIL with
+        // no message and a stack that only shows the watchdog rethrowing it, so this is the one
+        // place the originating description survives. "restrictedDescription" carries the message
+        // and its trace, "description" only the message.
+        {
+            HRESULT error;
+            BSTR bstrDescription = nullptr;
+            BSTR bstrRestricted = nullptr;
+            BSTR bstrCapabilitySid = nullptr;
 
-        CleanupIfFailed(result, info->QueryInterface(context.put()));
+            if (SUCCEEDED(info->GetErrorDetails(&bstrDescription, &error, &bstrRestricted, &bstrCapabilitySid)))
+            {
+                if (SysStringLen(bstrRestricted) > 0)
+                {
+                    description = hstring(bstrRestricted, SysStringLen(bstrRestricted));
+                }
+                else if (SysStringLen(bstrDescription) > 0)
+                {
+                    description = hstring(bstrDescription, SysStringLen(bstrDescription));
+                }
+            }
 
-        if (context == nullptr)
+            SysFreeString(bstrDescription);
+            SysFreeString(bstrRestricted);
+            SysFreeString(bstrCapabilitySid);
+        }
+
+        // Deliberately not CleanupIfFailed: the frames are the better signal, but losing them is
+        // no reason to throw the description away too.
+        if (SUCCEEDED(info->QueryInterface(context.put())) && context != nullptr
+            && SUCCEEDED(context->GetContext(&stowed)))
+        {
+            auto error = GetStowedException2(stowed);
+            if (error != nullptr)
+            {
+                if (!description.empty())
+                {
+                    error.StackTrace(description);
+                }
+
+                return error;
+            }
+        }
+
+        if (description.empty())
         {
             return nullptr;
         }
 
-        CleanupIfFailed(result, context->GetContext(&stowed));
-
-        return GetStowedException2(stowed);
+        return winrt::Telegram::Native::FatalError(L"", L"", description, winrt::single_threaded_vector<FatalErrorFrame>());
 
     Cleanup:
         return nullptr;

--- a/Telegram.Native/NativeUtils.cpp
+++ b/Telegram.Native/NativeUtils.cpp
@@ -345,7 +345,15 @@ namespace winrt::Telegram::Native::implementation
             {
                 if (!description.empty())
                 {
-                    error.StackTrace(description);
+                    // GetStowedException2 already put the record's own details here.
+                    std::wstring detail{ std::wstring_view(error.StackTrace()) };
+                    if (!detail.empty())
+                    {
+                        detail += L"\n";
+                    }
+
+                    detail += std::wstring_view(description);
+                    error.StackTrace(hstring(detail));
                 }
 
                 return error;
@@ -365,12 +373,21 @@ namespace winrt::Telegram::Native::implementation
 
     winrt::Telegram::Native::FatalError NativeUtils::GetStowedException2(STOWED_EXCEPTION_INFORMATION_V2* stowed)
     {
-        HRESULT result;
-
-        if (stowed != nullptr && stowed->ExceptionForm == 1 && stowed->Header.Signature == 'SE02')
+        if (stowed == nullptr || stowed->Header.Signature != 'SE02')
         {
-            auto frames = winrt::single_threaded_vector<FatalErrorFrame>();
+            return nullptr;
+        }
 
+        auto frames = winrt::single_threaded_vector<FatalErrorFrame>();
+
+        // ResultCode is the HRESULT the error was stowed with, before propagation flattened it to
+        // E_FAIL, and ThreadId is the thread it came from - not necessarily the one whose stack
+        // ends up in the report.
+        std::wstring detail = wstrprintf(L"Stowed HRESULT 0x%08X on thread %u",
+            (ULONG)stowed->ResultCode, (ULONG)stowed->ThreadId);
+
+        if (stowed->ExceptionForm == 1)
+        {
             for (int i = 0; i < stowed->StackTraceWords; ++i)
             {
                 PVOID pointer;
@@ -402,22 +419,24 @@ namespace winrt::Telegram::Native::implementation
                     //trace += wstrprintf(L"   at %s+0x%016llx\n", L"unknown", (uint64_t)pointer);
                 }
             }
-
-            if (frames.Size())
-            {
-                auto error = winrt::Telegram::Native::FatalError(L"", L"", L"", frames);
-
-                if (stowed->NestedExceptionType == STOWED_EXCEPTION_NESTED_TYPE_STOWED)
-                {
-                    error.InnerException(GetStowedException2((STOWED_EXCEPTION_INFORMATION_V2*)stowed->NestedException));
-                }
-
-                return error;
-            }
+        }
+        else if (stowed->ExceptionForm == 2 && stowed->ErrorText != nullptr)
+        {
+            // The text form carries no stack at all, so requiring form 1 discarded it whole.
+            detail += L"\n";
+            detail += stowed->ErrorText;
         }
 
-    Cleanup:
-        return nullptr;
+        // Returned even with no frames: ResultCode, ThreadId and the nested record are worth
+        // keeping on their own, and used to be dropped along with them.
+        auto error = winrt::Telegram::Native::FatalError(L"", L"", hstring(detail), frames);
+
+        if (stowed->NestedExceptionType == STOWED_EXCEPTION_NESTED_TYPE_STOWED)
+        {
+            error.InnerException(GetStowedException2((STOWED_EXCEPTION_INFORMATION_V2*)stowed->NestedException));
+        }
+
+        return error;
     }
 
     // From http://davidpritchard.org/archives/907

--- a/Telegram/Common/WatchDog.cs
+++ b/Telegram/Common/WatchDog.cs
@@ -146,7 +146,13 @@ namespace Telegram
                 {
                     stowed.Type = ex.GetType().Name;
                     stowed.Message = ex.Message;
-                    stowed.StackTrace = ex.StackTrace;
+
+                    // GetStowedException puts the originating description here when it can recover
+                    // one, and the cases where it can are exactly the ones where ex is a bare
+                    // E_FAIL - so keep both rather than letting the empty one win.
+                    stowed.StackTrace = string.IsNullOrEmpty(stowed.StackTrace)
+                        ? ex.StackTrace
+                        : stowed.StackTrace + "\n" + ex.StackTrace;
 
                     ProcessException(stowed, ex.HResult == unchecked((int)0x8001010A));
                 }


### PR DESCRIPTION
One of the largest crash signatures, present in every release, has this stack and nothing else:

```
0  McgMarshal.ThrowOnExternalCallFailed
1  __Interop.ComCallHelpers.Call
2  __Interop.ForwardComStubs.Stub_18
3  Telegram.WatchDog.OnUnhandledExceptionDetected   WatchDog.cs:141
```

`WatchDog.cs:141` is `e.UnhandledError.Propagate()`, so all four frames describe the watchdog
rethrowing rather than anything that broke. The message is "Unspecified error" and the HRESULT is
`0x80004005`.

It is not one bug. The group hash is built from frame offsets:

```csharp
hashBuilder.Append(binary.Name.ToLowerInvariant());
hashBuilder.Append(nativeIP - nativeImageBase);
```

so every unhandled E_FAIL that loses its context produces identical frames and lands in the same
bucket regardless of cause. The evidence agrees: across sampled reports the last logged call site
scatters over five unrelated places (`NavigateToAsync`, `OnVisibleBoundsChanged`, `UpdateToast`,
`OnNavigatedToAsync`, `AsyncMediaPlayer.cpp:553`), and memory is unremarkable in all of them. That
is also why it never shrinks between releases.

## What this changes

`GetStowedException` already tries to recover the real context — it reads `IRestrictedErrorInfo`,
QIs to `IRestrictedErrorInfoContext` and converts the stowed native stack into frames. But it
returns `nullptr` if any step fails, so when the frames are unavailable the caller falls back to
reporting the bare propagated exception and everything is lost.

The description was already sitting there, written out in a comment and left unused:

```cpp
// TODO: Currently unused, we still propagate the managed exception and we get details from there
// ...
//info->GetErrorDetails(&description, &error, &restrictedDescription, &capabilitySid);
```

"We get details from there" is precisely the assumption that fails for this family. So:

- `GetErrorDetails` is now called, preferring `restrictedDescription` (message + trace) and falling
  back to `description` (message only). BSTRs are freed on every path; `SysStringLen`/`SysFreeString`
  are null-safe.
- The QI and `GetContext` are no longer `CleanupIfFailed`. Frames remain the better signal, but
  losing them is no reason to discard the description as well — a `FatalError` carrying just the
  description is still returned.
- `WatchDog` no longer unconditionally overwrites `stowed.StackTrace` with the propagated
  exception's. Today the stowed strings are always empty so the overwrite is harmless, but it would
  have silently erased everything above. Both are kept.

## What it does not do

It will not split the bucket on its own. Grouping hashes on frames, so recovering only a description
improves what each report *says* without changing where it lands — separating them needs either the
stowed frames to resolve or the backend to fold the description into grouping. And I cannot promise
`restrictedDescription` is populated for these particular failures; the original comment notes the
strings are "a little messed up", and whether XAML fills it in varies. Whether this pays off is an
empirical question, answered one release after it ships.

`GetErrorDetails` also yields the originating `HRESULT`, which is likely more discriminating than
the propagated `E_FAIL`. I left it out to keep the diff small; easy to add if wanted.

## Verification

Not built or run — a .NET Native/C++ build was not available here. Verified by reading: `description`
is declared above the first `CleanupIfFailed` because that macro is a `goto` and cannot jump over an
initialization, `stowed` is initialized and only read inside the guarded branch, braces balance, and
both files keep their existing encoding and CRLF endings. The C++ has not been compiled, so it wants
a real build before merging.
