### PR TITLE
Composer typing and pasting performance

### DIFF
--- a/Telegram/Common/CommonStyles.xaml
+++ b/Telegram/Common/CommonStyles.xaml
@@ -32,7 +32,7 @@
         <Setter Property="BorderThickness"
                 Value="{ThemeResource TextControlBorderThemeThickness}" />
         <Setter Property="FontFamily"
-                Value="{ThemeResource ContentControlThemeFontFamily}" />
+                Value="{ThemeResource EmojiTextThemeFontFamily}" />
         <Setter Property="FontSize"
                 Value="{ThemeResource ControlContentThemeFontSize}" />
         <Setter Property="ScrollViewer.HorizontalScrollMode"
@@ -383,7 +383,7 @@
         <Setter Property="BorderThickness"
                 Value="{ThemeResource TextControlBorderThemeThickness}" />
         <Setter Property="FontFamily"
-                Value="{ThemeResource ContentControlThemeFontFamily}" />
+                Value="{ThemeResource EmojiTextThemeFontFamily}" />
         <Setter Property="FontSize"
                 Value="{ThemeResource ControlContentThemeFontSize}" />
         <Setter Property="ScrollViewer.HorizontalScrollMode"

--- a/Telegram/Common/Extensions.cs
+++ b/Telegram/Common/Extensions.cs
@@ -1562,6 +1562,16 @@ namespace Telegram.Common
 
         public static bool IsValidUrl(this string text)
         {
+            // IsValidEntity only accepts an entity spanning the whole string, and a URL never
+            // spans whitespace, so this rejects without handing the text over to the parser.
+            foreach (var character in text)
+            {
+                if (char.IsWhiteSpace(character))
+                {
+                    return false;
+                }
+            }
+
             return IsValidEntity<TextEntityTypeUrl>(text);
         }
 

--- a/Telegram/Common/ImageHelper.cs
+++ b/Telegram/Common/ImageHelper.cs
@@ -258,8 +258,8 @@ namespace Telegram.Common
         /// longer side.
         ///
         /// Single frame only: SoftwareBitmapSource holds one, so an animated GIF comes
-        /// back static. No GIF reaches this today — StorageMedia previews photos through
-        /// a BitmapImage with DecodePixelWidth and only calls the overload above for
+        /// back static. No GIF reaches this today — StorageThumbnailCache previews photos
+        /// through a BitmapImage with DecodePixelWidth and only calls the overload above for
         /// video, leaving its StoragePhoto branch untaken — but a caller that changes
         /// that needs a FrameCount > 1 branch returning a BitmapImage, which can carry
         /// the same bound through DecodePixelWidth and DecodePixelHeight.
@@ -473,7 +473,7 @@ namespace Telegram.Common
 
                 var frame = BufferSurface.Create((uint)(width * height * 4));
 
-                // Throws rather than returning null: StorageMedia.Refresh recovers by
+                // Throws rather than returning null: StorageThumbnailCache recovers by
                 // falling back to the unedited preview, and does so from a catch.
                 if (!await Task.Run(() => animation.RenderSync(frame, width, height, true, out _)))
                 {

--- a/Telegram/Common/PageBlockHelper.cs
+++ b/Telegram/Common/PageBlockHelper.cs
@@ -92,17 +92,6 @@ namespace Telegram.Common
         private const string PlaceholderChatLink = "[chat]";
         private const string PlaceholderDivider = "---";
 
-        // A button contributes no text of its own: its label belongs to the button,
-        // not to the page, so it is never harvested. This stands in for it wherever
-        // a flat projection needs *something* — and its length must stay stable,
-        // because streaming (DialogPendingTextMessage) computes offsets from it and
-        // a mismatch would truncate at the wrong position. Flatten additionally
-        // covers it with a TextEntityTypeButton carrying the button itself, so a
-        // renderer can substitute the real thing without needing the label here.
-        // internal: TdExtensions has its own RichText walkers that need the same
-        // stand-in. They fold into this class in the walker consolidation.
-        internal const string PlaceholderButton = "[button]";
-
         // =====================================================================
         // FindFirstMedia
         // =====================================================================
@@ -517,10 +506,9 @@ namespace Telegram.Common
                 case null:
                     return;
 
-                // No-link leaves. RichTextButton is one of them on purpose: a
-                // button is an action, not a link, and its label is not page
-                // content to be harvested — the same reason an inline keyboard
-                // never appears in GetLinks.
+                // No-link leaves. RichTextButton is one of them on purpose: its target
+                // is an action to invoke, not a link to follow — the same reason an
+                // inline keyboard never appears in GetLinks.
                 case RichTextButton _:
                 case RichTextPlain _:
                 case RichTextCustomEmoji _:
@@ -889,10 +877,6 @@ namespace Telegram.Common
                 case RichTextCustomEmoji ce:
                     if (ce.AlternativeText != null) sb.Append(ce.AlternativeText);
                     return;
-                // The label is the button's, not the page's — stand in for it.
-                case RichTextButton _:
-                    sb.Append(PlaceholderButton);
-                    return;
                 case RichTextMathematicalExpression me:
                     if (me.Expression != null) sb.Append(me.Expression);
                     return;
@@ -918,6 +902,7 @@ namespace Telegram.Common
                 case RichTextReferenceLink b: AppendPlainText(b.Text, sb); return;
                 case RichTextAnchorLink b: AppendPlainText(b.Text, sb); return;
                 case RichTextDateTime b: AppendPlainText(b.Text, sb); return;
+                case RichTextButton b: AppendPlainText(b.Button.Text, sb); return;
             }
         }
 
@@ -1083,19 +1068,13 @@ namespace Telegram.Common
                         return;
                     }
 
-                // Leaf whose text belongs to the button, not to the page: emit the
-                // placeholder so the entity has a non-zero length, and hand the
-                // whole button to the renderer through the entity. The label is
-                // reachable as Button.Text if the renderer wants it — nothing here
-                // harvests it into the page's text.
+                // The label carries the text, the entity carries the whole button, so a
+                // renderer can substitute the real thing and anything that doesn't still
+                // reads. Flattened like any other span: the server allows custom emoji
+                // and date-time inside a label, and both need their own entity.
                 case RichTextButton button:
-                    {
-                        int start = text.Length;
-                        text.Append(PlaceholderButton);
-                        entities.Add(new TextEntity(start, PlaceholderButton.Length,
-                            new TextEntityTypeButton(button.Button)));
-                        return;
-                    }
+                    EmitSpan(button.Button.Text, text, entities, new TextEntityTypeButton(button.Button));
+                    return;
 
                 case RichTextAnchor _:
                     // Skipped — see ObjectReplacementChar comment above.

--- a/Telegram/Common/Profiler.cs
+++ b/Telegram/Common/Profiler.cs
@@ -1,0 +1,58 @@
+//
+// Copyright (c) Fela Ameghino 2015-2026
+//
+// Distributed under the GNU General Public License v3.0. (See accompanying
+// file LICENSE or copy at https://www.gnu.org/licenses/gpl-3.0.txt)
+//
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Telegram.Common
+{
+    // Scoped timings, written to the debug output through Logger.Info.
+    //
+    // Begin/End are [Conditional("INSTRUMENTATION")] like Instrumentation.Register, so a probe can
+    // stay where it was needed and compiles out of every build that doesn't define the symbol. That
+    // is the whole point of the shape: a helper returning a timestamp would leave the reading itself
+    // in the hot path, which is exactly where these get placed.
+    //
+    // Scopes nest and are reported indented, so an outer scope shows what it contains. End unwinds
+    // to its own label, so a return between a pair reports the abandoned scopes rather than silently
+    // charging the rest of the run to them.
+    public static class Profiler
+    {
+        // Under this is noise: the paths worth probing run on every keystroke.
+        private const double ThresholdMs = 1;
+
+        [ThreadStatic]
+        private static Stack<(string Label, long Timestamp)> t_scopes;
+
+        [Conditional("INSTRUMENTATION")]
+        public static void Begin(string label)
+        {
+            (t_scopes ??= new()).Push((label, Stopwatch.GetTimestamp()));
+        }
+
+        [Conditional("INSTRUMENTATION")]
+        public static void End(string label)
+        {
+            while (t_scopes != null && t_scopes.Count > 0)
+            {
+                var scope = t_scopes.Pop();
+                var elapsed = (Stopwatch.GetTimestamp() - scope.Timestamp) * 1000d / Stopwatch.Frequency;
+
+                if (elapsed >= ThresholdMs)
+                {
+                    Logger.Info(new string(' ', t_scopes.Count * 2) + scope.Label + " " + elapsed.ToString("F1") + "ms");
+                }
+
+                if (scope.Label == label)
+                {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Telegram/Common/Theme.cs
+++ b/Telegram/Common/Theme.cs
@@ -82,13 +82,20 @@ namespace Telegram.Common
             if (xamlAutoFontFamilyDefault)
             {
                 XamlAutoFontFamily = emojiFontFamily;
-                this["EmojiTextThemeFontFamily"] = new FontFamily(emojiFontFamily + comma + xamlAutoFontFamilyValue);
             }
             else
             {
                 XamlAutoFontFamily = xamlAutoFontFamilyValue + comma + emojiFontFamily;
-                this["EmojiTextThemeFontFamily"] = new FontFamily(xamlAutoFontFamilyValue + comma + emojiFontFamily);
             }
+
+            // Text input only (TextBox, RichEditBox, ChatTextBox), and there the emoji font can't
+            // come first: the editor resolves the font once per run and it breaks runs at every
+            // space, so resolving each one against a packaged font file costs about a millisecond
+            // per word - seconds to paste a long text. Leading with the text font costs the emojis
+            // whose base character the text font already covers (keycaps, the copyright and
+            // trademark signs and so on) rendering as plain glyphs while composing. What gets
+            // sent is unaffected, and so is the bubble that renders it.
+            this["EmojiTextThemeFontFamily"] = new FontFamily(xamlAutoFontFamilyValue + comma + emojiFontFamily);
 
             this["ContentControlThemeFontFamily"] = new FontFamily(XamlAutoFontFamily);
             this["EmojiThemeFontFamily"] = new FontFamily(XamlAutoFontFamily);

--- a/Telegram/Controls/Chats/ChatSearchBar.xaml
+++ b/Telegram/Controls/Chats/ChatSearchBar.xaml
@@ -24,7 +24,7 @@
             <Setter Property="BorderThickness"
                     Value="{ThemeResource TextControlBorderThemeThickness}" />
             <Setter Property="FontFamily"
-                    Value="{ThemeResource ContentControlThemeFontFamily}" />
+                    Value="{ThemeResource EmojiTextThemeFontFamily}" />
             <Setter Property="FontSize"
                     Value="{ThemeResource ControlContentThemeFontSize}" />
             <Setter Property="ScrollViewer.HorizontalScrollMode"

--- a/Telegram/Controls/Chats/ChatTextBox.cs
+++ b/Telegram/Controls/Chats/ChatTextBox.cs
@@ -1076,6 +1076,19 @@ namespace Telegram.Controls.Chats
             var flag = false;
             searchText = string.Empty;
 
+            // This runs on every keystroke, and without an inline bot to address none of the
+            // string work below can lead anywhere, so it's not worth an allocation.
+            var inlineBot = ViewModel.CurrentInlineBot;
+            if (inlineBot == null)
+            {
+                if (apply)
+                {
+                    ClearInlineBotResults();
+                }
+
+                return false;
+            }
+
             if (text.EndsWith('\r'))
             {
                 text = text.Substring(0, text.Length - 1);
@@ -1086,8 +1099,10 @@ namespace Telegram.Controls.Chats
                 text = text.Substring(1);
             }
 
-            var split = text.Split(' ');
-            if (split.Length >= 1 && ViewModel.CurrentInlineBot != null && ViewModel.CurrentInlineBot.HasActiveUsername(split[0], out string username))
+            var space = text.IndexOf(' ');
+            var first = space < 0 ? text : text.Substring(0, space);
+
+            if (inlineBot.HasActiveUsername(first, out string username))
             {
                 searchText = ReplaceFirst(text.TrimStart(), username, string.Empty);
                 if (searchText.StartsWith(" "))

--- a/Telegram/Controls/CountryBox.xaml
+++ b/Telegram/Controls/CountryBox.xaml
@@ -51,6 +51,8 @@
         <AutoSuggestBox.TextBoxStyle>
             <Style TargetType="TextBox"
                    BasedOn="{StaticResource AutoSuggestBoxTextBoxStyle}">
+                <Setter Property="FontFamily"
+                        Value="{ThemeResource EmojiTextThemeFontFamily}" />
                 <Setter Property="Padding"
                         Value="38,5,6,6" />
             </Style>

--- a/Telegram/Controls/FormattedTextBox.cs
+++ b/Telegram/Controls/FormattedTextBox.cs
@@ -11,7 +11,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using Telegram.Common;
 using Telegram.Controls.Media;
 using Telegram.Controls.Messages;
@@ -304,23 +303,44 @@ namespace Telegram.Controls
 
         private void OnCharacterReceived(CoreWindow sender, CharacterReceivedEventArgs args)
         {
-            if (FocusState == FocusState.Unfocused || !IsReplaceEmojiEnabled || string.Equals(Document.Selection.CharacterFormat.Name, "Consolas", StringComparison.OrdinalIgnoreCase))
+            if (FocusState == FocusState.Unfocused || !IsReplaceEmojiEnabled)
             {
                 return;
             }
 
-            var character = Encoding.UTF32.GetString(BitConverter.GetBytes(args.KeyCode));
+            // Emoticons are keyed by their last character, and the vast majority of keystrokes
+            // aren't one, so this runs before anything that costs an allocation or a text host call.
+            var character = args.KeyCode < 0x10000
+                ? (char)args.KeyCode
+                : (char)((args.KeyCode - 0x10000) / 0x400 + 0xD800);
 
             //var matches = Emoticon.Data.Keys.Where(x => x.EndsWith(character)).ToArray();
-            if (Emoticon.Matches.TryGetValue(character[0], out string[] matches))
+            if (Emoticon.Matches.TryGetValue(character, out string[] matches)
+                && !string.Equals(Document.Selection.CharacterFormat.Name, "Consolas", StringComparison.OrdinalIgnoreCase))
             {
-                var length = matches.Max(x => x.Length);
+                var length = 0;
+
+                foreach (var match in matches)
+                {
+                    length = Math.Max(length, match.Length);
+                }
+
                 var start = Math.Max(Document.Selection.EndPosition - length, 0);
 
                 var range = Document.GetRange(start, Document.Selection.EndPosition);
                 range.GetText(TextGetOptions.NoHidden, out string value);
 
-                var emoticon = matches.FirstOrDefault(x => value.EndsWith(x));
+                var emoticon = default(string);
+
+                foreach (var match in matches)
+                {
+                    if (value.EndsWith(match, StringComparison.Ordinal))
+                    {
+                        emoticon = match;
+                        break;
+                    }
+                }
+
                 if (emoticon != null)
                 {
                     BeginUndoGroup();

--- a/Telegram/Controls/FormattedTextBox.cs
+++ b/Telegram/Controls/FormattedTextBox.cs
@@ -1146,24 +1146,82 @@ namespace Telegram.Controls
                     var start = Document.Selection.StartPosition;
                     var length = Math.Abs(Document.Selection.Length);
 
-                    if (length > 0 && text.IsValidUrl())
+                    // A URL pasted over a selection labels it instead of replacing it
+                    if (length > 0 && text.IsValidUrl() && TryLinkSelection(text))
                     {
-                        Document.Selection.GetText(TextGetOptions.NoHidden, out string value);
-                        SetText(value, new[] { new TextEntity(0, value.Length, new TextEntityTypeTextUrl(text)) }, true);
+                        return;
                     }
-                    else
-                    {
-                        if (IsLongerThanMaxLength(text.Length, out int exceeding))
-                        {
-                            text = text.Substring(0, exceeding);
-                        }
 
+                    if (IsLongerThanMaxLength(text.Length, out int exceeding))
+                    {
+                        text = text.Substring(0, exceeding);
+                    }
+
+                    // Both calls below lay the document out, and moving the caret scrolls it
+                    // into view, so a large paste is worth one pass rather than two.
+                    Document.BatchDisplayUpdates();
+
+                    try
+                    {
                         Document.Selection.SetText(TextSetOptions.Unhide, text);
                         Document.Selection.SetRange(start + text.Length, start + text.Length);
+                    }
+                    finally
+                    {
+                        Document.ApplyDisplayUpdates();
                     }
                 }
             }
             catch { }
+        }
+
+        private bool TryLinkSelection(string url)
+        {
+            if ((AllowedEntities & FormattedTextEntity.TextUrl) == 0)
+            {
+                return false;
+            }
+
+            var selection = Document.Selection;
+
+            // A link keeps its URL in a hidden run and so does a custom emoji, so anything hidden
+            // under the selection means it isn't the plain text this is meant to label.
+            if (selection.CharacterFormat.Hidden != FormatEffect.Off)
+            {
+                return false;
+            }
+
+            var clone = selection.GetClone();
+            clone.StartOf(TextRangeUnit.Link, true);
+
+            if (clone.Link.Length > 0)
+            {
+                return false;
+            }
+
+            selection.GetText(TextGetOptions.NoHidden, out string value);
+
+            // The selection is a URL itself: the user is replacing that link, not labelling it.
+            // Nothing marks it as one while composing, so this is the only way to tell.
+            if (value.IsValidUrl() || !IsSafe(value))
+            {
+                return false;
+            }
+
+            BeginUndoGroup();
+
+            selection.CharacterFormat = Document.GetDefaultCharacterFormat();
+            selection.Link = $"\"{url}\"";
+            selection.Collapse(false);
+
+            EndUndoGroup();
+
+            if (_undoGroup == 0 && !_updateLocked)
+            {
+                TextChangedForRealNoCap?.Invoke(this, EventArgs.Empty);
+            }
+
+            return true;
         }
 
         private void ContextDelete_Click()

--- a/Telegram/Controls/FormattedTextBox.cs
+++ b/Telegram/Controls/FormattedTextBox.cs
@@ -66,6 +66,9 @@ namespace Telegram.Controls
         private int _selectionIndex;
 
         private ITextRange _reusableRange;
+        private ITextRange _reusableProbe;
+
+        private List<EmojiPosition> _emojiPositions;
 
         public CustomEmojiCanvas CustomEmoji { get; set; }
         private Grid Blocks;
@@ -153,8 +156,16 @@ namespace Telegram.Controls
 
         private void OnTextChanged(object sender, RoutedEventArgs e)
         {
-            UpdateCustomEmoji();
-            UpdateBlocks();
+            // Both updates have to walk the document to find what they're looking for, which is
+            // O(runs) round trips into the text host on every single keystroke. TOM reports a
+            // property as undefined when it isn't uniform over the range, so reading it once over
+            // the whole document tells us whether there's anything to walk for at all.
+            var whole = GetReusableRange(0, TextConstants.MaxUnitCount);
+            var anyHidden = whole.CharacterFormat.Hidden != FormatEffect.Off;
+            var anyQuote = whole.ParagraphFormat.SpaceAfter != 0;
+
+            UpdateCustomEmoji(anyHidden);
+            UpdateBlocks(anyQuote);
 
             if (_updateLocked || !_isContentChanging)
             {
@@ -212,16 +223,7 @@ namespace Telegram.Controls
         // Experiment: change bottom padding depending on text position to allow wrapping around send and other buttons
         private void UpdatePadding()
         {
-            if (_reusableRange == null)
-            {
-                _reusableRange = Document.GetRange(TextConstants.MaxUnitCount, TextConstants.MaxUnitCount);
-            }
-            else
-            {
-                _reusableRange.SetRange(TextConstants.MaxUnitCount, TextConstants.MaxUnitCount);
-            }
-
-            var range = _reusableRange;
+            var range = GetReusableRange(TextConstants.MaxUnitCount, TextConstants.MaxUnitCount);
             range.GetRect(PointOptions.ClientCoordinates | PointOptions.AllowOffClient, out Rect rect, out _);
 
             double scaleFactor = 1.0;  // Assuming a 1.0 scale factor when no XamlRoot is available at the moment.
@@ -1203,20 +1205,12 @@ namespace Telegram.Controls
             }
             else
             {
-                if (_reusableRange == null)
-                {
-                    _reusableRange = Document.GetRange(0, 0);
-                }
-                else
-                {
-                    _reusableRange.SetRange(0, 0);
-                }
+                range = GetReusableRange(0, 0);
 
                 // We need to get one character less not to include the trailing \r
                 // otherwise default character format comparison will fail
-                _reusableRange.SetRange(0, _reusableRange.StoryLength - 1);
+                range.SetRange(0, range.StoryLength - 1);
 
-                range = _reusableRange;
                 storyLength = range.StoryLength - 1;
                 hidden = 0;
             }
@@ -1577,8 +1571,15 @@ namespace Telegram.Controls
                     var index = updateSelection ? Document.Selection.StartPosition : 0;
                     var affecting = default(List<TextEntity>);
 
-                    foreach (var entity in entities.Reverse())
+                    // Pasting a formatted message can bring in hundreds of entities, and every
+                    // ITextRange is a COM object, so a single one is moved over them instead.
+                    // It can't be the shared field, as the insertions below re-enter this class.
+                    var reusable = default(ITextRange);
+
+                    for (int i = entities.Count - 1; i >= 0; i--)
                     {
+                        var entity = entities[i];
+
                         if (entity.Type is TextEntityTypeDateTime or TextEntityTypeMentionName or TextEntityTypeTextUrl or TextEntityTypeCustomEmoji)
                         {
                             affecting ??= new();
@@ -1587,7 +1588,7 @@ namespace Telegram.Controls
                             continue;
                         }
 
-                        var range = Document.GetRange(index + entity.Offset, index + entity.Offset + entity.Length);
+                        var range = GetRange(ref reusable, index + entity.Offset, index + entity.Offset + entity.Length);
 
                         if (entity.Type is TextEntityTypeBlockQuote or TextEntityTypeExpandableBlockQuote && (allowedEntities & FormattedTextEntity.Quote) != 0)
                         {
@@ -1623,7 +1624,7 @@ namespace Telegram.Controls
                     {
                         foreach (var entity in affecting)
                         {
-                            var range = Document.GetRange(index + entity.Offset, index + entity.Offset + entity.Length);
+                            var range = GetRange(ref reusable, index + entity.Offset, index + entity.Offset + entity.Length);
 
                             if (entity.Type is TextEntityTypeTextUrl textUrl && (allowedEntities & FormattedTextEntity.TextUrl) != 0 && IsSafe(text, entity))
                             {
@@ -1891,65 +1892,82 @@ namespace Telegram.Controls
             }
         }
 
-        private void UpdateCustomEmoji()
+        // Every ITextRange is a COM object, so the ones used by the per-keystroke updates
+        // are kept around and moved rather than allocated again on each pass.
+        private ITextRange GetReusableRange(int startPosition, int endPosition)
+        {
+            return GetRange(ref _reusableRange, startPosition, endPosition);
+        }
+
+        private ITextRange GetReusableProbe(int startPosition, int endPosition)
+        {
+            return GetRange(ref _reusableProbe, startPosition, endPosition);
+        }
+
+        private ITextRange GetRange(ref ITextRange reusable, int startPosition, int endPosition)
+        {
+            if (reusable == null)
+            {
+                reusable = Document.GetRange(startPosition, endPosition);
+            }
+            else
+            {
+                reusable.SetRange(startPosition, endPosition);
+            }
+
+            return reusable;
+        }
+
+        private void UpdateCustomEmoji(bool anyHidden)
         {
             if (_updateLocked)
             {
                 return;
             }
 
-            if (_reusableRange == null)
+            _emojiPositions?.Clear();
+
+            // Custom emoji are stored as hidden text, so without any there's nothing to walk
+            if (anyHidden)
             {
-                _reusableRange = Document.GetRange(0, 0);
-            }
-            else
-            {
-                _reusableRange.SetRange(0, 0);
-            }
+                var range = GetReusableRange(0, 0);
+                var lastPosition = -1;
 
-            var range = _reusableRange;
-            var lastPosition = -1;
+                var firstCall = true;
 
-            var firstCall = true;
-
-            HashSet<long> emoji = null;
-            List<EmojiPosition> positions = null;
-
-            do
-            {
-                if (range.StartPosition == lastPosition || (range.EndOf(TextRangeUnit.Hidden, true) <= 0 && !firstCall))
+                do
                 {
-                    break;
-                }
-
-                lastPosition = range.StartPosition;
-                firstCall = false;
-
-                if (range.CharacterFormat.Hidden == FormatEffect.On && range.Link.Length == 0)
-                {
-                    var follow = Document.GetRange(range.EndPosition, range.EndPosition);
-                    if (follow.Character == '\uEA4F' && IsCustomEmoji(range, out _, out long customEmojiId))
+                    if (range.StartPosition == lastPosition || (range.EndOf(TextRangeUnit.Hidden, true) <= 0 && !firstCall))
                     {
-                        emoji ??= new();
-                        emoji.Add(customEmojiId);
-
-                        range.GetPoint(HorizontalCharacterAlignment.Left, VerticalCharacterAlignment.Baseline, PointOptions.ClientCoordinates | PointOptions.AllowOffClient, out Point point);
-
-                        positions ??= new();
-                        positions.Add(new EmojiPosition
-                        {
-                            CustomEmojiId = customEmojiId,
-                            X = (int)point.X + 2,
-                            Y = (int)point.Y - 10,
-                            FontSize = follow.CharacterFormat.Size
-                        });
+                        break;
                     }
-                }
-            } while (range.MoveStart(TextRangeUnit.Hidden, 1) > 0);
+
+                    lastPosition = range.StartPosition;
+                    firstCall = false;
+
+                    if (range.CharacterFormat.Hidden == FormatEffect.On && range.Link.Length == 0)
+                    {
+                        var follow = GetReusableProbe(range.EndPosition, range.EndPosition);
+                        if (follow.Character == '\uEA4F' && IsCustomEmoji(range, out _, out long customEmojiId))
+                        {
+                            range.GetPoint(HorizontalCharacterAlignment.Left, VerticalCharacterAlignment.Baseline, PointOptions.ClientCoordinates | PointOptions.AllowOffClient, out Point point);
+
+                            _emojiPositions ??= new();
+                            _emojiPositions.Add(new EmojiPosition
+                            {
+                                CustomEmojiId = customEmojiId,
+                                X = (int)point.X + 2,
+                                Y = (int)point.Y - 10,
+                                FontSize = follow.CharacterFormat.Size
+                            });
+                        }
+                    }
+                } while (range.MoveStart(TextRangeUnit.Hidden, 1) > 0);
+            }
 
             if (CustomEmoji != null && DataContext is ViewModelBase viewModel)
             {
-                CustomEmoji.UpdateEntities(viewModel.ClientService, positions);
+                CustomEmoji.UpdateEntities(viewModel.ClientService, _emojiPositions);
             }
         }
 
@@ -2012,16 +2030,18 @@ namespace Telegram.Controls
 
         private void UpdateFormat()
         {
-            if (_reusableRange == null)
+            var range = GetReusableRange(0, TextConstants.MaxUnitCount);
+
+            // CharacterFormat breaks at every space, so the walk below is O(words) per keystroke.
+            // A document without quotes and already at the regular size has nothing to fix, and an
+            // undefined value (mixed content) never matches, so this only ever skips a no-op walk.
+            if (range.ParagraphFormat.SpaceAfter == 0 && range.CharacterFormat.Size == 10.5f)
             {
-                _reusableRange = Document.GetRange(0, 0);
-            }
-            else
-            {
-                _reusableRange.SetRange(0, 0);
+                return;
             }
 
-            var range = _reusableRange;
+            range.SetRange(0, 0);
+
             var lastPosition = -1;
 
             do
@@ -2033,13 +2053,12 @@ namespace Telegram.Controls
 
                 lastPosition = range.StartPosition;
 
-                if (range.ParagraphFormat.SpaceAfter == 6 && range.CharacterFormat.Size != 9)
+                var format = range.CharacterFormat;
+                var size = range.ParagraphFormat.SpaceAfter == 6 ? 9 : 10.5f;
+
+                if (format.Size != size)
                 {
-                    range.CharacterFormat.Size = 9;
-                }
-                else if (range.ParagraphFormat.SpaceAfter != 6 && range.CharacterFormat.Size != 10.5f)
-                {
-                    range.CharacterFormat.Size = 10.5f;
+                    format.Size = size;
                 }
 
                 range.Collapse(false);
@@ -2049,57 +2068,51 @@ namespace Telegram.Controls
             //EndUndoGroup();
         }
 
-        private void UpdateBlocks()
+        private void UpdateBlocks(bool anyQuote)
         {
-            if (Blocks == null)
+            if (Blocks == null || (!anyQuote && Blocks.Children.Count == 0))
             {
                 return;
             }
 
-            if (_reusableRange == null)
-            {
-                _reusableRange = Document.GetRange(0, 0);
-            }
-            else
-            {
-                _reusableRange.SetRange(0, 0);
-            }
-
-            var range = _reusableRange;
-            var lastPosition = -1;
-
             var rects = 0;
 
-            do
+            if (anyQuote)
             {
-                if (lastPosition == range.StartPosition || range.MoveEnd(TextRangeUnit.HardParagraph, 1) <= 0)
+                var range = GetReusableRange(0, 0);
+                var lastPosition = -1;
+
+                do
                 {
-                    break;
-                }
-
-                lastPosition = range.StartPosition;
-
-                if (range.ParagraphFormat.SpaceAfter != 0)
-                {
-                    range.GetRect(PointOptions.None, out Rect rect, out _);
-                    rects++;
-
-                    if (Blocks.Children.Count < rects)
+                    if (lastPosition == range.StartPosition || range.MoveEnd(TextRangeUnit.HardParagraph, 1) <= 0)
                     {
-                        Blocks.Children.Add(CreateBlock(rect));
+                        break;
                     }
-                    else if (Blocks.Children[rects - 1] is FrameworkElement block)
-                    {
-                        block.Margin = new Thickness(0, rect.Y + 2, 8, 0);
-                        block.Height = Math.Max(0, rect.Height - 6);
-                        block.Width = Math.Max(0, ActualWidth - _blockPadding);
-                    }
-                }
-            } while (range.MoveStart(TextRangeUnit.HardParagraph, 1) > 0);
 
-            for (int i = rects; i < Blocks.Children.Count; i++)
+                    lastPosition = range.StartPosition;
+
+                    if (range.ParagraphFormat.SpaceAfter != 0)
+                    {
+                        range.GetRect(PointOptions.None, out Rect rect, out _);
+                        rects++;
+
+                        if (Blocks.Children.Count < rects)
+                        {
+                            Blocks.Children.Add(CreateBlock(rect));
+                        }
+                        else if (Blocks.Children[rects - 1] is FrameworkElement block)
+                        {
+                            block.Margin = new Thickness(0, rect.Y + 2, 8, 0);
+                            block.Height = Math.Max(0, rect.Height - 6);
+                            block.Width = Math.Max(0, ActualWidth - _blockPadding);
+                        }
+                    }
+                } while (range.MoveStart(TextRangeUnit.HardParagraph, 1) > 0);
+            }
+
+            while (Blocks.Children.Count > rects)
             {
-                Blocks.Children.RemoveAt(i);
+                Blocks.Children.RemoveAt(Blocks.Children.Count - 1);
             }
         }
 

--- a/Telegram/Controls/Messages/CustomEmojiCanvas.cs
+++ b/Telegram/Controls/Messages/CustomEmojiCanvas.cs
@@ -47,23 +47,25 @@ namespace Telegram.Controls.Messages
                         Children.Add(player);
                     }
 
-                    if (positions[i].FontSize == 9) // 12 * 0.75
+                    var position = positions[i];
+                    var size = position.FontSize == 9 ? 16 : 20; // 12 * 0.75
+
+                    if (player.Width != size)
                     {
-                        player.Width = 16;
-                        player.Height = 16;
-                        player.FrameSize = new Size(16, 16);
-                    }
-                    else
-                    {
-                        player.Width = 20;
-                        player.Height = 20;
-                        player.FrameSize = new Size(20, 20);
+                        player.Width = size;
+                        player.Height = size;
+                        player.FrameSize = new Size(size, size);
                     }
 
-                    player.Source = new CustomEmojiFileSource(clientService, positions[i].CustomEmojiId);
+                    // This is called on every keystroke, and a new source means a new
+                    // getCustomEmojiStickers request and a reload of the animation.
+                    if (player.Source is not CustomEmojiFileSource source || source.Id != position.CustomEmojiId)
+                    {
+                        player.Source = new CustomEmojiFileSource(clientService, position.CustomEmojiId);
+                    }
 
-                    SetTop(player, positions[i].Y);
-                    SetLeft(player, positions[i].X);
+                    SetTop(player, position.Y);
+                    SetLeft(player, position.X);
                 }
             }
         }

--- a/Telegram/Entities/StorageAlbum.cs
+++ b/Telegram/Entities/StorageAlbum.cs
@@ -24,12 +24,27 @@ namespace Telegram.Entities
 
     public partial class StorageAlbum : StorageMedia
     {
-        public IList<StorageMedia> Media { get; }
+        public IList<StorageMedia> Media { get; private set; }
 
-        public StorageAlbum(IList<StorageMedia> media)
+        public StorageAlbum(int ordinal, IList<StorageMedia> media)
             : base(null, 0)
         {
+            Ordinal = ordinal;
             Media = media.ToList();
+        }
+
+        /// <summary>
+        /// Position among the albums of a view, and the album's identity while diffing: one that
+        /// gains a photo is the same album with new contents rather than a different album. Without
+        /// that, every arriving photo tears its album's container down and builds it again, which
+        /// costs a full remeasure and throws away the thumbnails the containers were holding.
+        /// </summary>
+        public int Ordinal { get; }
+
+        public void Update(IList<StorageMedia> media)
+        {
+            Media = media.ToList();
+            Invalidate();
         }
 
         public const double ITEM_MARGIN = 2;

--- a/Telegram/Entities/StorageMedia.cs
+++ b/Telegram/Entities/StorageMedia.cs
@@ -14,8 +14,6 @@ using Telegram.Navigation;
 using Telegram.Td.Api;
 using Windows.Storage;
 using Windows.Storage.FileProperties;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Media.Imaging;
 
 namespace Telegram.Entities
 {
@@ -40,20 +38,6 @@ namespace Telegram.Entities
         public StorageFile File { get; private set; }
 
         public ulong Size { get; }
-
-        protected ImageSource _preview;
-        public ImageSource Preview
-        {
-            get
-            {
-                if (_preview == null)
-                {
-                    Refresh();
-                }
-
-                return _preview;
-            }
-        }
 
         protected MessageSelfDestructType _ttl;
         public MessageSelfDestructType Ttl
@@ -121,57 +105,6 @@ namespace Telegram.Entities
         }
 
         public bool IsEdited => !_editState?.IsEmpty ?? false;
-
-        public virtual async void Refresh()
-        {
-            if (_editState is ImageGeneration editState && !editState.IsEmpty)
-            {
-                try
-                {
-                    // TODO: actual logical pixel size
-                    _preview = await ImageHelper.CropAndPreviewAsync(this, editState, 600);
-                }
-                catch
-                {
-                    await RefreshAsync();
-                }
-            }
-            else
-            {
-                await RefreshAsync();
-            }
-
-            RaisePropertyChanged(nameof(Preview));
-        }
-
-        private async Task RefreshAsync()
-        {
-            try
-            {
-                if (this is StorageVideo)
-                {
-                    // TODO: actual logical pixel size
-                    _preview = await ImageHelper.GetPreviewBitmapAsync(this, 600);
-                }
-                else
-                {
-                    var preview = new BitmapImage
-                    {
-                        DecodePixelWidth = 300,
-                        DecodePixelType = DecodePixelType.Logical
-                    };
-
-                    using var stream = await File.OpenReadAsync();
-                    await preview.SetSourceAsync(stream);
-
-                    _preview = preview;
-                }
-            }
-            catch
-            {
-                _preview = new BitmapImage();
-            }
-        }
 
         public static async Task<StorageMedia> CreateAsync(StorageFile file, bool probe = true)
         {

--- a/Telegram/Entities/StorageMedia.cs
+++ b/Telegram/Entities/StorageMedia.cs
@@ -240,4 +240,63 @@ namespace Telegram.Entities
             await Task.WhenAll(probes);
         }
     }
+
+    /// <summary>
+    /// The content of a <c>SendFilesPopup</c>, which may not all exist yet.
+    ///
+    /// Callers either hand over items they have already typed, or the files behind them; the popup
+    /// takes one of these either way, so it cannot be handed a half-built set or be asked to start
+    /// loading as a separate step.
+    /// </summary>
+    public sealed partial class StorageMediaSource
+    {
+        private readonly IReadOnlyList<StorageFile> _files;
+
+        private StorageMediaSource(IReadOnlyList<StorageMedia> ready, IReadOnlyList<StorageFile> files)
+        {
+            Ready = ready;
+            _files = files;
+        }
+
+        public static StorageMediaSource FromMedia(IReadOnlyList<StorageMedia> items)
+        {
+            return new StorageMediaSource(items, null);
+        }
+
+        public static StorageMediaSource FromFiles(IReadOnlyList<StorageFile> files)
+        {
+            return new StorageMediaSource(Array.Empty<StorageMedia>(), files);
+        }
+
+        /// <summary>
+        /// Everything that exists before the popup is shown, so it can be seeded rather than filled
+        /// in. Empty when the files still have to be typed.
+        /// </summary>
+        public IReadOnlyList<StorageMedia> Ready { get; }
+
+        /// <summary>
+        /// How many items will arrive in total, known up front either way — the title can state the
+        /// size of a drop before any of it has been typed.
+        /// </summary>
+        public int Count => _files?.Count ?? Ready.Count;
+
+        /// <summary>
+        /// True when <see cref="Ready"/> is all there is, and <see cref="LoadAsync"/> has nothing
+        /// left to deliver.
+        /// </summary>
+        public bool IsComplete => _files == null;
+
+        /// <summary>
+        /// Delivers whatever <see cref="Ready"/> did not, reporting each item as it lands.
+        /// </summary>
+        public Task LoadAsync(Action<int, StorageMedia> resolved, CancellationToken cancellationToken)
+        {
+            if (_files == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            return StorageMedia.ProbeAsync(_files, resolved, cancellationToken);
+        }
+    }
 }

--- a/Telegram/Entities/StorageMedia.cs
+++ b/Telegram/Entities/StorageMedia.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Telegram.Common;
 using Telegram.Navigation;
@@ -160,9 +161,9 @@ namespace Telegram.Entities
         {
             var results = new List<StorageMedia>();
 
-            try
+            foreach (StorageFile file in items.OfType<StorageFile>())
             {
-                foreach (StorageFile file in items.OfType<StorageFile>())
+                try
                 {
                     var media = await CreateAsync(file);
                     if (media != null)
@@ -170,13 +171,73 @@ namespace Telegram.Entities
                         results.Add(media);
                     }
                 }
-            }
-            catch
-            {
-                // All the remote procedure calls must be wrapped in a try-catch block
+                catch
+                {
+                    // All the remote procedure calls must be wrapped in a try-catch block, and
+                    // per-file: one unreadable item used to discard every file after it.
+                }
             }
 
             return results;
+        }
+
+        /// <summary>
+        /// Probes files concurrently, reporting each one through <paramref name="resolved"/> as it
+        /// lands so the caller can show a popup before anything has been typed. Results arrive out
+        /// of order — <c>index</c> is the file's position in <paramref name="files"/>.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="resolved"/> is invoked on the calling thread's context.
+        /// </remarks>
+        public static async Task ProbeAsync(IReadOnlyList<StorageFile> files, Action<int, StorageMedia> resolved, CancellationToken cancellationToken)
+        {
+            // A probe is a file open plus a header decode, or a whole ffmpeg open for video and
+            // audio. Running them one after another is what used to stall a large drop; the cap
+            // keeps that same drop from opening hundreds of decoders at once.
+            using var throttle = new SemaphoreSlim(Math.Clamp(Environment.ProcessorCount, 2, 8));
+
+            async Task ProbeOneAsync(int index)
+            {
+                try
+                {
+                    await throttle.WaitAsync(cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+
+                try
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    var media = await CreateAsync(files[index]);
+                    if (media != null && !cancellationToken.IsCancellationRequested)
+                    {
+                        resolved(index, media);
+                    }
+                }
+                catch
+                {
+                    // One unreadable file must not take the rest of the drop with it.
+                }
+                finally
+                {
+                    throttle.Release();
+                }
+            }
+
+            var probes = new Task[files.Count];
+
+            for (int i = 0; i < files.Count; i++)
+            {
+                probes[i] = ProbeOneAsync(i);
+            }
+
+            await Task.WhenAll(probes);
         }
     }
 }

--- a/Telegram/Entities/StorageVideo.cs
+++ b/Telegram/Entities/StorageVideo.cs
@@ -86,12 +86,6 @@ namespace Telegram.Entities
             }
         }
 
-        public override void Refresh()
-        {
-            base.Refresh();
-            LoadPreview();
-        }
-
         public int TotalSeconds { get; }
 
         public string Duration

--- a/Telegram/Services/Calls/VoipGroupCall.cs
+++ b/Telegram/Services/Calls/VoipGroupCall.cs
@@ -51,6 +51,13 @@ namespace Telegram.Services.Calls
 
         private GroupCallParticipant _currentUser;
 
+        // Guards _manager and _screenManager against Dispose. Both are reached from more
+        // than one thread — the UI thread calls in while Update, and so Dispose, arrives
+        // on TDLib's update thread — and stopping a manager frees the tgcalls instance
+        // that another thread may be part way through calling into.
+        //
+        // Held only around calls that reach that instance. The IsMuted and
+        // IsNoiseSuppressionEnabled getters read a native field and are safe without it.
         private readonly object _managerLock = new();
 
         private VoipGroupManager _manager;
@@ -142,13 +149,16 @@ namespace Telegram.Services.Calls
                 IsNoiseSuppressionEnabled = Settings.VoIP.IsNoiseSuppressionEnabled
             };
 
-            _manager = new VoipGroupManager(descriptor);
-            _manager.NetworkStateUpdated += OnNetworkStateUpdated;
-            _manager.AudioLevelsUpdated += OnAudioLevelsUpdated;
-            _manager.BroadcastTimeRequested += OnBroadcastTimeRequested;
-            _manager.AudioBroadcastPartRequested += OnAudioBroadcastPartRequested;
-            _manager.VideoBroadcastPartRequested += OnVideoBroadcastPartRequested;
-            _manager.MediaChannelDescriptionsRequested += OnMediaChannelDescriptionsRequested;
+            lock (_managerLock)
+            {
+                _manager = new VoipGroupManager(descriptor);
+                _manager.NetworkStateUpdated += OnNetworkStateUpdated;
+                _manager.AudioLevelsUpdated += OnAudioLevelsUpdated;
+                _manager.BroadcastTimeRequested += OnBroadcastTimeRequested;
+                _manager.AudioBroadcastPartRequested += OnAudioBroadcastPartRequested;
+                _manager.VideoBroadcastPartRequested += OnVideoBroadcastPartRequested;
+                _manager.MediaChannelDescriptionsRequested += OnMediaChannelDescriptionsRequested;
+            }
 
             if (_isLiveStory)
             {
@@ -287,14 +297,17 @@ namespace Telegram.Services.Calls
                 IsNoiseSuppressionEnabled = Settings.VoIP.IsNoiseSuppressionEnabled
             };
 
-            _manager = new VoipGroupManager(descriptor);
-            _manager.NetworkStateUpdated += OnNetworkStateUpdated;
-            _manager.AudioLevelsUpdated += OnAudioLevelsUpdated;
-            _manager.BroadcastTimeRequested += OnBroadcastTimeRequested;
-            _manager.AudioBroadcastPartRequested += OnAudioBroadcastPartRequested;
-            _manager.VideoBroadcastPartRequested += OnVideoBroadcastPartRequested;
-            _manager.MediaChannelDescriptionsRequested += OnMediaChannelDescriptionsRequested;
-            _manager.SetEncryptDecrypt(EncryptData, DecryptData);
+            lock (_managerLock)
+            {
+                _manager = new VoipGroupManager(descriptor);
+                _manager.NetworkStateUpdated += OnNetworkStateUpdated;
+                _manager.AudioLevelsUpdated += OnAudioLevelsUpdated;
+                _manager.BroadcastTimeRequested += OnBroadcastTimeRequested;
+                _manager.AudioBroadcastPartRequested += OnAudioBroadcastPartRequested;
+                _manager.VideoBroadcastPartRequested += OnVideoBroadcastPartRequested;
+                _manager.MediaChannelDescriptionsRequested += OnMediaChannelDescriptionsRequested;
+                _manager.SetEncryptDecrypt(EncryptData, DecryptData);
+            }
 
             _ = JoinConferenceAsync();
         }
@@ -342,14 +355,17 @@ namespace Telegram.Services.Calls
                 IsNoiseSuppressionEnabled = Settings.VoIP.IsNoiseSuppressionEnabled
             };
 
-            _manager = new VoipGroupManager(descriptor);
-            _manager.NetworkStateUpdated += OnNetworkStateUpdated;
-            _manager.AudioLevelsUpdated += OnAudioLevelsUpdated;
-            _manager.BroadcastTimeRequested += OnBroadcastTimeRequested;
-            _manager.AudioBroadcastPartRequested += OnAudioBroadcastPartRequested;
-            _manager.VideoBroadcastPartRequested += OnVideoBroadcastPartRequested;
-            _manager.MediaChannelDescriptionsRequested += OnMediaChannelDescriptionsRequested;
-            _manager.SetEncryptDecrypt(EncryptData, DecryptData);
+            lock (_managerLock)
+            {
+                _manager = new VoipGroupManager(descriptor);
+                _manager.NetworkStateUpdated += OnNetworkStateUpdated;
+                _manager.AudioLevelsUpdated += OnAudioLevelsUpdated;
+                _manager.BroadcastTimeRequested += OnBroadcastTimeRequested;
+                _manager.AudioBroadcastPartRequested += OnAudioBroadcastPartRequested;
+                _manager.VideoBroadcastPartRequested += OnVideoBroadcastPartRequested;
+                _manager.MediaChannelDescriptionsRequested += OnMediaChannelDescriptionsRequested;
+                _manager.SetEncryptDecrypt(EncryptData, DecryptData);
+            }
 
             _ = JoinConferenceAsync();
         }
@@ -570,85 +586,94 @@ namespace Telegram.Services.Calls
         {
             _alias = alias;
 
-            _manager?.SetConnectionMode(VoipGroupConnectionMode.None, false, IsRtmpStream);
-            _manager?.EmitJoinPayload(async (ssrc, payload) =>
+            lock (_managerLock)
             {
-                if (_manager == null)
+                _manager?.SetConnectionMode(VoipGroupConnectionMode.None, false, IsRtmpStream);
+                _manager?.EmitJoinPayload(async (ssrc, payload) =>
                 {
-                    return;
-                }
-
-                if (IsRtmpStream)
-                {
-                    Participants = null;
-                }
-                else
-                {
-                    Participants ??= new GroupCallParticipantsCollection(this);
-                }
-
-                if (_inputGroupCallTask != null)
-                {
-                    await _inputGroupCallTask.Task;
-                }
-
-                var joinParameters = new GroupCallJoinParameters(ssrc, payload, _manager.IsMuted, _capturer != null);
-                Function request = _inputGroupCall != null
-                    ? new JoinGroupCall(_inputGroupCall, joinParameters)
-                    : _inviteUserIds != null
-                    ? new CreateGroupCall(joinParameters)
-                    : _isLiveStory
-                    ? new JoinLiveStory(Id, joinParameters)
-                    : new JoinVideoChat(Id, alias, joinParameters, _inviteHash);
-
-                var response = await ClientService.SendAsync(request);
-                if (response is GroupCallInfo info)
-                {
-                    Id = info.GroupCallId;
-                    response = new Text(info.JoinPayload);
-
-                    if (ClientService.TryGetGroupCall(info.GroupCallId, out GroupCall groupCall))
+                    if (_manager == null)
                     {
-                        _inputGroupCall ??= new InputGroupCallLink(groupCall.InviteLink);
-                        _inputGroupCallTask.TrySetResult(_inputGroupCall);
-                        Update(groupCall, out _);
+                        return;
                     }
 
-                    if (_inviteUserIds != null)
+                    if (IsRtmpStream)
                     {
-                        foreach (var userId in _inviteUserIds)
-                        {
-                            ClientService.Send(new InviteGroupCallParticipant(info.GroupCallId, userId, false));
-                        }
-
-                        _inviteUserIds = null;
-                    }
-                }
-
-                if (response is Text json && _manager != null)
-                {
-                    bool broadcast;
-                    if (JsonObject.TryParse(json.TextValue, out JsonObject data))
-                    {
-                        broadcast = data.GetNamedBoolean("stream", false);
+                        Participants = null;
                     }
                     else
                     {
-                        broadcast = false;
+                        Participants ??= new GroupCallParticipantsCollection(this);
                     }
 
-                    _source = ssrc;
-                    _manager.SetConnectionMode(broadcast ? VoipGroupConnectionMode.Broadcast : VoipGroupConnectionMode.Rtc, true, IsRtmpStream);
-                    _manager.SetJoinResponsePayload(json.TextValue);
+                    if (_inputGroupCallTask != null)
+                    {
+                        await _inputGroupCallTask.Task;
+                    }
 
-                    RejoinScreenSharing();
-                }
+                    var joinParameters = new GroupCallJoinParameters(ssrc, payload, _manager.IsMuted, _capturer != null);
+                    Function request = _inputGroupCall != null
+                        ? new JoinGroupCall(_inputGroupCall, joinParameters)
+                        : _inviteUserIds != null
+                        ? new CreateGroupCall(joinParameters)
+                        : _isLiveStory
+                        ? new JoinLiveStory(Id, joinParameters)
+                        : new JoinVideoChat(Id, alias, joinParameters, _inviteHash);
 
-                if (IsLiveStory && !IsRtmpStream)
-                {
-                    InitializeStreamer();
-                }
-            });
+                    var response = await ClientService.SendAsync(request);
+                    if (response is GroupCallInfo info)
+                    {
+                        Id = info.GroupCallId;
+                        response = new Text(info.JoinPayload);
+
+                        if (ClientService.TryGetGroupCall(info.GroupCallId, out GroupCall groupCall))
+                        {
+                            _inputGroupCall ??= new InputGroupCallLink(groupCall.InviteLink);
+                            _inputGroupCallTask.TrySetResult(_inputGroupCall);
+                            Update(groupCall, out _);
+                        }
+
+                        if (_inviteUserIds != null)
+                        {
+                            foreach (var userId in _inviteUserIds)
+                            {
+                                ClientService.Send(new InviteGroupCallParticipant(info.GroupCallId, userId, false));
+                            }
+
+                            _inviteUserIds = null;
+                        }
+                    }
+
+                    if (response is Text json && _manager != null)
+                    {
+                        bool broadcast;
+                        if (JsonObject.TryParse(json.TextValue, out JsonObject data))
+                        {
+                            broadcast = data.GetNamedBoolean("stream", false);
+                        }
+                        else
+                        {
+                            broadcast = false;
+                        }
+
+                        _source = ssrc;
+
+                        // Taken again here: this runs after the awaits above, long after
+                        // the lock around EmitJoinPayload was released.
+                        lock (_managerLock)
+                        {
+                            _manager?.SetConnectionMode(broadcast ? VoipGroupConnectionMode.Broadcast : VoipGroupConnectionMode.Rtc, true, IsRtmpStream);
+                            _manager?.SetJoinResponsePayload(json.TextValue);
+                        }
+
+                        RejoinScreenSharing();
+                    }
+
+                    if (IsLiveStory && !IsRtmpStream)
+                    {
+                        InitializeStreamer();
+                    }
+                });
+            }
         }
 
         private async void InitializeStreamer()
@@ -694,23 +719,26 @@ namespace Telegram.Services.Calls
 
         public void ToggleCapturing()
         {
-            if (_manager == null)
+            lock (_managerLock)
             {
-                return;
-            }
+                if (_manager == null)
+                {
+                    return;
+                }
 
-            if (_capturer != null)
-            {
-                _capturer.SetOutput(null);
-                _manager.SetVideoCapture(null);
+                if (_capturer != null)
+                {
+                    _capturer.SetOutput(null);
+                    _manager.SetVideoCapture(null);
 
-                _capturer.Stop();
-                _capturer = null;
-            }
-            else
-            {
-                _capturer = new VoipVideoCapture(_videoInputId);
-                _manager.SetVideoCapture(_capturer);
+                    _capturer.Stop();
+                    _capturer = null;
+                }
+                else
+                {
+                    _capturer = new VoipVideoCapture(_videoInputId);
+                    _manager.SetVideoCapture(_capturer);
+                }
             }
 
             ClientService.Send(new ToggleGroupCallIsMyVideoEnabled(Id, _capturer != null));
@@ -753,8 +781,11 @@ namespace Telegram.Services.Calls
                 AudioProcessId = item.ProcessId
             };
 
-            _screenManager = new VoipGroupManager(descriptor);
-            _screenManager.SetEncryptDecrypt(EncryptData, DecryptData);
+            lock (_managerLock)
+            {
+                _screenManager = new VoipGroupManager(descriptor);
+                _screenManager.SetEncryptDecrypt(EncryptData, DecryptData);
+            }
 
             RejoinScreenSharing();
         }
@@ -771,38 +802,49 @@ namespace Telegram.Services.Calls
 
         private void RejoinScreenSharing()
         {
-            _screenManager?.SetConnectionMode(VoipGroupConnectionMode.None, false, IsRtmpStream);
-            _screenManager?.EmitJoinPayload(async (ssrc, payload) =>
+            lock (_managerLock)
             {
-                var response = await ClientService.SendAsync(new StartGroupCallScreenSharing(Id, ssrc, payload));
-                if (response is Text json)
+                _screenManager?.SetConnectionMode(VoipGroupConnectionMode.None, false, IsRtmpStream);
+                _screenManager?.EmitJoinPayload(async (ssrc, payload) =>
                 {
-                    if (_screenManager == null)
+                    var response = await ClientService.SendAsync(new StartGroupCallScreenSharing(Id, ssrc, payload));
+                    if (response is Text json)
                     {
-                        return;
-                    }
+                        // See Rejoin: the lock around EmitJoinPayload is long gone by the
+                        // time this continuation runs.
+                        lock (_managerLock)
+                        {
+                            if (_screenManager == null)
+                            {
+                                return;
+                            }
 
-                    _screenSource = ssrc;
-                    _screenManager.SetConnectionMode(VoipGroupConnectionMode.Rtc, true, IsRtmpStream);
-                    _screenManager.SetJoinResponsePayload(json.TextValue);
-                }
-            });
+                            _screenSource = ssrc;
+                            _screenManager.SetConnectionMode(VoipGroupConnectionMode.Rtc, true, IsRtmpStream);
+                            _screenManager.SetJoinResponsePayload(json.TextValue);
+                        }
+                    }
+                });
+            }
         }
 
         public void EndScreenSharing()
         {
-            if (_screenManager != null)
+            lock (_managerLock)
             {
-                _screenManager.SetVideoCapture(null);
-                _screenManager.Stop();
+                if (_screenManager != null)
+                {
+                    _screenManager.SetVideoCapture(null);
+                    _screenManager.Stop();
 
-                // Clearing the delegates breaks the native to managed cycle that would
-                // otherwise leak the call, but it has to happen after Stop: until the
-                // instance is gone tgcalls can still ask us to transform a frame.
-                _screenManager.SetEncryptDecrypt(null, null);
-                _screenManager = null;
+                    // Clearing the delegates breaks the native to managed cycle that would
+                    // otherwise leak the call, but it has to happen after Stop: until the
+                    // instance is gone tgcalls can still ask us to transform a frame.
+                    _screenManager.SetEncryptDecrypt(null, null);
+                    _screenManager = null;
 
-                _screenSource = 0;
+                    _screenSource = 0;
+                }
             }
 
             if (_screenCapturer != null)
@@ -825,17 +867,26 @@ namespace Telegram.Services.Calls
 
         public void SetRequestedVideoChannels(IList<VoipVideoChannelInfo> descriptions)
         {
-            _manager?.SetRequestedVideoChannels(descriptions);
+            lock (_managerLock)
+            {
+                _manager?.SetRequestedVideoChannels(descriptions);
+            }
         }
 
         public void AddIncomingVideoOutput(string endpointId, VoipVideoOutputSink sink)
         {
-            _manager?.AddIncomingVideoOutput(endpointId, sink);
+            lock (_managerLock)
+            {
+                _manager?.AddIncomingVideoOutput(endpointId, sink);
+            }
         }
 
         public void AddScreenSharingVideoOutput(string endpointId, VoipVideoOutputSink sink)
         {
-            _screenManager?.AddIncomingVideoOutput(endpointId, sink);
+            lock (_managerLock)
+            {
+                _screenManager?.AddIncomingVideoOutput(endpointId, sink);
+            }
         }
 
         private async void OnBroadcastTimeRequested(VoipGroupManager sender, BroadcastTimeRequestedEventArgs args)
@@ -1120,31 +1171,36 @@ namespace Telegram.Services.Calls
             _devices.Changed -= OnDeviceChanged;
             _devices.Stop();
 
-            if (_manager != null)
+            // This runs on TDLib's update thread, not the UI thread, which is the whole
+            // reason the lock exists: the UI thread calls into the manager meanwhile.
+            lock (_managerLock)
             {
-                _manager.NetworkStateUpdated -= OnNetworkStateUpdated;
-                _manager.AudioLevelsUpdated -= OnAudioLevelsUpdated;
-                _manager.BroadcastTimeRequested -= OnBroadcastTimeRequested;
-                _manager.AudioBroadcastPartRequested -= OnAudioBroadcastPartRequested;
-                _manager.VideoBroadcastPartRequested -= OnVideoBroadcastPartRequested;
-                _manager.MediaChannelDescriptionsRequested -= OnMediaChannelDescriptionsRequested;
+                if (_manager != null)
+                {
+                    _manager.NetworkStateUpdated -= OnNetworkStateUpdated;
+                    _manager.AudioLevelsUpdated -= OnAudioLevelsUpdated;
+                    _manager.BroadcastTimeRequested -= OnBroadcastTimeRequested;
+                    _manager.AudioBroadcastPartRequested -= OnAudioBroadcastPartRequested;
+                    _manager.VideoBroadcastPartRequested -= OnVideoBroadcastPartRequested;
+                    _manager.MediaChannelDescriptionsRequested -= OnMediaChannelDescriptionsRequested;
 
-                _manager.SetVideoCapture(null);
-                _manager.Stop();
+                    _manager.SetVideoCapture(null);
+                    _manager.Stop();
 
-                // See EndScreenSharing: the delegates have to outlive the instance.
-                _manager.SetEncryptDecrypt(null, null);
-                _manager = null;
+                    // See EndScreenSharing: the delegates have to outlive the instance.
+                    _manager.SetEncryptDecrypt(null, null);
+                    _manager = null;
 
-                _source = 0;
-            }
+                    _source = 0;
+                }
 
-            if (_capturer != null)
-            {
-                _capturer.SetOutput(null);
+                if (_capturer != null)
+                {
+                    _capturer.SetOutput(null);
 
-                _capturer.Stop();
-                _capturer = null;
+                    _capturer.Stop();
+                    _capturer = null;
+                }
             }
 
             EndScreenSharing();
@@ -1201,7 +1257,11 @@ namespace Telegram.Services.Calls
             set
             {
                 _devices.Track(MediaDeviceClass.AudioInput, value);
-                _manager?.SetAudioInputDevice(_audioInputId = value);
+
+                lock (_managerLock)
+                {
+                    _manager?.SetAudioInputDevice(_audioInputId = value);
+                }
             }
         }
 
@@ -1212,23 +1272,30 @@ namespace Telegram.Services.Calls
             set
             {
                 _devices.Track(MediaDeviceClass.AudioOutput, value);
-                _manager?.SetAudioOutputDevice(_audioOutputId = value);
+
+                lock (_managerLock)
+                {
+                    _manager?.SetAudioOutputDevice(_audioOutputId = value);
+                }
             }
         }
 
         private void OnDeviceChanged(object sender, MediaDeviceChangedEventArgs e)
         {
-            switch (e.DeviceClass)
+            lock (_managerLock)
             {
-                case MediaDeviceClass.VideoInput:
-                    _capturer?.SwitchToDevice(_videoInputId = e.DeviceId);
-                    break;
-                case MediaDeviceClass.AudioInput:
-                    _manager?.SetAudioInputDevice(_audioInputId = e.DeviceId);
-                    break;
-                case MediaDeviceClass.AudioOutput:
-                    _manager?.SetAudioOutputDevice(_audioOutputId = e.DeviceId);
-                    break;
+                switch (e.DeviceClass)
+                {
+                    case MediaDeviceClass.VideoInput:
+                        _capturer?.SwitchToDevice(_videoInputId = e.DeviceId);
+                        break;
+                    case MediaDeviceClass.AudioInput:
+                        _manager?.SetAudioInputDevice(_audioInputId = e.DeviceId);
+                        break;
+                    case MediaDeviceClass.AudioOutput:
+                        _manager?.SetAudioOutputDevice(_audioOutputId = e.DeviceId);
+                        break;
+                }
             }
         }
 
@@ -1237,10 +1304,25 @@ namespace Telegram.Services.Calls
             get => _manager?.IsMuted ?? true;
             set
             {
-                if (_manager != null && _currentUser != null && _manager.IsMuted != value)
+                GroupCallParticipant currentUser;
+
+                lock (_managerLock)
                 {
-                    _manager.IsMuted = value;
-                    ClientService.Send(new ToggleGroupCallParticipantIsMuted(Id, _currentUser.ParticipantId, value));
+                    currentUser = _currentUser;
+
+                    if (_manager != null && currentUser != null && _manager.IsMuted != value)
+                    {
+                        _manager.IsMuted = value;
+                    }
+                    else
+                    {
+                        currentUser = null;
+                    }
+                }
+
+                if (currentUser != null)
+                {
+                    ClientService.Send(new ToggleGroupCallParticipantIsMuted(Id, currentUser.ParticipantId, value));
                     MutedChanged?.Invoke(this, EventArgs.Empty);
 
                     _coordinator?.TryNotifyMutedChanged(value);
@@ -1260,7 +1342,10 @@ namespace Telegram.Services.Calls
             get => _manager?.IsNoiseSuppressionEnabled ?? false;
             set
             {
-                _manager?.IsNoiseSuppressionEnabled = value;
+                lock (_managerLock)
+                {
+                    _manager?.IsNoiseSuppressionEnabled = value;
+                }
 
                 Settings.VoIP.IsNoiseSuppressionEnabled = value;
             }
@@ -1270,7 +1355,13 @@ namespace Telegram.Services.Calls
         public double VolumeLevel
         {
             get => _volumeLevel;
-            set => _manager?.SetVolume(1, _volumeLevel = value);
+            set
+            {
+                lock (_managerLock)
+                {
+                    _manager?.SetVolume(1, _volumeLevel = value);
+                }
+            }
         }
 
         public bool IsClosed => _isClosed;
@@ -1433,15 +1524,23 @@ namespace Telegram.Services.Calls
                 // User got muted by admins, update local state
                 if (participant.IsMutedForAllUsers && !participant.CanUnmuteSelf)
                 {
-                    _manager.IsMuted = true;
-
-                    if (_currentUser?.VideoInfo != null && participant.VideoInfo == null && _capturer != null)
+                    lock (_managerLock)
                     {
-                        _capturer.SetOutput(null);
-                        _manager.SetVideoCapture(null);
+                        // Was an unconditional dereference: this runs on TDLib's update
+                        // thread and Dispose can have cleared the field already.
+                        if (_manager != null)
+                        {
+                            _manager.IsMuted = true;
+                        }
 
-                        _capturer.Stop();
-                        _capturer = null;
+                        if (_currentUser?.VideoInfo != null && participant.VideoInfo == null && _capturer != null)
+                        {
+                            _capturer.SetOutput(null);
+                            _manager?.SetVideoCapture(null);
+
+                            _capturer.Stop();
+                            _capturer = null;
+                        }
                     }
 
                     if (_currentUser?.ScreenSharingVideoInfo != null && participant.ScreenSharingVideoInfo == null && _screenCapturer != null)
@@ -1458,21 +1557,21 @@ namespace Telegram.Services.Calls
                 RaisePropertyChanged(nameof(CurrentUser));
             }
 
-            var manager = _manager;
-            if (manager == null)
+            // Reading into a local kept this from throwing, but not from calling into an
+            // instance Dispose had already stopped.
+            lock (_managerLock)
             {
-                return;
-            }
+                if (_manager == null)
+                {
+                    return;
+                }
 
-            if (participant.IsMutedForCurrentUser)
-            {
-                manager.SetVolume(participant.AudioSourceId, 0);
-                manager.SetVolume(participant.ScreenSharingAudioSourceId, 0);
-            }
-            else
-            {
-                manager.SetVolume(participant.AudioSourceId, participant.VolumeLevel / 10000d);
-                manager.SetVolume(participant.ScreenSharingAudioSourceId, participant.VolumeLevel / 10000d);
+                var volume = participant.IsMutedForCurrentUser
+                    ? 0
+                    : participant.VolumeLevel / 10000d;
+
+                _manager.SetVolume(participant.AudioSourceId, volume);
+                _manager.SetVolume(participant.ScreenSharingAudioSourceId, volume);
             }
         }
 

--- a/Telegram/Services/ClientService.Files.cs
+++ b/Telegram/Services/ClientService.Files.cs
@@ -371,12 +371,15 @@ namespace Telegram.Services
 
         public void PrepareLogs(int fileId, int verbosityLevel)
         {
-            _preparedLogsFileIds ??= new();
-            _preparedLogsFileIds.Add(fileId);
-
-            if (_preparedLogsVerbosity == -1)
+            lock (_preparedLogsLock)
             {
-                _preparedLogsVerbosity = verbosityLevel;
+                _preparedLogsFileIds ??= new();
+                _preparedLogsFileIds.Add(fileId);
+
+                if (_preparedLogsVerbosity == -1)
+                {
+                    _preparedLogsVerbosity = verbosityLevel;
+                }
             }
         }
 

--- a/Telegram/Services/ClientService.cs
+++ b/Telegram/Services/ClientService.cs
@@ -3133,6 +3133,8 @@ namespace Telegram.Services
             reader.Read();
 
             var id = reader.GetInt32();
+            var created = false;
+
             if (_files.TryGetValue(id, out File obj))
             {
                 //if (!updateFile)
@@ -3149,6 +3151,8 @@ namespace Telegram.Services
             }
             else
             {
+                created = true;
+
                 obj = new File();
                 obj.Id = id;
                 obj.Local = new();
@@ -3165,7 +3169,18 @@ namespace Telegram.Services
                 reader.Read();
             }
 
-            if (obj.Local.IsDownloadingCompleted && !NativeUtils.FileExists(obj.Local.Path))
+            // Only the first time this id is seen. This runs on the TDLib thread, and every
+            // parsed object carries files — a chat history page is hundreds of them, nearly
+            // all already cached — so checking on every update spent a syscall each time to
+            // re-answer a question already answered.
+            //
+            // Nothing is really lost: TDLib sends no update when a file disappears behind its
+            // back, so the repeat check only ever caught an external delete by luck, when some
+            // unrelated update happened to arrive for that same file. The reliable detection
+            // is GetFileAsync catching FileNotFoundException at the point of use. What the
+            // first-sight check is genuinely for is the cache being cleared between sessions,
+            // which it still covers.
+            if (created && obj.Local.IsDownloadingCompleted && !NativeUtils.FileExists(obj.Local.Path))
             {
                 Send(new DeleteFile(obj.Id));
             }

--- a/Telegram/Services/ClientService.cs
+++ b/Telegram/Services/ClientService.cs
@@ -924,8 +924,15 @@ namespace Telegram.Services
             _cachedReactions.Clear();
 
             _chats.Clear();
-            _chatList.Clear();
-            _haveFullChatList.Clear();
+
+            // Clear() runs on the TDLib thread while the UI may have a list load in flight,
+            // so everything below takes the same lock its readers do. One after another and
+            // never nested, so no ordering is introduced.
+            lock (_chatList)
+            {
+                _chatList.Clear();
+                _haveFullChatList.Clear();
+            }
 
             _chatActions.Clear();
             _topicActions.Clear();
@@ -955,13 +962,25 @@ namespace Telegram.Services
             // _activeStories holds the story state itself; clearing only the ordering left
             // the previous account's stories reachable through GetActiveStories.
             _activeStories.Clear();
-            _storyList.Clear();
-            _haveFullStoryList.Clear();
 
-            _haveFullSavedMessages = false;
-            _savedMessages.Clear();
+            lock (_storyList)
+            {
+                _storyList.Clear();
+                _haveFullStoryList.Clear();
+            }
+
+            lock (_savedMessages)
+            {
+                _haveFullSavedMessages = false;
+                _savedMessages.Clear();
+            }
+
             _savedMessagesTopics.Clear();
-            _savedMessagesTags.Clear();
+
+            lock (_savedMessagesTags)
+            {
+                _savedMessagesTags.Clear();
+            }
 
             _settings.Notifications.Scope.Clear();
 
@@ -971,7 +990,10 @@ namespace Telegram.Services
 
             _groupCallMessageLevels = null;
 
-            _suggestedActions.Clear();
+            lock (_suggestedActions)
+            {
+                _suggestedActions.Clear();
+            }
 
             _savedAnimations = null;
             _recentStickers = null;
@@ -981,12 +1003,19 @@ namespace Telegram.Services
             _installedEmojiSets = null;
             _textCompositionStyles = null;
 
-            _chatFolders = Array.Empty<ChatFolderInfo>();
-            _chatFolders2.Clear();
+            lock (_chatFoldersLock)
+            {
+                _chatFolders = Array.Empty<ChatFolderInfo>();
+                _chatFolders2.Clear();
+            }
+
             _mainChatListPosition = 0;
             _areTagsEnabled = false;
 
-            _timezones.Clear();
+            lock (_timezones)
+            {
+                _timezones.Clear();
+            }
 
             _animationSearchParameters = null;
 

--- a/Telegram/Services/ClientService.cs
+++ b/Telegram/Services/ClientService.cs
@@ -350,6 +350,14 @@ namespace Telegram.Services
         private readonly List<long> _recentChats = new();
         private readonly object _recentChatsLock = new();
 
+        // A lock rather than a ReaderWriterDictionary, which is what the rest of the caches
+        // use, because neither of the two things that make that work applies here: this is a
+        // set, not a dictionary, and the field is assigned null — so the operation that
+        // matters is compound. UpdateFile removes an id and, only if that emptied the set,
+        // restores the verbosity and clears the field; PrepareLogs creates the set and adds
+        // to it. A per-call lock inside a collection cannot make either atomic, and without
+        // that, a PrepareLogs landing between its own ??= and its Add dereferences null.
+        private readonly object _preparedLogsLock = new();
         private HashSet<int> _preparedLogsFileIds;
         private int _preparedLogsVerbosity = -1;
 
@@ -378,7 +386,7 @@ namespace Telegram.Services
         private UpdateAvailableMessageEffects _availableMessageEffects;
 
         private IList<string> _activeReactions = Array.Empty<string>();
-        private Dictionary<string, EmojiReaction> _cachedReactions = new();
+        private readonly ReaderWriterDictionary<string, EmojiReaction> _cachedReactions = new();
 
         private IList<AttachmentMenuBot> _attachmentMenuBots = Array.Empty<AttachmentMenuBot>();
 
@@ -1065,8 +1073,11 @@ namespace Telegram.Services
 
             _chatAccessibleUntil.Clear();
 
-            _preparedLogsFileIds = null;
-            _preparedLogsVerbosity = -1;
+            lock (_preparedLogsLock)
+            {
+                _preparedLogsFileIds = null;
+                _preparedLogsVerbosity = -1;
+            }
 
             ClearDownloads();
 
@@ -1188,7 +1199,7 @@ namespace Telegram.Services
 
 
 
-        private readonly Dictionary<long, DateTime> _chatAccessibleUntil = new();
+        private readonly ReaderWriterDictionary<long, DateTime> _chatAccessibleUntil = new();
 
         public async Task<Object> CheckChatInviteLinkAsync(string inviteLink)
         {
@@ -3259,20 +3270,27 @@ namespace Telegram.Services
 
         private void UpdateFile(File file)
         {
-            if (_preparedLogsFileIds != null && _preparedLogsFileIds.Contains(file.Id))
+            var restoreVerbosity = int.MinValue;
+
+            lock (_preparedLogsLock)
             {
-                if (file.Remote.UploadedSize > 0)
+                if (_preparedLogsFileIds != null && _preparedLogsFileIds.Contains(file.Id) && file.Remote.UploadedSize > 0)
                 {
                     _preparedLogsFileIds.Remove(file.Id);
 
                     if (_preparedLogsFileIds.Empty())
                     {
-                        Client.Execute(new SetLogVerbosityLevel(_preparedLogsVerbosity));
+                        restoreVerbosity = _preparedLogsVerbosity;
 
                         _preparedLogsFileIds = null;
                         _preparedLogsVerbosity = -1;
                     }
                 }
+            }
+
+            if (restoreVerbosity != int.MinValue)
+            {
+                Client.Execute(new SetLogVerbosityLevel(restoreVerbosity));
             }
 
             // TODO: move the message after track when figured out why WeakAction throws a NRE

--- a/Telegram/Td/Api/TdExtensions.cs
+++ b/Telegram/Td/Api/TdExtensions.cs
@@ -1580,9 +1580,8 @@ namespace Telegram.Td.Api
                     return ToPlainText(underlineText.Text);
                 case RichTextUrl urlText:
                     return ToPlainText(urlText.Text);
-                case RichTextButton _:
-                    // TODO: decide if to extract text or not.
-                    return PageBlockHelper.PlaceholderButton;
+                case RichTextButton button:
+                    return ToPlainText(button.Button.Text);
                 default:
                     return null;
             }
@@ -2620,9 +2619,10 @@ namespace Telegram.Td.Api
                     }
                     return;
 
-                case RichTextButton _:
-                    // TODO: decide what to do here
-                    sb.Append(PageBlockHelper.PlaceholderButton);
+                // Unlike PageBlockHelper.Flatten there is no button entity to compete
+                // with here, so the label keeps whatever formatting it carries.
+                case RichTextButton button:
+                    Append(button.Button.Text, sb, entities);
                     return;
 
                 case RichTextAnchor _:

--- a/Telegram/Telegram.csproj
+++ b/Telegram/Telegram.csproj
@@ -226,6 +226,7 @@
     <Compile Include="Common\MediaDevicePermissions.cs" />
     <Compile Include="Common\NativeMethodChecker.cs" />
     <Compile Include="Common\PageBlockHelper.cs" />
+    <Compile Include="Common\Profiler.cs" />
     <Compile Include="Common\SliderHelper.cs" />
     <Compile Include="Common\StackCapture.cs" />
     <Compile Include="Common\TextSelectionCoordinator.cs" />

--- a/Telegram/Themes/Generic.xaml
+++ b/Telegram/Themes/Generic.xaml
@@ -110,7 +110,7 @@
         <Setter Property="BorderThickness"
                 Value="{ThemeResource TextControlBorderThemeThickness}" />
         <Setter Property="FontFamily"
-                Value="{ThemeResource ContentControlThemeFontFamily}" />
+                Value="{ThemeResource EmojiTextThemeFontFamily}" />
         <Setter Property="FontSize"
                 Value="{ThemeResource ControlContentThemeFontSize}" />
         <Setter Property="ScrollViewer.HorizontalScrollMode"

--- a/Telegram/ViewModels/ComposeViewModel.cs
+++ b/Telegram/ViewModels/ComposeViewModel.cs
@@ -590,12 +590,13 @@ namespace Telegram.ViewModels
             var view = new List<StorageMedia>();
             var album = new List<StorageMedia>();
             var albumType = StorageAlbumType.None;
+            var ordinal = 0;
 
             void AddAlbum()
             {
                 if (album.Count > 0)
                 {
-                    view.Add(new StorageAlbum(album));
+                    view.Add(new StorageAlbum(ordinal++, album));
                     album = new List<StorageMedia>();
                 }
             }

--- a/Telegram/ViewModels/ComposeViewModel.cs
+++ b/Telegram/ViewModels/ComposeViewModel.cs
@@ -422,48 +422,81 @@ namespace Telegram.ViewModels
             }
         }
 
-        public async void SendFileExecute(IReadOnlyList<StorageFile> files, FormattedText caption = null, bool media = true)
+        public void SendFileExecute(IReadOnlyList<StorageFile> files, FormattedText caption = null, bool media = true)
         {
-            var items = await StorageMedia.CreateAsync(files);
-            if (items.Count > 0)
+            if (files is { Count: > 0 })
             {
-                SendFileExecute(items, caption, media);
+                SendFilesAsync(null, files, caption, media);
             }
         }
 
-
-        public async void SendFileExecute(IList<StorageMedia> items, FormattedText caption = null, bool media = true)
+        public void SendFileExecute(IList<StorageMedia> items, FormattedText caption = null, bool media = true)
         {
-            if (Chat is not Chat chat || items.Empty())
+            if (items is { Count: > 0 })
+            {
+                SendFilesAsync(items, null, caption, media);
+            }
+        }
+
+        /// <summary>
+        /// Exactly one of <paramref name="items"/> and <paramref name="files"/> is given. Files are
+        /// typed after the popup is up, so the guard that used to run over the whole batch first
+        /// runs per item as it resolves — see <see cref="SendFilesPopup.Validating"/>.
+        /// </summary>
+        private async void SendFilesAsync(IList<StorageMedia> items, IReadOnlyList<StorageFile> files, FormattedText caption, bool media)
+        {
+            if (Chat is not Chat chat)
             {
                 return;
             }
 
             var permissions = ClientService.GetPermissions(chat, out bool restricted);
 
-            foreach (var item in items)
+            string restrictedError = null;
+            var sizeExceeded = false;
+
+            bool Validating(StorageMedia item)
             {
                 if (item is StoragePhoto && !permissions.CanSendPhotos)
                 {
-                    await ShowPopupAsync(restricted ? Strings.ErrorSendRestrictedPhoto : Strings.ErrorSendRestrictedPhotoAll, Strings.AppName, Strings.OK);
-                    return;
+                    restrictedError = restricted ? Strings.ErrorSendRestrictedPhoto : Strings.ErrorSendRestrictedPhotoAll;
                 }
                 else if (item is StorageVideo && !permissions.CanSendVideos)
                 {
-                    await ShowPopupAsync(restricted ? Strings.ErrorSendRestrictedVideo : Strings.ErrorSendRestrictedVideoAll, Strings.AppName, Strings.OK);
-                    return;
+                    restrictedError = restricted ? Strings.ErrorSendRestrictedVideo : Strings.ErrorSendRestrictedVideoAll;
                 }
                 else if (item is StorageAudio && !permissions.CanSendAudios)
                 {
-                    await ShowPopupAsync(restricted ? Strings.ErrorSendRestrictedMusic : Strings.ErrorSendRestrictedMusicAll, Strings.AppName, Strings.OK);
-                    return;
+                    restrictedError = restricted ? Strings.ErrorSendRestrictedMusic : Strings.ErrorSendRestrictedMusicAll;
                 }
                 else if (item is StorageDocument && !permissions.CanSendDocuments)
                 {
-                    await ShowPopupAsync(restricted ? Strings.ErrorSendRestrictedDocuments : Strings.ErrorSendRestrictedDocumentsAll, Strings.AppName, Strings.OK);
-                    return;
+                    restrictedError = restricted ? Strings.ErrorSendRestrictedDocuments : Strings.ErrorSendRestrictedDocumentsAll;
                 }
                 else if (item.Size > (4000L << 20) || (item.Size > (2000L << 20) && !IsPremium))
+                {
+                    sizeExceeded = true;
+                }
+
+                return restrictedError == null && !sizeExceeded;
+            }
+
+            if (items != null)
+            {
+                foreach (var item in items)
+                {
+                    if (!Validating(item))
+                    {
+                        break;
+                    }
+                }
+
+                if (restrictedError != null)
+                {
+                    await ShowPopupAsync(restrictedError, Strings.AppName, Strings.OK);
+                    return;
+                }
+                else if (sizeExceeded)
                 {
                     NavigationService.ShowLimitReached(new PremiumLimitTypeFileSize());
                     return;
@@ -479,15 +512,27 @@ namespace Telegram.ViewModels
 
             var self = ClientService.IsSavedMessages(chat);
 
-            var popup = new SendFilesPopup(this, items, media, permissions, chat.Type is ChatTypePrivate && !self, CanSchedule, self, false);
+            var popup = new SendFilesPopup(this, items ?? Array.Empty<StorageMedia>(), media, permissions, chat.Type is ChatTypePrivate && !self, CanSchedule, self, false);
             popup.Loaded += (s, args) =>
             {
                 popup.Caption = caption;
+
+                // Only once it is on screen: probing can abandon the drop, and OpenAsync queues
+                // behind any other dialog, so an earlier Hide would have nothing to close.
+                if (files != null)
+                {
+                    popup.Probe(files);
+                }
             };
 
             if (ClientService.TryGetSupergroupFull(chat, out SupergroupFullInfo fullInfo))
             {
                 popup.HasPaidMediaAllowed = fullInfo.HasPaidMediaAllowed;
+            }
+
+            if (files != null)
+            {
+                popup.Validating = Validating;
             }
 
             var confirm = await popup.OpenAsync(XamlRoot);
@@ -496,6 +541,16 @@ namespace Telegram.ViewModels
                 if (formattedText != null)
                 {
                     SetFormattedText(formattedText);
+                }
+
+                // Raised while the popup was up, by an item that only typed itself once probed.
+                if (restrictedError != null)
+                {
+                    await ShowPopupAsync(restrictedError, Strings.AppName, Strings.OK);
+                }
+                else if (sizeExceeded)
+                {
+                    NavigationService.ShowLimitReached(new PremiumLimitTypeFileSize());
                 }
 
                 return;

--- a/Telegram/ViewModels/ComposeViewModel.cs
+++ b/Telegram/ViewModels/ComposeViewModel.cs
@@ -426,24 +426,19 @@ namespace Telegram.ViewModels
         {
             if (files is { Count: > 0 })
             {
-                SendFilesAsync(null, files, caption, media);
+                SendFilesAsync(StorageMediaSource.FromFiles(files), caption, media);
             }
         }
 
-        public void SendFileExecute(IList<StorageMedia> items, FormattedText caption = null, bool media = true)
+        public void SendFileExecute(IReadOnlyList<StorageMedia> items, FormattedText caption = null, bool media = true)
         {
             if (items is { Count: > 0 })
             {
-                SendFilesAsync(items, null, caption, media);
+                SendFilesAsync(StorageMediaSource.FromMedia(items), caption, media);
             }
         }
 
-        /// <summary>
-        /// Exactly one of <paramref name="items"/> and <paramref name="files"/> is given. Files are
-        /// typed after the popup is up, so the guard that used to run over the whole batch first
-        /// runs per item as it resolves — see <see cref="SendFilesPopup.Validating"/>.
-        /// </summary>
-        private async void SendFilesAsync(IList<StorageMedia> items, IReadOnlyList<StorageFile> files, FormattedText caption, bool media)
+        private async void SendFilesAsync(StorageMediaSource source, FormattedText caption, bool media)
         {
             if (Chat is not Chat chat)
             {
@@ -481,26 +476,26 @@ namespace Telegram.ViewModels
                 return restrictedError == null && !sizeExceeded;
             }
 
-            if (items != null)
+            // Anything already typed is refused before the popup exists, as it always was. Files
+            // are refused as they land instead, from inside the popup — Ready is empty for those,
+            // so this loop simply does not run.
+            foreach (var item in source.Ready)
             {
-                foreach (var item in items)
+                if (!Validating(item))
                 {
-                    if (!Validating(item))
-                    {
-                        break;
-                    }
+                    break;
                 }
+            }
 
-                if (restrictedError != null)
-                {
-                    await ShowPopupAsync(restrictedError, Strings.AppName, Strings.OK);
-                    return;
-                }
-                else if (sizeExceeded)
-                {
-                    NavigationService.ShowLimitReached(new PremiumLimitTypeFileSize());
-                    return;
-                }
+            if (restrictedError != null)
+            {
+                await ShowPopupAsync(restrictedError, Strings.AppName, Strings.OK);
+                return;
+            }
+            else if (sizeExceeded)
+            {
+                NavigationService.ShowLimitReached(new PremiumLimitTypeFileSize());
+                return;
             }
 
             FormattedText formattedText = null;
@@ -512,27 +507,15 @@ namespace Telegram.ViewModels
 
             var self = ClientService.IsSavedMessages(chat);
 
-            var popup = new SendFilesPopup(this, items ?? Array.Empty<StorageMedia>(), media, permissions, chat.Type is ChatTypePrivate && !self, CanSchedule, self, false);
+            var popup = new SendFilesPopup(this, source, Validating, media, permissions, chat.Type is ChatTypePrivate && !self, CanSchedule, self, false);
             popup.Loaded += (s, args) =>
             {
                 popup.Caption = caption;
-
-                // Only once it is on screen: probing can abandon the drop, and OpenAsync queues
-                // behind any other dialog, so an earlier Hide would have nothing to close.
-                if (files != null)
-                {
-                    popup.Probe(files);
-                }
             };
 
             if (ClientService.TryGetSupergroupFull(chat, out SupergroupFullInfo fullInfo))
             {
                 popup.HasPaidMediaAllowed = fullInfo.HasPaidMediaAllowed;
-            }
-
-            if (files != null)
-            {
-                popup.Validating = Validating;
             }
 
             var confirm = await popup.OpenAsync(XamlRoot);

--- a/Telegram/ViewModels/DialogViewModel.Media.cs
+++ b/Telegram/ViewModels/DialogViewModel.Media.cs
@@ -401,8 +401,10 @@ namespace Telegram.ViewModels
 
             var permissions = ClientService.GetPermissions(chat, out _);
 
+            // Editing replaces a single message, so the item is always already typed and there is
+            // nothing to guard: the permission check happened when it was first sent.
             var items = new[] { storage };
-            var popup = new SendFilesPopup(this, items, mediaSelected, permissions, false, false, false, true);
+            var popup = new SendFilesPopup(this, StorageMediaSource.FromMedia(items), null, mediaSelected, permissions, false, false, false, true);
             popup.ShowCaptionAboveMedia = header.Editing.Message.ShowCaptionAboveMedia();
             popup.Caption = formattedText
                 .Substring(0, ClientService.Options.MessageCaptionLengthMax);

--- a/Telegram/Views/ChatView.xaml.cs
+++ b/Telegram/Views/ChatView.xaml.cs
@@ -1853,25 +1853,12 @@ namespace Telegram.Views
             var text = TextField.Text;
             var embedded = viewModel.ComposerHeader;
 
-            if (string.IsNullOrEmpty(text))
+            // getLinkPreview means serializing the whole message to JSON, a trip through the
+            // TDLib queue and a dispatcher hop back, on every keystroke. A text that can't
+            // contain a URL can't produce a preview either, so it's asked for nothing.
+            if (string.IsNullOrEmpty(text) || (embedded?.LinkPreviewOptions?.Url == null && !MayContainUrl(text)))
             {
-                if (embedded != null)
-                {
-                    if (embedded.IsEmpty)
-                    {
-                        viewModel.ComposerHeader = null;
-                    }
-                    else if (embedded.LinkPreview != null)
-                    {
-                        viewModel.ComposerHeader = new MessageComposerHeader(viewModel.ClientService)
-                        {
-                            Editing = embedded.Editing,
-                            ReplyTo = embedded.ReplyTo,
-                            SuggestedPostInfo = embedded.SuggestedPostInfo,
-                        };
-                    }
-                }
-
+                ClearLinkPreview(viewModel, embedded);
                 return;
             }
 
@@ -1901,24 +1888,62 @@ namespace Telegram.Views
                             LinkPreviewUrl = linkPreview.Url,
                         };
                     }
-                    else if (embedded != null)
+                    else
                     {
-                        if (embedded.IsEmpty)
-                        {
-                            viewModel.ComposerHeader = null;
-                        }
-                        else if (embedded.LinkPreview != null)
-                        {
-                            viewModel.ComposerHeader = new MessageComposerHeader(viewModel.ClientService)
-                            {
-                                Editing = embedded.Editing,
-                                ReplyTo = embedded.ReplyTo,
-                                SuggestedPostInfo = embedded.SuggestedPostInfo,
-                            };
-                        }
+                        ClearLinkPreview(viewModel, embedded);
                     }
                 });
             });
+
+        }
+
+        private static void ClearLinkPreview(DialogViewModel viewModel, MessageComposerHeader embedded)
+        {
+            if (embedded == null)
+            {
+                return;
+            }
+
+            if (embedded.IsEmpty)
+            {
+                viewModel.ComposerHeader = null;
+            }
+            else if (embedded.LinkPreview != null)
+            {
+                viewModel.ComposerHeader = new MessageComposerHeader(viewModel.ClientService)
+                {
+                    Editing = embedded.Editing,
+                    ReplyTo = embedded.ReplyTo,
+                    SuggestedPostInfo = embedded.SuggestedPostInfo,
+                };
+            }
+        }
+
+        // The URL parser accepts these in place of a regular full stop
+        private const char IdeographicFullStop = (char)0x3002;
+        private const char FullwidthFullStop = (char)0xFF0E;
+
+        // Deliberately permissive: a URL always carries either an explicit scheme or a dot
+        // before its top level domain, so this can be wrong about a link being there, but
+        // never about one not being there.
+        private static bool MayContainUrl(string text)
+        {
+            for (int i = 0; i < text.Length - 1; i++)
+            {
+                if (text[i] is '.' or IdeographicFullStop or FullwidthFullStop)
+                {
+                    if (char.IsLetterOrDigit(text[i + 1]))
+                    {
+                        return true;
+                    }
+                }
+                else if (text[i] == ':' && text[i + 1] == '/')
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private void TryGetWebPagePreview(IClientService clientService, Chat chat, string text, string url, Action<Object> result)

--- a/Telegram/Views/Popups/SendFilesPopup.xaml
+++ b/Telegram/Views/Popups/SendFilesPopup.xaml
@@ -189,9 +189,10 @@
                                  BorderThickness="1"
                                  BackgroundSizing="OuterBorderEdge"
                                  CornerRadius="4">
+                <!--  ImageSource is pushed by SendFilesPopup.UpdateThumbnail and cleared on recycle: the
+                      decoded bitmap must not outlive the container, and StorageMedia outlives the popup.  -->
                 <Grid.Background>
                     <ImageBrush x:Name="Preview"
-                                ImageSource="{x:Bind Preview, Mode=OneWay}"
                                 Stretch="UniformToFill"
                                 AlignmentX="Center"
                                 AlignmentY="Center" />

--- a/Telegram/Views/Popups/SendFilesPopup.xaml.cs
+++ b/Telegram/Views/Popups/SendFilesPopup.xaml.cs
@@ -268,32 +268,16 @@ namespace Telegram.Views.Popups
             _source = source;
             _validating = validating;
 
-            var builder = new StringBuilder();
-
-            foreach (var item in source.Ready)
+            if (source.IsComplete)
             {
-                switch (item)
-                {
-                    case StoragePhoto photo:
-                        builder.Prepend(string.Format("photo {0}x{1}", photo.Width, photo.Height), ", ");
-                        break;
-                    case StorageVideo video:
-                        builder.Prepend(string.Format("video {0}x{1}", video.Width, video.Height), ", ");
-                        break;
-                    default:
-                        builder.Prepend("file", ", ");
-                        break;
-                }
+                LogContent(source.Ready);
             }
-
-            // Nothing is typed yet on the drop path, so record the size of what is coming — this
-            // line ships with crash reports and used to name every item.
-            if (!source.IsComplete)
+            else
             {
-                builder.Prepend(string.Format("{0} pending", source.Count), ", ");
+                // Nothing is typed yet, so only the size of what is coming can be recorded here.
+                // LogContent runs again once it has all landed.
+                Logger.Info(string.Format("{0} pending", source.Count));
             }
-
-            Logger.Info(builder);
 
             IsSavedMessages = savedMessages;
             CanSchedule = schedule;
@@ -358,6 +342,33 @@ namespace Telegram.Views.Popups
 
             UpdateView();
             UpdatePanel();
+        }
+
+        /// <summary>
+        /// Records the dimensions of every item. This line ships with crash reports and is what
+        /// album layout bugs get diagnosed from, so it has to name sizes rather than counts.
+        /// </summary>
+        private static void LogContent(IEnumerable<StorageMedia> items)
+        {
+            var builder = new StringBuilder();
+
+            foreach (var item in items)
+            {
+                switch (item)
+                {
+                    case StoragePhoto photo:
+                        builder.Prepend(string.Format("photo {0}x{1}", photo.Width, photo.Height), ", ");
+                        break;
+                    case StorageVideo video:
+                        builder.Prepend(string.Format("video {0}x{1}", video.Width, video.Height), ", ");
+                        break;
+                    default:
+                        builder.Prepend("file", ", ");
+                        break;
+                }
+            }
+
+            Logger.Info(builder);
         }
 
         private void OnCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
@@ -844,6 +855,8 @@ namespace Telegram.Views.Popups
             _expectedCount = 0;
             UpdateLoading();
 
+            LogContent(Items);
+
             if (Items.Count == 0)
             {
                 Hide();
@@ -995,12 +1008,13 @@ namespace Telegram.Views.Popups
             if (IsMediaSelected)
             {
                 var album = new List<StorageMedia>();
+                var ordinal = 0;
 
                 void AddAlbum()
                 {
                     if (album.Count > 0)
                     {
-                        view.Add(new StorageAlbum(album));
+                        view.Add(new StorageAlbum(ordinal++, album));
                         album = new List<StorageMedia>();
                     }
                 }
@@ -1325,6 +1339,10 @@ namespace Telegram.Views.Popups
             var button = sender as Button;
             if (button.Tag is StorageMedia media)
             {
+                // The album panel reuses its children now, so a removed item's thumbnail is no
+                // longer released by a container recycling underneath it.
+                _thumbnails.Invalidate(media);
+
                 Items.Remove(media);
             }
         }
@@ -1596,22 +1614,10 @@ namespace Telegram.Views.Popups
         {
             if (oldItem is StorageAlbum oldAlbum && newItem is StorageAlbum newAlbum)
             {
-                if (oldAlbum.Media.Count != newAlbum.Media.Count)
-                {
-                    return false;
-                }
-
-                for (int i = 0; i < oldAlbum.Media.Count; i++)
-                {
-                    if (CompareItems(oldAlbum.Media[i], newAlbum.Media[i]))
-                    {
-                        continue;
-                    }
-
-                    return false;
-                }
-
-                return true;
+                // Identity, not contents: comparing the media made a growing album a different
+                // item, so every batch of arriving photos rebuilt it from nothing. UpdateItem
+                // carries the new contents over instead.
+                return oldAlbum.Ordinal == newAlbum.Ordinal;
             }
             if (oldItem is StoragePhoto oldPhoto && newItem is StoragePhoto newPhoto)
             {
@@ -1632,15 +1638,26 @@ namespace Telegram.Views.Popups
 
         public void UpdateItem(StorageMedia oldItem, StorageMedia newItem)
         {
+            // The collection keeps the old instance, so the new contents have to be moved onto it.
             if (oldItem is StorageAlbum album)
             {
+                if (newItem is StorageAlbum updated)
+                {
+                    album.Update(updated.Media);
+                }
+                else
+                {
+                    album.Invalidate();
+                }
+
                 var container = ScrollingHost.ContainerFromItem(album) as SelectorItem;
                 var content = container?.ContentTemplateRoot as Grid;
 
+                // Nothing to do when it is not realized: OnContainerContentChanging reads the
+                // album again on the way in.
                 if (content != null && content.Children[0] is StorageAlbumPanel panel)
                 {
-                    album.Invalidate();
-                    panel.Invalidate();
+                    panel.UpdateMessage(album);
                 }
             }
         }
@@ -1751,17 +1768,47 @@ namespace Telegram.Views.Popups
 
         public event EventHandler<StorageMedia> ItemClick;
 
+        /// <summary>
+        /// Children are reused across calls. An album gains photos as a drop is typed, and this
+        /// runs again on every one of those: rebuilding it each time discards the templates and
+        /// makes every surviving item re-request the thumbnail it already had.
+        /// </summary>
         public void UpdateMessage(StorageAlbum album)
         {
             _album = album;
-            Children.Clear();
 
-            foreach (var pos in album.Media)
+            var media = album.Media;
+
+            while (Children.Count > media.Count)
             {
+                var index = Children.Count - 1;
+
+                if (Children[index] is Button removed)
+                {
+                    removed.Click -= Element_Click;
+                }
+
+                Children.RemoveAt(index);
+            }
+
+            for (int i = 0; i < media.Count; i++)
+            {
+                if (i < Children.Count)
+                {
+                    // Content drives the template root's DataContext, which is what the popup
+                    // hangs the thumbnail and the button visibility off.
+                    if (Children[i] is Button existing && existing.Content != media[i])
+                    {
+                        existing.Content = media[i];
+                    }
+
+                    continue;
+                }
+
                 var element = new Button
                 {
                     ContentTemplate = ItemTemplate,
-                    Content = pos,
+                    Content = media[i],
                     HorizontalContentAlignment = HorizontalAlignment.Stretch,
                     VerticalContentAlignment = VerticalAlignment.Stretch,
                     MinWidth = 0,
@@ -1777,6 +1824,8 @@ namespace Telegram.Views.Popups
 
                 Children.Add(element);
             }
+
+            Invalidate();
         }
 
         private void Element_Click(object sender, RoutedEventArgs e)

--- a/Telegram/Views/Popups/SendFilesPopup.xaml.cs
+++ b/Telegram/Views/Popups/SendFilesPopup.xaml.cs
@@ -60,24 +60,25 @@ namespace Telegram.Views.Popups
 
         private readonly StorageThumbnailCache _thumbnails = new();
 
-        private readonly CancellationTokenSource _probeCancellation = new();
+        private readonly StorageMediaSource _source;
+        private readonly CancellationTokenSource _loadCancellation = new();
 
-        // Probed but not yet published. A drop of many files then costs a couple of UpdatePanel
-        // passes instead of one per file, since everything that resolves within a single UI turn
-        // is appended together.
+        // Returning false abandons the whole drop, which is what the guard this replaced did
+        // before the popup was shown. Null when the caller has nothing to enforce.
+        private readonly Func<StorageMedia, bool> _validating;
+
+        // Resolved but not yet published. A drop of many files then costs a couple of UpdatePanel
+        // passes instead of one per file, since everything that lands within a single UI turn is
+        // appended together.
         private readonly List<(int Index, StorageMedia Media)> _resolved = new();
         private bool _flushScheduled;
 
-        private bool _probeStarted;
-        private bool _isProbing;
-        private int _probeCount;
-        private bool _mediaRequested;
+        private bool _loadStarted;
+        private bool _isLoading;
 
-        /// <summary>
-        /// Called on the UI thread for each item as it finishes probing. Returning false abandons
-        /// the whole drop, which is what the guard this replaced did before the popup was shown.
-        /// </summary>
-        public Func<StorageMedia, bool> Validating { get; set; }
+        // What the source says is still coming. Zero once everything has arrived.
+        private int _expectedCount;
+        private bool _mediaRequested;
 
         private IAutocompleteCollection _autocomplete;
         public IAutocompleteCollection Autocomplete
@@ -162,11 +163,11 @@ namespace Telegram.Views.Popups
         {
             get
             {
-                // While probing, count the files still to come — otherwise the title ticks upwards
-                // one item at a time. Their type is not known yet, so they only count as files.
-                var count = Math.Max(Items.Count, _probeCount);
+                // Count what is still coming, or the title ticks upwards one item at a time. Their
+                // type is not known until they land, so they only count as files.
+                var count = Math.Max(Items.Count, _expectedCount);
 
-                if (IsMediaSelected && _probeCount == 0)
+                if (IsMediaSelected && _expectedCount == 0)
                 {
                     if (Items.All(x => x is StoragePhoto))
                     {
@@ -260,13 +261,16 @@ namespace Telegram.Views.Popups
 
         public long PaidMessageStarCount { get; private set; }
 
-        public SendFilesPopup(ComposeViewModel viewModel, IEnumerable<StorageMedia> items, bool media, ChatPermissions permissions, bool ttlAllowed, bool schedule, bool savedMessages, bool editing)
+        public SendFilesPopup(ComposeViewModel viewModel, StorageMediaSource source, Func<StorageMedia, bool> validating, bool media, ChatPermissions permissions, bool ttlAllowed, bool schedule, bool savedMessages, bool editing)
         {
             InitializeComponent();
 
+            _source = source;
+            _validating = validating;
+
             var builder = new StringBuilder();
 
-            foreach (var item in items)
+            foreach (var item in source.Ready)
             {
                 switch (item)
                 {
@@ -280,6 +284,13 @@ namespace Telegram.Views.Popups
                         builder.Prepend("file", ", ");
                         break;
                 }
+            }
+
+            // Nothing is typed yet on the drop path, so record the size of what is coming — this
+            // line ships with crash reports and used to name every item.
+            if (!source.IsComplete)
+            {
+                builder.Prepend(string.Format("{0} pending", source.Count), ", ");
             }
 
             Logger.Info(builder);
@@ -299,11 +310,16 @@ namespace Telegram.Views.Popups
 
             ItemsView = new DiffObservableCollection<StorageMedia>(this, Constants.DiffOptions);
 
-            Items = new MvxObservableCollection<StorageMedia>(items);
+            // Seeded rather than loaded, so a caller handing over typed items can read Items back
+            // the moment the popup closes. Only what the source still owes arrives later.
+            Items = new MvxObservableCollection<StorageMedia>(source.Ready);
             Items.CollectionChanged += OnCollectionChanged;
 
-            // When the caller is going to probe, Items starts empty and IsMediaAllowed cannot
-            // answer yet. UpdateView re-derives the mode as the first items land.
+            _isLoading = !source.IsComplete;
+            _expectedCount = source.IsComplete ? 0 : source.Count;
+
+            // With nothing typed yet IsMediaAllowed cannot answer, so UpdateView re-derives the
+            // mode as the first items land.
             _mediaRequested = media;
             IsMediaSelected = media && IsMediaAllowed;
             IsFilesSelected = !IsMediaSelected;
@@ -741,7 +757,7 @@ namespace Telegram.Views.Popups
         public void Accept()
         {
             // Reachable from Enter even while the send button is disabled.
-            if (_isProbing)
+            if (_isLoading)
             {
                 return;
             }
@@ -797,40 +813,36 @@ namespace Telegram.Views.Popups
         }
 
         /// <summary>
-        /// Types <paramref name="files"/> in the background, appending each one as it resolves.
-        /// The popup is expected to be shown right after this returns — probing a large drop up
-        /// front is what used to leave the user staring at nothing.
+        /// Drains whatever the source did not hand over at construction, appending items as they
+        /// land. Driven from the popup's own Loaded so a caller cannot forget it — and only once
+        /// on screen, since a rejected item closes the popup and OpenAsync queues behind any other
+        /// dialog, leaving an earlier Hide with nothing to close.
         /// </summary>
-        public async void Probe(IReadOnlyList<StorageFile> files)
+        private async void Load()
         {
-            // Loaded can fire more than once.
-            if (_probeStarted)
+            // Loaded fires again whenever the popup is re-parented.
+            if (_loadStarted || _source.IsComplete)
             {
                 return;
             }
 
-            _probeStarted = true;
-            _isProbing = true;
+            _loadStarted = true;
+            UpdateLoading();
 
-            // The title counts what is coming rather than what has landed, so it does not tick up
-            // one file at a time.
-            _probeCount = files.Count;
-            UpdateProbing();
+            await _source.LoadAsync(OnResolved, _loadCancellation.Token);
 
-            await StorageMedia.ProbeAsync(files, OnResolved, _probeCancellation.Token);
-
-            if (_probeCancellation.IsCancellationRequested)
+            if (_loadCancellation.IsCancellationRequested)
             {
                 return;
             }
 
-            // Flush before clearing the flag: the last batch still needs UpdateView to see a
-            // probe in progress so it can settle the media/files mode.
+            // Flush before clearing the flag: the last batch still needs UpdateView to see a load
+            // in progress so it can settle the media/files mode.
             Flush();
 
-            _isProbing = false;
-            _probeCount = 0;
-            UpdateProbing();
+            _isLoading = false;
+            _expectedCount = 0;
+            UpdateLoading();
 
             if (Items.Count == 0)
             {
@@ -840,9 +852,9 @@ namespace Telegram.Views.Popups
 
         private void OnResolved(int index, StorageMedia media)
         {
-            if (Validating?.Invoke(media) == false)
+            if (_validating?.Invoke(media) == false)
             {
-                _probeCancellation.Cancel();
+                _loadCancellation.Cancel();
                 Hide();
 
                 return;
@@ -863,7 +875,7 @@ namespace Telegram.Views.Popups
         {
             _flushScheduled = false;
 
-            if (_resolved.Count == 0 || _probeCancellation.IsCancellationRequested)
+            if (_resolved.Count == 0 || _loadCancellation.IsCancellationRequested)
             {
                 return;
             }
@@ -885,11 +897,11 @@ namespace Telegram.Views.Popups
             Items.AddRange(media);
         }
 
-        private void UpdateProbing()
+        private void UpdateLoading()
         {
             // Sending half a drop would silently drop the rest, so the button waits.
-            SendMessage.IsEnabled = !_isProbing;
-            PaidMessage.IsEnabled = !_isProbing;
+            SendMessage.IsEnabled = !_isLoading;
+            PaidMessage.IsEnabled = !_isLoading;
 
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TitleText)));
         }
@@ -959,7 +971,7 @@ namespace Telegram.Views.Popups
 
             // The constructor could not honour the requested mode against an empty list, so it is
             // settled here instead — but only until the user picks a mode of their own.
-            if (_isProbing && _mediaRequested && !IsMediaSelected && IsMediaAllowed)
+            if (_isLoading && _mediaRequested && !IsMediaSelected && IsMediaAllowed)
             {
                 IsMediaSelected = true;
                 IsFilesSelected = false;
@@ -1366,6 +1378,8 @@ namespace Telegram.Views.Popups
         {
             CaptionInput.Focus(FocusState.Keyboard);
             Window.Current.CoreWindow.CharacterReceived += OnCharacterReceived;
+
+            Load();
         }
 
         private void OnUnloaded(object sender, RoutedEventArgs e)
@@ -1378,7 +1392,7 @@ namespace Telegram.Views.Popups
 
             // Stops further files from being probed. Probes already running still finish; see the
             // cancellation survey in sendfiles-popup-todo.md.
-            _probeCancellation.Cancel();
+            _loadCancellation.Cancel();
         }
 
         private void OnCharacterReceived(CoreWindow sender, CharacterReceivedEventArgs args)

--- a/Telegram/Views/Popups/SendFilesPopup.xaml.cs
+++ b/Telegram/Views/Popups/SendFilesPopup.xaml.cs
@@ -45,6 +45,7 @@ using Windows.UI.Xaml.Hosting;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
+using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Shapes;
 
 namespace Telegram.Views.Popups
@@ -55,6 +56,8 @@ namespace Telegram.Views.Popups
         public MvxObservableCollection<StorageMedia> Items { get; private set; }
 
         public DiffObservableCollection<StorageMedia> ItemsView { get; private set; }
+
+        private readonly StorageThumbnailCache _thumbnails = new();
 
         private IAutocompleteCollection _autocomplete;
         public IAutocompleteCollection Autocomplete
@@ -462,6 +465,16 @@ namespace Telegram.Views.Popups
         {
             if (args.InRecycleQueue)
             {
+                // The container keeps its template while queued, so the ImageBrush would go on
+                // rooting the decoded bitmap. Read the album off the panel rather than args.Item,
+                // which is not guaranteed to survive into the recycle notification.
+                if (args.ItemContainer.ContentTemplateRoot is Grid recycled
+                    && recycled.Children.Count > 0
+                    && recycled.Children[0] is StorageAlbumPanel recycledPanel)
+                {
+                    ReleaseThumbnails(recycledPanel);
+                }
+
                 return;
             }
 
@@ -627,6 +640,8 @@ namespace Telegram.Views.Popups
 
         private void UpdateTemplate(Grid root, StorageMedia storage)
         {
+            UpdateThumbnail(root, storage);
+
             var overlay = root.FindName("Overlay") as Border;
             overlay.Visibility = storage is StorageVideo ? Visibility.Visible : Visibility.Collapsed;
 
@@ -651,6 +666,48 @@ namespace Telegram.Views.Popups
 
             crop.Visibility = storage is StoragePhoto ? Visibility.Visible : Visibility.Collapsed;
             ttl.Visibility = IsTtlAvailable ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        private void UpdateThumbnail(Grid root, StorageMedia storage)
+        {
+            if (storage == null || root.Background is not ImageBrush brush)
+            {
+                return;
+            }
+
+            if (_thumbnails.TryGet(storage, out var cached))
+            {
+                brush.ImageSource = cached;
+                return;
+            }
+
+            brush.ImageSource = null;
+            LoadThumbnail(root, storage);
+        }
+
+        private async void LoadThumbnail(Grid root, StorageMedia storage)
+        {
+            var source = await _thumbnails.GetAsync(storage);
+
+            // The container may have been recycled onto another item, or torn down entirely,
+            // while the decode was in flight.
+            if (root.DataContext == storage && root.Background is ImageBrush brush)
+            {
+                brush.ImageSource = source;
+            }
+        }
+
+        private void ReleaseThumbnails(StorageAlbumPanel panel)
+        {
+            foreach (var child in panel.Children)
+            {
+                if (child is ContentControl { ContentTemplateRoot: Grid inner } && inner.Background is ImageBrush brush)
+                {
+                    brush.ImageSource = null;
+                }
+            }
+
+            _thumbnails.Release(panel.Album);
         }
 
         public void Accept()
@@ -1083,7 +1140,7 @@ namespace Telegram.Views.Popups
                 var confirm = await popup.ShowAsync(XamlRoot);
                 if (confirm == ContentDialogResult.Primary)
                 {
-                    media.Refresh();
+                    _thumbnails.Invalidate(media);
 
                     UpdateView();
                     UpdatePanel();
@@ -1104,7 +1161,7 @@ namespace Telegram.Views.Popups
             var confirm = await popup.ShowAsync(XamlRoot);
             if (confirm == ContentDialogResult.Primary)
             {
-                args.Refresh();
+                _thumbnails.Invalidate(args);
 
                 UpdateView();
                 UpdatePanel();
@@ -1174,6 +1231,10 @@ namespace Telegram.Views.Popups
         private void OnUnloaded(object sender, RoutedEventArgs e)
         {
             Window.Current.CoreWindow.CharacterReceived -= OnCharacterReceived;
+
+            // The items outlive the popup — they are handed to the send loop — so the thumbnails
+            // have to be dropped here rather than left to follow the models.
+            _thumbnails.Clear();
         }
 
         private void OnCharacterReceived(CoreWindow sender, CharacterReceivedEventArgs args)
@@ -1473,6 +1534,8 @@ namespace Telegram.Views.Popups
             Margin = new Thickness(0, 0, -StorageAlbum.ITEM_MARGIN, -StorageAlbum.ITEM_MARGIN);
         }
 
+        public StorageAlbum Album => _album;
+
         private (Rect[], Size) _positions;
 
         public void Invalidate()
@@ -1570,5 +1633,139 @@ namespace Telegram.Views.Popups
 
         public static readonly DependencyProperty ItemTemplateProperty =
             DependencyProperty.Register("ItemTemplate", typeof(DataTemplate), typeof(StorageAlbumPanel), new PropertyMetadata(null));
+    }
+
+    /// <summary>
+    /// Owns the thumbnails shown by <see cref="SendFilesPopup"/>, for the lifetime of the popup.
+    ///
+    /// They used to hang off StorageMedia, which is the wrong owner twice over: the models are
+    /// handed to the send loop and so outlive the popup, and nothing ever released a decoded
+    /// bitmap once it had been produced. A photo costs roughly a megabyte and a video twice that,
+    /// so a large drop retained tens of megabytes for the rest of the send.
+    ///
+    /// Entries are dropped as their album container is recycled, so the live set is bounded by
+    /// what the ListView has realized rather than by how many files the user picked.
+    ///
+    /// A decode already under way cannot be stopped — neither BitmapImage.SetSourceAsync nor the
+    /// video path takes a cancellation token — so closing the popup drops the result instead.
+    /// </summary>
+    public sealed partial class StorageThumbnailCache
+    {
+        // UI thread only: every entry point is a XAML callback or a continuation resumed on it.
+        private readonly Dictionary<StorageMedia, ImageSource> _cache = new();
+        private readonly Dictionary<StorageMedia, Task<ImageSource>> _inflight = new();
+
+        public bool TryGet(StorageMedia media, out ImageSource source)
+        {
+            return _cache.TryGetValue(media, out source);
+        }
+
+        /// <summary>
+        /// Returns null when there is no preview to show, and caches that so a file that cannot be
+        /// decoded is not retried on every realization.
+        /// </summary>
+        public Task<ImageSource> GetAsync(StorageMedia media)
+        {
+            if (_cache.TryGetValue(media, out var cached))
+            {
+                return Task.FromResult(cached);
+            }
+
+            // Several containers can ask for the same file before the first decode returns, and
+            // the album panel rebuilds all of its children on every UpdatePanel.
+            if (_inflight.TryGetValue(media, out var pending))
+            {
+                return pending;
+            }
+
+            var task = DecodeAsync(media);
+            _inflight[media] = task;
+
+            return task;
+        }
+
+        private async Task<ImageSource> DecodeAsync(StorageMedia media)
+        {
+            ImageSource source = null;
+
+            try
+            {
+                if (media.EditState is ImageGeneration editState && !editState.IsEmpty)
+                {
+                    try
+                    {
+                        // TODO: actual logical pixel size
+                        source = await ImageHelper.CropAndPreviewAsync(media, editState, 600);
+                    }
+                    catch
+                    {
+                        // Fall back to the unedited preview below.
+                    }
+                }
+
+                if (source == null)
+                {
+                    if (media is StorageVideo)
+                    {
+                        // TODO: actual logical pixel size
+                        source = await ImageHelper.GetPreviewBitmapAsync(media, 600);
+                    }
+                    else
+                    {
+                        var preview = new BitmapImage
+                        {
+                            DecodePixelWidth = 300,
+                            DecodePixelType = DecodePixelType.Logical
+                        };
+
+                        using var stream = await media.File.OpenReadAsync();
+                        await preview.SetSourceAsync(stream);
+
+                        source = preview;
+                    }
+                }
+            }
+            catch
+            {
+                // A file we cannot decode shows the type glyph instead.
+                source = null;
+            }
+
+            // Release, Invalidate or Clear may have dropped this request while it was in flight.
+            // Caching it now would either resurrect a bitmap nothing is left to release, or hand
+            // back the pre-crop image.
+            if (_inflight.Remove(media))
+            {
+                _cache[media] = source;
+            }
+
+            return source;
+        }
+
+        public void Invalidate(StorageMedia media)
+        {
+            _cache.Remove(media);
+            _inflight.Remove(media);
+        }
+
+        public void Release(StorageAlbum album)
+        {
+            if (album == null)
+            {
+                return;
+            }
+
+            foreach (var media in album.Media)
+            {
+                _cache.Remove(media);
+                _inflight.Remove(media);
+            }
+        }
+
+        public void Clear()
+        {
+            _cache.Clear();
+            _inflight.Clear();
+        }
     }
 }

--- a/Telegram/Views/Popups/SendFilesPopup.xaml.cs
+++ b/Telegram/Views/Popups/SendFilesPopup.xaml.cs
@@ -14,6 +14,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Numerics;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Telegram.Collections;
 using Telegram.Common;
@@ -58,6 +59,25 @@ namespace Telegram.Views.Popups
         public DiffObservableCollection<StorageMedia> ItemsView { get; private set; }
 
         private readonly StorageThumbnailCache _thumbnails = new();
+
+        private readonly CancellationTokenSource _probeCancellation = new();
+
+        // Probed but not yet published. A drop of many files then costs a couple of UpdatePanel
+        // passes instead of one per file, since everything that resolves within a single UI turn
+        // is appended together.
+        private readonly List<(int Index, StorageMedia Media)> _resolved = new();
+        private bool _flushScheduled;
+
+        private bool _probeStarted;
+        private bool _isProbing;
+        private int _probeCount;
+        private bool _mediaRequested;
+
+        /// <summary>
+        /// Called on the UI thread for each item as it finishes probing. Returning false abandons
+        /// the whole drop, which is what the guard this replaced did before the popup was shown.
+        /// </summary>
+        public Func<StorageMedia, bool> Validating { get; set; }
 
         private IAutocompleteCollection _autocomplete;
         public IAutocompleteCollection Autocomplete
@@ -142,23 +162,27 @@ namespace Telegram.Views.Popups
         {
             get
             {
-                if (IsMediaSelected)
+                // While probing, count the files still to come — otherwise the title ticks upwards
+                // one item at a time. Their type is not known yet, so they only count as files.
+                var count = Math.Max(Items.Count, _probeCount);
+
+                if (IsMediaSelected && _probeCount == 0)
                 {
                     if (Items.All(x => x is StoragePhoto))
                     {
-                        return string.Format(Strings.SendItems, Locale.Declension(Strings.R.Photos, Items.Count));
+                        return string.Format(Strings.SendItems, Locale.Declension(Strings.R.Photos, count));
                     }
                     else if (Items.All(x => x is StorageVideo))
                     {
-                        return string.Format(Strings.SendItems, Locale.Declension(Strings.R.Videos, Items.Count));
+                        return string.Format(Strings.SendItems, Locale.Declension(Strings.R.Videos, count));
                     }
                     else if (Items.All(x => x is StoragePhoto or StorageVideo))
                     {
-                        return string.Format(Strings.SendItems, Locale.Declension(Strings.R.Media, Items.Count));
+                        return string.Format(Strings.SendItems, Locale.Declension(Strings.R.Media, count));
                     }
                 }
 
-                return string.Format(Strings.SendItems, Locale.Declension(Strings.R.Files, Items.Count));
+                return string.Format(Strings.SendItems, Locale.Declension(Strings.R.Files, count));
             }
         }
 
@@ -277,6 +301,10 @@ namespace Telegram.Views.Popups
 
             Items = new MvxObservableCollection<StorageMedia>(items);
             Items.CollectionChanged += OnCollectionChanged;
+
+            // When the caller is going to probe, Items starts empty and IsMediaAllowed cannot
+            // answer yet. UpdateView re-derives the mode as the first items land.
+            _mediaRequested = media;
             IsMediaSelected = media && IsMediaAllowed;
             IsFilesSelected = !IsMediaSelected;
 
@@ -712,6 +740,12 @@ namespace Telegram.Views.Popups
 
         public void Accept()
         {
+            // Reachable from Enter even while the send button is disabled.
+            if (_isProbing)
+            {
+                return;
+            }
+
             if (CaptionInput.HandwritingView.IsOpen)
             {
                 void handler(object s, RoutedEventArgs args)
@@ -760,6 +794,104 @@ namespace Telegram.Views.Popups
         private async void ListView_Drop(object sender, DragEventArgs e)
         {
             await HandlePackageAsync(e.DataView);
+        }
+
+        /// <summary>
+        /// Types <paramref name="files"/> in the background, appending each one as it resolves.
+        /// The popup is expected to be shown right after this returns — probing a large drop up
+        /// front is what used to leave the user staring at nothing.
+        /// </summary>
+        public async void Probe(IReadOnlyList<StorageFile> files)
+        {
+            // Loaded can fire more than once.
+            if (_probeStarted)
+            {
+                return;
+            }
+
+            _probeStarted = true;
+            _isProbing = true;
+
+            // The title counts what is coming rather than what has landed, so it does not tick up
+            // one file at a time.
+            _probeCount = files.Count;
+            UpdateProbing();
+
+            await StorageMedia.ProbeAsync(files, OnResolved, _probeCancellation.Token);
+
+            if (_probeCancellation.IsCancellationRequested)
+            {
+                return;
+            }
+
+            // Flush before clearing the flag: the last batch still needs UpdateView to see a
+            // probe in progress so it can settle the media/files mode.
+            Flush();
+
+            _isProbing = false;
+            _probeCount = 0;
+            UpdateProbing();
+
+            if (Items.Count == 0)
+            {
+                Hide();
+            }
+        }
+
+        private void OnResolved(int index, StorageMedia media)
+        {
+            if (Validating?.Invoke(media) == false)
+            {
+                _probeCancellation.Cancel();
+                Hide();
+
+                return;
+            }
+
+            _resolved.Add((index, media));
+
+            if (_flushScheduled)
+            {
+                return;
+            }
+
+            _flushScheduled = true;
+            _ = Dispatcher.RunAsync(CoreDispatcherPriority.Low, Flush);
+        }
+
+        private void Flush()
+        {
+            _flushScheduled = false;
+
+            if (_resolved.Count == 0 || _probeCancellation.IsCancellationRequested)
+            {
+                return;
+            }
+
+            // Within a batch the picked order is preserved. Across batches items land in the order
+            // they resolve, which is the whole point of not waiting for the slow ones.
+            _resolved.Sort(static (x, y) => x.Index.CompareTo(y.Index));
+
+            var media = new StorageMedia[_resolved.Count];
+
+            for (int i = 0; i < _resolved.Count; i++)
+            {
+                media[i] = _resolved[i].Media;
+            }
+
+            _resolved.Clear();
+
+            // One CollectionChanged for the batch, so one UpdateView and one UpdatePanel.
+            Items.AddRange(media);
+        }
+
+        private void UpdateProbing()
+        {
+            // Sending half a drop would silently drop the rest, so the button waits.
+            SendMessage.IsEnabled = !_isProbing;
+            PaidMessage.IsEnabled = !_isProbing;
+
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TitleText)));
         }
 
         public async Task HandlePackageAsync(DataPackageView package)
@@ -824,6 +956,14 @@ namespace Telegram.Views.Popups
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsMediaAllowed)));
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TitleText)));
+
+            // The constructor could not honour the requested mode against an empty list, so it is
+            // settled here instead — but only until the user picks a mode of their own.
+            if (_isProbing && _mediaRequested && !IsMediaSelected && IsMediaAllowed)
+            {
+                IsMediaSelected = true;
+                IsFilesSelected = false;
+            }
 
             if (IsMediaSelected && !IsMediaAllowed && _documentAllowed)
             {
@@ -1235,6 +1375,10 @@ namespace Telegram.Views.Popups
             // The items outlive the popup — they are handed to the send loop — so the thumbnails
             // have to be dropped here rather than left to follow the models.
             _thumbnails.Clear();
+
+            // Stops further files from being probed. Probes already running still finish; see the
+            // cancellation survey in sendfiles-popup-todo.md.
+            _probeCancellation.Cancel();
         }
 
         private void OnCharacterReceived(CoreWindow sender, CharacterReceivedEventArgs args)
@@ -1365,6 +1509,9 @@ namespace Telegram.Views.Popups
 
         private void ToggleIsFilesSelected(bool value)
         {
+            // An explicit choice outranks the mode the caller asked for, even mid-probe.
+            _mediaRequested = !value;
+
             IsFilesSelected = value;
             UpdateView();
             UpdatePanel();
@@ -1423,6 +1570,7 @@ namespace Telegram.Views.Popups
             }
 
             StarCount = popup.Value;
+            _mediaRequested = true;
             IsFilesSelected = false;
             IsAlbum = true;
 

--- a/clientservice-review.md
+++ b/clientservice-review.md
@@ -164,7 +164,8 @@ The two facts most of this rests on:
       A concurrent read during a resize doesn't throw, it spins. All three are
       low-frequency, which is exactly why this would be a bug that never reproduces.
 
-- [ ] **`Clear()` empties lock-guarded collections without their locks** — `ClientService.cs:914` **[live]**
+- [x] **`Clear()` empties lock-guarded collections without their locks** — `ClientService.cs:914` **[live]**
+      → fixed in the commit that checked this box
 
       **This replaces a mis-aimed item.** The original said `NewDictionary` /
       `DefaultDictionary` getters mutate on a miss — true — and concluded that
@@ -193,8 +194,11 @@ The two facts most of this rests on:
       out from under an enumerator, or a `Dictionary` mid-lookup. Narrow window, real
       corruption.
 
-      Fix is mechanical — wrap each group in the lock it already has. They are taken one
-      after another, never nested, so no ordering is introduced.
+      Fixed by wrapping each group in the lock it already has, taken one after another and
+      never nested, so no ordering is introduced. `_timezones` turned out to be a ninth
+      collection the table above missed — enumerating every `lock (_x)` target in the
+      partials found it, and that is the check to repeat rather than re-reading `Clear()`.
+      All nine lock objects are now held while their collection is emptied.
 
       **This was missed by the earlier `Clear()` fix**, which audited *which* fields were
       cleared and never asked whether clearing them was synchronized.

--- a/clientservice-review.md
+++ b/clientservice-review.md
@@ -150,7 +150,23 @@ The two facts most of this rests on:
       one object replaced wholesale would make the next miss impossible — see
       *Needs your call*.
 
-- [ ] **Plain `Dictionary` shared across threads — 3 fields** **[latent]**
+- [x] **Plain `Dictionary` shared across threads — 3 fields** **[latent]**
+      → fixed in the commit that checked this box
+
+      **The rule, since this came up twice:** a standalone dictionary whose operations are
+      single calls becomes a `ReaderWriterDictionary`, matching the rest of the caches. A
+      lock is only for what that type cannot express — a set rather than a dictionary, a
+      field that gets assigned null, or an operation that must be compound. By that rule
+      `_chatAccessibleUntil` and `_cachedReactions` are now `ReaderWriterDictionary` and lost
+      their explicit locks entirely, while `_preparedLogsFileIds` keeps one and says why in
+      place. The same rule is what put `ForumTopicService` on a single lock: six of its eight
+      collections are sets, a list and a sorted set, with compounds spanning them.
+
+      `_preparedLogsFileIds` was worse than "latent". `PrepareLogs` does `??= new()` then
+      `.Add()` on the UI thread while `UpdateFile` assigns the field null on the TDLib thread
+      — landing between those two statements is a null dereference, not just a torn read.
+      Its remove-then-maybe-reset is now one critical section, with the `Client.Execute` that
+      restores the verbosity hoisted out of it.
 
       - `_chatAccessibleUntil` (`:1147`) — written from the `CheckChatInviteLinkAsync`
         continuation, cleared on the TDLib thread, read from the UI thread

--- a/clientservice-review.md
+++ b/clientservice-review.md
@@ -708,9 +708,25 @@ in better shape than `ForumTopicService`; `_topics` is a `ReaderWriterDictionary
       through `GetDirectMessagesChatTopicsAsync` instead — worth confirming against
       `TopicListViewModel` before changing.
 
-- [ ] **D3 · P1 · `_haveFullList` written outside the `_order` monitor** — `:162`
+- [x] **~~D3 · P1 · `_haveFullList` written outside the `_order` monitor~~ — no race exists** — `:162`
 
-      Same shape as the `_haveFullChatList` item in P1 above.
+      It said "same shape as the `_haveFullChatList` item in P1 above", and it was — including
+      being wrong for the same reason, so it inherited the correction rather than the bug.
+
+      `_haveFullList` is a plain `bool` with exactly three references: the declaration, one
+      read inside the lock, one write outside it. Its only caller is
+      `TopicListViewModel.cs:1052`, and with no `ConfigureAwait(false)` anywhere in the repo
+      that continuation resumes on the UI thread — the same thread that took the lock. No
+      second thread touches the field: the TDLib thread reaches this class only through
+      `UpdateDirectMessagesChatTopic`, which never reads or writes it.
+
+      Even granting a second thread, a `bool` write is atomic, so the worst case would be one
+      redundant `loadDirectMessagesChatTopics`, not corruption.
+
+      The same reasoning clears `ForumTopicService._haveFullList`, which has the identical
+      shape and was never raised as an item. Both `await`s complete on a
+      `TaskCompletionSource` set from the TDLib thread, but the continuation posts back to the
+      UI context, which is what makes the lock-then-unlocked-write sequence single-threaded.
 
 - [ ] **D4 · P3** — missing `continue` in `GetTopics` (see F3) and the dropped `unreadCount`
       (see F10).

--- a/clientservice-review.md
+++ b/clientservice-review.md
@@ -164,14 +164,47 @@ The two facts most of this rests on:
       A concurrent read during a resize doesn't throw, it spins. All three are
       low-frequency, which is exactly why this would be a bug that never reproduces.
 
-- [ ] **`NewDictionary` / `DefaultDictionary` getters mutate** — `ChatList.cs:144-158`, `:170-185` **[latent]**
+- [ ] **`Clear()` empties lock-guarded collections without their locks** — `ClientService.cs:914` **[live]**
 
-      The indexer *getter* inserts on a miss, so every "read" is a write.
-      `_haveFullChatList[chatList] = true` (`ChatList.cs:69`) and
-      `_haveFullStoryList[storyList] = true` (`StoryList.cs:104`) both run **after**
-      `Monitor.Exit`, from an async continuation, against a dictionary another thread reads
-      — and therefore writes — under the monitor. Same hazard as the item above, but
-      disguised as a read.
+      **This replaces a mis-aimed item.** The original said `NewDictionary` /
+      `DefaultDictionary` getters mutate on a miss — true — and concluded that
+      `_haveFullChatList[chatList] = true` (`ChatList.cs:100`) racing outside the monitor was
+      the bug. It isn't. Every one of the seven `GetChatListAsync` / `GetStoryListAsync`
+      callers is UI-layer, the repo contains no `ConfigureAwait(false)`, so those
+      continuations resume on the UI thread. There is no second thread reading those
+      dictionaries under the monitor, and the mutating getter is only ever reached from
+      inside a `lock` — a trap for the next reader, not a defect. Demoted to P3 below.
+
+      The real cross-thread party is `Clear()`, which runs on the **TDLib receive thread**
+      (`OnResult` → `AuthorizationStateClosed`) and takes only two locks —
+      `_recentChatsLock`, and `_downloadsLock` via `ClearDownloads` — while emptying eight
+      collections that every other accessor guards:
+
+      | Collection | Guarded elsewhere by |
+      |---|---|
+      | `_chatList`, `_haveFullChatList` | `lock (_chatList)` |
+      | `_storyList`, `_haveFullStoryList` | `lock (_storyList)` |
+      | `_savedMessages` | `lock (_savedMessages)` |
+      | `_savedMessagesTags` | `lock (_savedMessagesTags)` |
+      | `_suggestedActions` | `lock (_suggestedActions)` |
+      | `_chatFolders2` | `_chatFoldersLock` |
+
+      So a logout landing while the UI has a chat-list load in flight clears a `SortedSet`
+      out from under an enumerator, or a `Dictionary` mid-lookup. Narrow window, real
+      corruption.
+
+      Fix is mechanical — wrap each group in the lock it already has. They are taken one
+      after another, never nested, so no ordering is introduced.
+
+      **This was missed by the earlier `Clear()` fix**, which audited *which* fields were
+      cleared and never asked whether clearing them was synchronized.
+
+- [ ] **`NewDictionary` / `DefaultDictionary` getters mutate** — `ChatList.cs:144-158`, `:170-185` · **P3, trap not defect**
+
+      The indexer *getter* inserts on a miss, so what reads like a read is a write. Every
+      current call site is inside a `lock`, so nothing is broken today. Worth either renaming
+      to something that says "get or create", or giving them an explicit `GetOrAdd` method,
+      so the next person to add a call site outside a lock isn't misled.
 
 - [ ] **`SetResult` → `TrySetResult`, and `RunContinuationsAsynchronously`** — `ClientService.cs:1085`, `Files.cs:83`, `ClientService.cs:397` **[latent]**
 

--- a/clientservice-review.md
+++ b/clientservice-review.md
@@ -389,11 +389,25 @@ Ordered by measured reach, not by size of change.
       Making the fetch explicit rather than a side effect of a property getter would still be
       better, but that changes every call site.
 
-- [ ] **Sync filesystem I/O on the receive thread** — `ClientService.cs:3015`, `Files.cs:379` **[live]**
+- [x] **Sync filesystem I/O on the receive thread** — `ClientService.cs:3015`, `Files.cs:379` **[live]**
+      → fixed in the commit that checked this box
 
-      `ParseFile` and `ProcessFile` both call `NativeUtils.FileExists(file.Local.Path)` for
-      every file whose download reports complete — a synchronous syscall on the single
-      thread draining `td_receive`, on a path that fires constantly while media loads.
+      The framing was "sync I/O on the receive thread", as though it were inherent. It was
+      one path missing a guard the other had: `ProcessFile` did the check only for a file id
+      it had not seen, `ParseFile` did it after every parse, for known and new files alike.
+      `ParseFile` is the shipping path — and `ProcessFile` turned out to be dead code from the
+      TDLib/WinRT era, so the live parser was the wasteful one.
+
+      Now gated on first sight. Every parsed object carries files and a history page is
+      hundreds of them, nearly all already cached, so the syscall count drops from
+      per-file-per-update to once per file id per session.
+
+      Nothing real is lost. TDLib sends no update when a file vanishes behind its back, so the
+      repeated check only caught an external delete when an unrelated update happened to
+      arrive for that same file — luck, not detection. `GetFileAsync` catches
+      `FileNotFoundException` at the point of use (`Files.cs:125-128`), which is the reliable
+      path. First sight still covers what it is actually for: the cache having been cleared
+      between sessions.
 
 - [x] **~~Unbounded session-lifetime growth~~ — closed: `_files` is TDLib's model, the rest is noise** — `Files.cs:78-80`, `ClientService.cs:348`
 

--- a/formatted-text-box-review.md
+++ b/formatted-text-box-review.md
@@ -1,0 +1,122 @@
+# FormattedTextBox / ChatTextBox review
+
+Read-through of `Telegram/Controls/FormattedTextBox.cs` and
+`Telegram/Controls/Chats/ChatTextBox.cs` after the typing/pasting performance work.
+Line numbers are against the working tree at the time of writing.
+
+Everything below is unfixed. Check an item off in the same commit as its fix.
+
+## Bugs
+
+- [ ] **`_updateLocked` stays set if `GetFormattedText` throws** — `FormattedTextBox.cs:1263`
+      sets it and `:1479` clears it, with the whole TOM walk in between and no `try`/`finally`.
+      One exception disables `UpdateCustomEmoji` for the lifetime of the control (it early-returns
+      on `_updateLocked`), so custom emoji stop rendering in the box with no other symptom and no
+      way back. `SetText` already guards the same field this way at `:1596`-`:1612` — do the same.
+
+- [ ] **`_undoGroup` drifts if anything between `BeginUndoGroup` and `EndUndoGroup` throws** —
+      pairs at `:346`, `:375`, `:1211`, `:1823`, `:1884`, `:2232`, `:2270`, `:2284`, none of them
+      in a `try`/`finally`. Once the counter is stuck above zero, `OnTextChanging` stops calling
+      `UpdateFormat` permanently (it's gated on `_undoGroup == 0`), so blockquote font sizes
+      silently stop being normalized. Either wrap every pair, or give the helper a disposable
+      scope so the pairing can't be skipped.
+
+- [ ] **`CharacterReceived` can be subscribed more than once** — `FormattedTextBox.cs:294`
+      subscribes in `Loaded` and `:299` unsubscribes in `Unloaded`. `Loaded` can fire again
+      without an intervening `Unloaded` (re-parenting), and `CoreWindow` lives for the whole
+      session, so a second subscription both replaces the emoticon twice per keystroke and pins
+      the control until the app exits. This is the case the project rules single out. Guard the
+      subscription with a flag.
+
+- [ ] **`Text` includes hidden text** — `FormattedTextBox.cs:1249` reads with
+      `TextGetOptions.None`, and hidden runs are only dropped by `NoHidden`. The property
+      therefore returns custom emoji metadata (`<emoji>;00000000ABCDEF01`) and hyperlink URLs
+      interleaved with the visible text. Its one consumer is `ChatView.CheckMessageBoxEmpty`,
+      which feeds it to `getLinkPreview`. Carrying the hyperlink URLs may well be deliberate —
+      it's the only way a text-url entity gets a preview — but the emoji metadata isn't.
+      Decide which, then either switch to `NoHidden` or write down why not.
+
+## Performance
+
+- [ ] **`DateTime.Now` twice per keystroke** — `ChatTextBox.cs:336` and `:339`, in the typing
+      indicator. `Logger.cs` already documents that `Now` is expensive next to `UtcNow` (it
+      resolves the time zone on every call). `_lastKeystroke` is only ever compared against
+      itself, so `UtcNow` is a straight swap.
+
+- [ ] **`LoadQuickReplyShortcuts` is sent per keystroke while typing a command** —
+      `ChatTextBox.cs:669`. `GetCommands` runs for every new query that doesn't match the
+      previous `AutocompleteList`, so typing `/start` can send six identical requests. The
+      `// TODO: is this actually needed?` sitting on the line is the same question — answer it,
+      and if it is needed, send it once per chat rather than once per character.
+
+- [ ] **The whole draft is materialized on every selection change** — `ChatTextBox.cs:391`.
+      This runs on every keystroke *and* every caret move. Only three paths need the string: the
+      inline-bot search (already skipped when there's no inline bot), the sticker branch of
+      `TryGetAutocomplete`, and `SearchByInlineBot` — which reads only up to the first space and
+      only matters when the message starts with `@`, something a one-character range read can
+      answer. Defer materializing it to those branches.
+
+- [ ] **`UsernameCollection` re-queries `GetTopChats` for every autocomplete query** —
+      `ChatTextBox.cs:719` and `:736`. Two round trips per `@` query; the top-chat lists barely
+      move within a session.
+
+- [ ] **A `CancellationTokenSource` per keystroke on the autocomplete path** —
+      `ChatTextBox.cs:365`, `:429`, `:558`. Each assignment drops the previous instance without
+      disposing it unless it happened to go through `CancelInlineBotToken`.
+
+## Cleanup
+
+- [ ] **`ChatTextBox` redeclares `ContentElement`** — `ChatTextBox.cs:45` shadows
+      `FormattedTextBox.cs:74`. Two fields and two `GetTemplateChild` calls for one template
+      part. Make the base field `protected` and drop the derived one.
+
+- [ ] **`UpdatePadding` is an unfinished experiment** — `FormattedTextBox.cs:213`-`:259`, marked
+      as one, reachable only from the `FooterSize` setter. The scale-factor fallback its comment
+      describes doesn't exist: `:228` assigns `1.0` and the next line overwrites it inside a bare
+      block that dereferences `XamlRoot` unguarded. Finish it or delete it.
+
+- [ ] **`HandwritingView.Unloaded` is subscribed with a local function** —
+      `FormattedTextBox.cs:412`-`:415`. It does unsubscribe itself, and delegate equality makes
+      that work, but it's the pattern the project rules forbid, and if `TryClose()` doesn't raise
+      `Unloaded` the handler stays subscribed with its captured state.
+
+- [ ] **`ContentElement.ViewChanged` is subscribed on every `OnApplyTemplate`** —
+      `FormattedTextBox.cs:271`, never removed, so a second template application doubles the
+      handler. The same method null-checks `Blocks` and `CustomEmoji` but not `ContentElement`.
+
+- [ ] **Check that `MergeParagraphs` always advances** — `FormattedTextBox.cs:1961`. The `while`
+      body does nothing when `searchRange.StartPosition <= range.StartPosition`, and nothing else
+      moves the range, so termination rests entirely on `FindText` continuing past its own match.
+
+## Looked at, deliberately left alone
+
+- `IsLongerThanMaxLength` returns `exceeding = length` when `IsReadOnly`
+  (`FormattedTextBox.cs:1850`), so callers that truncate to `exceeding` insert the *whole* string
+  instead of nothing — a paste into a read-only box would go through. Nothing sets `IsReadOnly`
+  on a `FormattedTextBox` today, so it's unreachable; fix it if the property ever gets used.
+
+- `IsCustomEmoji` mutates the range it is handed (`range.EndPosition -= ...`) and its callers
+  depend on that. It reads as a query and isn't one, but the behaviour is load-bearing.
+
+## Landed already
+
+Fixed while investigating; listed so the file reads as the current state:
+
+- The three per-keystroke document walks (`UpdateFormat`, `UpdateBlocks`, `UpdateCustomEmoji`)
+  now start from one whole-document uniformity probe, and the ranges they walk with are reused
+  rather than reallocated.
+- `UpdateBlocks` removed stale blockquote decorations with an index loop that skipped every
+  other element.
+- `CustomEmojiCanvas.UpdateEntities` recreated every `CustomEmojiFileSource` on every keystroke,
+  each one firing a `getCustomEmojiStickers` request from its constructor.
+- `OnCharacterReceived` allocated a byte array, a string and a closure per character typed.
+- `SearchInlineBotResults` split the entire message on spaces per keystroke.
+- `ChatView` asked TDLib for a link preview on every keystroke, whatever the text.
+- `IsValidUrl` handed the whole string to the entity parser before checking it could be a URL.
+- Pasting applied entities through one COM range per entity, and inserted without batching
+  display updates.
+- Pasting a URL over a selection went through `SetText`, and turned an already-linked selection
+  into the label of a link to the new URL.
+- The composer's font family led with a packaged emoji font, which cost about a millisecond per
+  word to resolve — a 17,000 character paste froze the UI for 2.7 seconds. See
+  `Telegram/Common/Theme.cs`.

--- a/sendfiles-popup-todo.md
+++ b/sendfiles-popup-todo.md
@@ -138,6 +138,30 @@ Known edge: if every file fails to probe, the popup appears briefly and then clo
 before it never appeared. The alternative is waiting for the first result, which is the stall this
 task removed.
 
+### Follow-up: one input shape (Fela's review)
+
+The first cut left the popup with a three-step construction protocol — build with an empty list, set
+`Validating`, call `Probe` from the caller's `Loaded` — driven by a `SendFilesAsync(items, files, …)`
+null-pair. Miss a step and you get a silently empty popup or an unguarded send, with nothing
+enforcing it. The two construction sites differ enough that this was a real trap: the edit path
+passes exactly one already-typed item, has no guard at all, and reads `popup.Items[0]` back the
+moment the popup closes.
+
+- [x] **2.7** `StorageMediaSource` (in `StorageMedia.cs`, so no `.csproj` entry) is now the single
+  thing the popup is given. `FromMedia` exposes everything through `Ready`; `FromFiles` leaves
+  `Ready` empty and delivers through `LoadAsync`. `Count` is known up front either way.
+
+The constructor seeds `Items` from `source.Ready` — so the edit path still has its item before the
+popup opens and `Items[0]` cannot throw — and the popup calls `LoadAsync` from its own `OnLoaded`,
+which is a no-op for a complete source. Callers can no longer forget it. `_expectedCount` comes from
+`source.Count` at construction rather than being patched in later, so the title is right from the
+first frame.
+
+The guard is a constructor argument instead of a settable property, and the up-front loop in
+`SendFilesAsync` runs over `source.Ready` — empty for files, so the last flavour check disappeared
+rather than moving. The edit path passes `null`, which is honest: that item's permissions were
+checked when it was first sent.
+
 ## Task 3 — Stop rebuilding the world on every interaction
 
 `UpdatePanel()` is called from roughly a dozen places — mute, TTL, crop, spoiler toggle, item

--- a/sendfiles-popup-todo.md
+++ b/sendfiles-popup-todo.md
@@ -47,27 +47,96 @@ drops the album's entries, and `OnUnloaded` clears everything. A decode that com
 one is dropped rather than cached — `DecodeAsync` only writes to the cache if its own `_inflight`
 entry is still there, which is also what stops a pre-crop image from landing after `Invalidate`.
 
-Caveat on 1.3: neither `BitmapImage.SetSourceAsync` nor the video path accepts a cancellation token,
-so a decode already running still runs to completion. Only the retention is fixed, not the CPU.
-Truly cancelling it would need a token threaded through `ImageHelper` and `VideoAnimation`.
+Caveat on 1.3: no decode already under way is stopped, so only the retention is fixed, not the CPU.
+See the cancellation survey below for what it would take — the first estimate here was too
+pessimistic.
 
-## Task 2 — Show the popup first, probe files after
+### Cancellation survey (1.3 follow-up)
 
-- [ ] **2.1** `StorageMedia.CreateAsync(IEnumerable)` is a serial `foreach`, and every iteration is
+Two levers already exist and neither is used.
+
+**`.AsTask(token)`** covers every WinRT stage: `StorageFile.OpenReadAsync`,
+`BitmapImage.SetSourceAsync`, `BitmapDecoder.CreateAsync`, `GetSoftwareBitmapAsync`,
+`SoftwareBitmapSource.SetBitmapAsync`. That is the whole photo path and the whole cropped-photo
+path. The repo calls `AsTask()` in three places and never with a token.
+
+**`VideoAnimation.Stop()`** is projected to C# (`VideoAnimation.idl`) and the `stopped` flag it sets
+is already checked in all three hot spots — `readCallback`, `seekCallback`, and the
+`while (!stopped && triesCount > 0)` loop in `RenderSync` (`VideoAnimation.cpp`). Nothing in the app
+has ever called it. `ImageHelper`'s two video branches build the animation inside a `Task.Run` and
+never expose it, so reaching `Stop()` is a C#-side restructure, not a native one.
+
+The one genuinely uncancellable stage is the probe. `VideoAnimation::LoadFromFile` constructs the
+instance and only then runs `avformat_open_input` and `avformat_find_stream_info`, so the caller has
+no handle while the expensive part runs. The fix is `fmt_ctx->interrupt_callback` pointed at the same
+`stopped` flag before `avformat_open_input`; ffmpeg polls it through open, probe, read and seek.
+That one needs a `Telegram.Native` rebuild.
+
+Two latent bugs in the existing `Stop()` path, never exercised because nothing calls it:
+
+- [ ] **1.4** `stopped` is a plain `bool`, written by `Stop()` without taking `m_lock` and read from
+  the decode thread. Should be `std::atomic<bool>`.
+- [ ] **1.5** `readCallback` returns `0` when stopped rather than `AVERROR_EOF`. ffmpeg reads `0` as
+  "no bytes this call" and can spin instead of aborting.
+
+Cost × rate says this does not pay for thumbnails alone — closing the popup mid-decode is rare. It
+pays as part of Task 2, whose cancel affordance needs the same plumbing, and whose probe pipeline is
+what justifies the native `interrupt_callback` work.
+
+## Task 2 — Show the popup first, probe files after — **done**
+
+- [x] **2.1** `StorageMedia.CreateAsync(IEnumerable)` is a serial `foreach`, and every iteration is
   expensive: a `GetBasicPropertiesAsync` RPC per file, plus `BitmapDecoder.CreateAsync` for photos
   and a full `VideoAnimation.LoadFromFile` (ffmpeg open + probe) for video and audio. All of it is
   awaited before `new SendFilesPopup` is reached, with no feedback and no cancel.
-- [ ] **2.2** The whole loop sits in **one** try/catch, so a single throwing file silently discards
+- [x] **2.2** The whole loop sits in **one** try/catch, so a single throwing file silently discards
   every remaining file in the drop. Needs to be per-file.
 - [ ] **2.3** Each media item is opened and probed twice: `StoragePhoto.CreateAsync` decodes for
   dimensions and the preview opens the file again; `StorageVideo.CreateAsync` builds a
   `VideoAnimation` for dimensions and `GetPreviewBitmapAsync` builds a second one for one frame.
-- [ ] **2.4** (2a) Pipeline the probes with bounded concurrency and add a busy/cancel affordance,
-  keeping the current "resolve, then show" shape.
-- [ ] **2.5** (2b) Open the popup immediately with placeholder rows (name + size) and upgrade them
-  in place as probing completes. Needs the popup to tolerate a not-yet-typed item, which touches
-  `IsMediaAllowed`, `TitleText`, the media/files toggle, album layout, and the permission/size
-  checks currently done up front in `SendFileExecute`.
+  *Left open — a separate change to the `Storage*` factories, not to the popup flow.*
+- [x] **2.4** Pipeline the probes with bounded concurrency.
+- [x] **2.5** Open the popup first and append items as they resolve. **No placeholder rows** — Fela's
+  call: in the vast majority of cases probing is instant, so a row that exists only to be replaced
+  buys nothing and costs the popup having to tolerate a not-yet-typed item everywhere.
+- [ ] **2.6** `Add_Click` and the popup's own `HandlePackageAsync` still call the blocking
+  `CreateAsync`, so dropping onto an already-open popup stalls exactly the way the initial drop used
+  to. They need the same pipeline, but `Probe` is single-shot and owns `_probeCount`, so it has to
+  be generalised for a second batch first.
+
+**How it landed.** `StorageMedia.ProbeAsync` types files concurrently — capped at
+`Math.Clamp(Environment.ProcessorCount, 2, 8)` so a large drop cannot open hundreds of decoders —
+and reports each result through a callback as it lands, with the file's original index. Callbacks
+arrive on the UI thread, since every await in the chain captures the caller's context.
+
+`ComposeViewModel.SendFileExecute` no longer probes. Both overloads now funnel into `SendFilesAsync`,
+which takes either already-typed items or raw files; with files it builds the popup empty and starts
+`Probe` from the `Loaded` handler. That hook matters: `OpenAsync` queues behind any other dialog and
+only creates its closing task once it reaches the front, so a `Hide` from a probe result that
+resolved earlier would have had nothing to close.
+
+Results are buffered and flushed on a low-priority dispatch, so everything resolving within one UI
+turn is appended by a single `AddRange` — one `CollectionChanged`, one `UpdateView`, one
+`UpdatePanel`. Each batch is sorted by original index, so the picked order survives whenever
+probing is fast enough to land in one flush; across batches items appear as they resolve.
+
+The guard moved rather than disappeared. `SendFilesAsync` keeps one `Validating` function holding
+the original messages: run as a loop up front for already-typed items, handed to the popup as a
+callback for probed ones. The first failure cancels probing and closes the popup, and the error is
+raised after `OpenAsync` returns — which is also where the caption is already restored.
+
+Three smaller consequences:
+
+- `TitleText` counts `Math.Max(Items.Count, _probeCount)` while probing, so it shows the drop's real
+  size instead of ticking up, and stays on the Files declension until types are known.
+- The requested media/files mode cannot be resolved against an empty list, so `UpdateView` settles it
+  as the first items arrive — until the user picks a mode themselves, which wins from then on.
+- Send is disabled while probing, and `Accept` returns early, since sending half a drop would
+  silently discard the rest.
+
+Known edge: if every file fails to probe, the popup appears briefly and then closes itself, where
+before it never appeared. The alternative is waiting for the first result, which is the stall this
+task removed.
 
 ## Task 3 — Stop rebuilding the world on every interaction
 

--- a/sendfiles-popup-todo.md
+++ b/sendfiles-popup-todo.md
@@ -1,0 +1,121 @@
+# SendFilesPopup — improvement plan
+
+Findings from a read-through of `Telegram/Views/Popups/SendFilesPopup.xaml{,.cs}`, the five
+`Telegram/Entities/Storage*.cs` entities, both album-grouping implementations, and the entry
+points that reach the popup (`ComposeViewModel.SendFileExecute`, `DialogViewModel.HandlePackageAsync`,
+`SendMessagesView`, `Extensions.PickSingleMediaAsync`).
+
+Tasks are ordered so each one can land and be reviewed on its own. Check an item off in the
+same commit as its fix.
+
+---
+
+## Task 1 — Move the thumbnail lifecycle to the ListView — **done**
+
+- [x] **1.1** `StorageMedia._preview` is assigned in four places and released in none. Nothing
+  ever sets it back to null, so a decoded thumbnail lives as long as the model does — and the
+  model outlives the popup, because `ComposeViewModel.SendFileExecute` holds the `items` list
+  across the whole send loop.
+
+  Per item, never reclaimed:
+  - photo → `BitmapImage` at `DecodePixelWidth = 300` **logical**, so ~450px at 150% scale ≈ 1 MB
+  - video → `WriteableBitmap` at 600 min-side ≈ 2 MB, held as a live pixel buffer
+  - cropped → `SoftwareBitmapSource` at 600
+
+  40 dropped videos ≈ 75 MB retained past the popup.
+
+  The only consumer is the `ImageBrush` in `MediaItemTemplate` (`SendFilesPopup.xaml`), reached
+  only through `StorageAlbumPanel` — so the move is self-contained.
+
+- [x] **1.2** Thundering herd: `Refresh()` is `async void` fired from the `Preview` getter with no
+  in-flight guard. `_preview` stays null across the await, so every getter hit before it completes
+  starts another decode of the same file. `StorageAlbumPanel.UpdateMessage` clears and rebuilds
+  every button on each `UpdatePanel()`, re-evaluating every `x:Bind Preview`.
+
+- [x] **1.3** No cancellation. Closing the popup mid-decode leaves every outstanding decode running.
+
+**How it landed.** `Preview`/`Refresh`/`RefreshAsync` are gone from `StorageMedia`, along with the
+`StorageVideo.Refresh` override — the `LoadPreview()` it re-ran after a crop only feeds the
+compression fields that Task 5 shows are dead, and the constructor still runs it. The decode moved
+verbatim into `StorageThumbnailCache` at the foot of `SendFilesPopup.xaml.cs`, which keys two
+dictionaries off the model: the decoded source, and the in-flight `Task` that coalesces concurrent
+requests (1.2). The `ImageBrush` in `MediaItemTemplate` no longer binds; `UpdateTemplate` pushes into
+it, and `LoadThumbnail` re-checks `root.DataContext` before applying a late result.
+
+Eviction has two triggers: `OnContainerContentChanging` with `InRecycleQueue` nulls the brushes and
+drops the album's entries, and `OnUnloaded` clears everything. A decode that completes after either
+one is dropped rather than cached — `DecodeAsync` only writes to the cache if its own `_inflight`
+entry is still there, which is also what stops a pre-crop image from landing after `Invalidate`.
+
+Caveat on 1.3: neither `BitmapImage.SetSourceAsync` nor the video path accepts a cancellation token,
+so a decode already running still runs to completion. Only the retention is fixed, not the CPU.
+Truly cancelling it would need a token threaded through `ImageHelper` and `VideoAnimation`.
+
+## Task 2 — Show the popup first, probe files after
+
+- [ ] **2.1** `StorageMedia.CreateAsync(IEnumerable)` is a serial `foreach`, and every iteration is
+  expensive: a `GetBasicPropertiesAsync` RPC per file, plus `BitmapDecoder.CreateAsync` for photos
+  and a full `VideoAnimation.LoadFromFile` (ffmpeg open + probe) for video and audio. All of it is
+  awaited before `new SendFilesPopup` is reached, with no feedback and no cancel.
+- [ ] **2.2** The whole loop sits in **one** try/catch, so a single throwing file silently discards
+  every remaining file in the drop. Needs to be per-file.
+- [ ] **2.3** Each media item is opened and probed twice: `StoragePhoto.CreateAsync` decodes for
+  dimensions and the preview opens the file again; `StorageVideo.CreateAsync` builds a
+  `VideoAnimation` for dimensions and `GetPreviewBitmapAsync` builds a second one for one frame.
+- [ ] **2.4** (2a) Pipeline the probes with bounded concurrency and add a busy/cancel affordance,
+  keeping the current "resolve, then show" shape.
+- [ ] **2.5** (2b) Open the popup immediately with placeholder rows (name + size) and upgrade them
+  in place as probing completes. Needs the popup to tolerate a not-yet-typed item, which touches
+  `IsMediaAllowed`, `TitleText`, the media/files toggle, album layout, and the permission/size
+  checks currently done up front in `SendFileExecute`.
+
+## Task 3 — Stop rebuilding the world on every interaction
+
+`UpdatePanel()` is called from roughly a dozen places — mute, TTL, crop, spoiler toggle, item
+add/remove, even `SendFilesAlbumPanel_Loading`.
+
+- [ ] **3.1** `UpdateCollection()` rebuilds the whole view list and, in files-mode, allocates a fresh
+  `StorageDocument` wrapper for every item. New instances every time, so `CompareItems` falls back
+  to path comparison and the diff churns.
+- [ ] **3.2** `await ScrollingHost.UpdateLayoutAsync()` forces a synchronous layout pass per call.
+- [ ] **3.3** The container walk builds a **new** `GaussianBlurEffect`, effect factory,
+  `CompositionEffectBrush`, backdrop brush and `SpriteVisual` per media item per call. Effect
+  factories are expensive and meant to be created once and shared. Same for `new ParticlesImageSource()`.
+- [ ] **3.4** `StorageAlbumPanel.UpdateMessage` does `Children.Clear()` and a `new Button` with a
+  fresh `Click` subscription per media, on every container realization.
+
+## Task 4 — One grouping algorithm, not two
+
+- [ ] **4.1** `SendFilesPopup.UpdateCollection` and `ComposeViewModel.GetItemsView` both group into
+  `StorageAlbum`s and disagree. `GetItemsView` splits on muted video, splits `.webp` documents (the
+  server-side workaround), and tracks `albumType` so media/audio/documents never mix; `UpdateCollection`
+  does none of that. The grouping previewed is not the grouping sent — and `Send_ContextRequested`
+  already calls `GetItemsView`, comparing against a different grouping than the one on screen.
+
+## Task 5 — Dead code in StorageVideo
+
+- [ ] **5.1** `Compression`, `MaxCompression`, `CanCompress`, `GetEncodingAsync`, `ToString()`,
+  `UpdateWidthHeightBitrateForCompression` and the `original*`/`videoDuration`/`rotationValue` fields
+  have no consumer outside the file — only `GetGeneration()` is live. They cannot work either: every
+  `original*` field is assigned only in commented-out lines, so they are permanently 0,
+  `MaxCompression` is always 1, `CanCompress` always false, and `ToString()` divides by zero.
+
+## Task 6 — Smaller items
+
+- [ ] **6.1** `FileItem_PointerEntered`: `storage` is assigned and never used, and `content` is the
+  template root rather than the container, so `ItemFromContainer` returns null anyway.
+- [ ] **6.2** `OnContainerContentChanging`: the `root is AspectView` branch is unreachable. The
+  selector only returns `FileItemTemplate` or `AlbumTemplate`, both `Grid`-rooted; `MediaItemTemplate`
+  is only ever a `Button.ContentTemplate` inside `StorageAlbumPanel`.
+- [ ] **6.3** Six `root.FindName(...)` namescope walks per container realization, plus two `Substring`
+  allocations to split the filename extension.
+- [ ] **6.4** The constructor builds a log string with a `string.Format` per item and repeated
+  `StringBuilder.Prepend` (quadratic in characters) before the popup shows. `Logger.Info` is
+  unconditional, so this always runs.
+- [ ] **6.5** `HandlePackageAsync`, `Add_Click` and `StorageMedia.CreateAsync` all `catch { }` silently.
+- [ ] **6.6** `Add_Click` and drop-into-popup bypass the permission and file-size checks that
+  `SendFileExecute` applies to the initial set, and do not dedupe against files already listed.
+- [ ] **6.7** `StorageMedia.CreateAsync` uses `OfType<StorageFile>()`, so dropping a folder does
+  nothing with no feedback.
+- [ ] **6.8** `IsMediaAllowed` runs up to three LINQ passes and `TitleText` up to three more over
+  `Items`, on every `UpdateView()`.

--- a/sendfiles-popup-todo.md
+++ b/sendfiles-popup-todo.md
@@ -162,6 +162,31 @@ The guard is a constructor argument instead of a settable property, and the up-f
 rather than moving. The edit path passes `null`, which is honest: that item's permissions were
 checked when it was first sent.
 
+## Task 2b — Albums that grow instead of being rebuilt
+
+Pulled forward from Task 3, because incremental arrival made it much worse: a drop of 20 photos
+fills album 0 a batch at a time, then album 1, and each batch rebuilt the album from nothing.
+
+- [x] **2b.1** `CompareItems` compared album *contents*, so an album that gained a photo was a
+  different item and the diff removed and re-inserted it. `ChatDiffHandler` shows the intended
+  contract — `CompareItems` is identity, `UpdateItem` carries content over. `StorageAlbum` now has
+  an `Ordinal` (its position among the albums of a view) and that is what is compared.
+- [x] **2b.2** The remove/insert recycled the container, and the Task 1 recycle handler released the
+  album's thumbnails on the way out — so **every batch re-decoded every thumbnail in the album**.
+  This was the expensive half, not the remeasure. Fixed by 2b.1: the container survives.
+- [x] **2b.3** `UpdateItem` now moves the new media onto the retained album instance and refreshes
+  the realized panel, rather than only invalidating layout — which had left the panel showing the
+  old contents whenever it did fire.
+- [x] **2b.4** `StorageAlbumPanel.UpdateMessage` reuses its children instead of `Children.Clear()`
+  plus a fresh `Button` per item. Growth now only appends, and a surviving item keeps the thumbnail
+  it already had. (This was Task 3.4.)
+- [x] **2b.5** `Remove_Click` invalidates the removed item's thumbnail, since a container recycling
+  underneath it no longer does.
+
+Also restored: the constructor's `Logger.Info` line names each item's width and height, which is
+what album layout bugs get diagnosed from. On the drop path nothing is typed yet, so it logs the
+pending count there and logs the dimensions again once everything has landed.
+
 ## Task 3 — Stop rebuilding the world on every interaction
 
 `UpdatePanel()` is called from roughly a dozen places — mute, TTL, crop, spoiler toggle, item
@@ -174,8 +199,8 @@ add/remove, even `SendFilesAlbumPanel_Loading`.
 - [ ] **3.3** The container walk builds a **new** `GaussianBlurEffect`, effect factory,
   `CompositionEffectBrush`, backdrop brush and `SpriteVisual` per media item per call. Effect
   factories are expensive and meant to be created once and shared. Same for `new ParticlesImageSource()`.
-- [ ] **3.4** `StorageAlbumPanel.UpdateMessage` does `Children.Clear()` and a `new Button` with a
-  fresh `Click` subscription per media, on every container realization.
+- [x] **3.4** `StorageAlbumPanel.UpdateMessage` does `Children.Clear()` and a `new Button` with a
+  fresh `Click` subscription per media, on every container realization. *Done as 2b.4.*
 
 ## Task 4 — One grouping algorithm, not two
 

--- a/voip-review.md
+++ b/voip-review.md
@@ -312,7 +312,7 @@ All five landed on `develop` as `4eda2af98..c4bbb77f6`, one fix per commit, buil
 
   A comment on the event fields records why there is no lock, so it does not come back.
 
-- [ ] **`m_impl` is not guarded** — reachable in `VoipGroupManager`, not in `VoipManager`
+- [x] **`m_impl` is not guarded** — reachable in `VoipGroupManager`, not in `VoipManager`
 
   Every `if (m_impl)` is TOCTOU against `Stop()`'s `reset()`. Traced properly rather than
   assumed, and the two managers turn out to differ:
@@ -330,15 +330,25 @@ All five landed on `develop` as `4eda2af98..c4bbb77f6`, one fix per commit, buil
   path that reaches managed code. The callbacks never touch `m_impl` — only inbound calls
   do, and those go to tgcalls, not to C#. That reasoning was wrong.
 
-  Three ways out, in the order I would rank them:
+  **Fixed the first way**: `VoipGroupCall` now takes the `_managerLock` it already
+  declared — the field existed but guarded nothing except a block of commented-out code
+  copied from `VoipCall`. Held around every call that reaches the tgcalls instance, and
+  around the teardown in `Dispose` and `EndScreenSharing`.
 
-  1. Give `VoipGroupCall` the `_managerLock` its sibling already has. Symmetric, keeps the
-     native contract simple, and is the pattern the codebase already uses.
-  2. A dedicated native mutex around `m_impl`. Watch the ordering: `Stop()` holding it
-     while it stops the loopback would deadlock against `AddExternalAudioSamples` coming
-     from the capture thread, so the loopback has to be stopped first.
-  3. An atomic `shared_ptr` swap, so a late caller keeps the instance alive instead of
-     blocking. No deadlock, but it allows calls on an instance that has already stopped.
+  Deliberately left outside the lock: the `IsMuted` and `IsNoiseSuppressionEnabled`
+  getters, which read a native field rather than touching `m_impl`, and the null checks
+  that only decide whether to start something.
+
+  Two places needed more than a wrapper. The `EmitJoinPayload` continuations in `Rejoin`
+  and `RejoinScreenSharing` run after awaits, so they take the lock again where they call
+  in — C# cannot hold one across an await. And `UpdateParticipant` dereferenced `_manager`
+  unconditionally on TDLib's update thread, which was a null reference waiting to happen
+  quite apart from the race.
+
+  The two alternatives, if this ever proves too coarse: a dedicated native mutex around
+  `m_impl` (watch the ordering — `Stop()` holding it while stopping the loopback would
+  deadlock against `AddExternalAudioSamples`), or an atomic `shared_ptr` swap so a late
+  caller keeps the instance alive instead of blocking.
 
 - [x] **No destructor on either manager**
 
@@ -519,8 +529,6 @@ what he decided and the three things still genuinely open.
 
 **Still open:**
 
-- **`m_impl` unguarded in `VoipGroupManager`** — see P2 above. Now known to be a real
-  use-after-free rather than a theoretical one, and the three fixes are ranked there.
 - The unmanaged buffer between the WASAPI and WebRTC clocks — worth logging the
   steady-state depth over a long share before designing anything.
 

--- a/voip-review.md
+++ b/voip-review.md
@@ -180,7 +180,7 @@ All five landed on `develop` as `4eda2af98..c4bbb77f6`, one fix per commit, buil
   `hresult_out_of_bounds` out of `Start`. One `GetMany` into the shared array, which clamps
   to what is there, and the redundant copy through a stack `std::array` is gone.
 
-- [ ] **`RequestMediaChannelDescriptionTaskImpl::done` hardcodes `type = Audio`** —
+- [x] **DECIDED, kept as is** — **`RequestMediaChannelDescriptionTaskImpl::done` hardcodes `type = Audio`** —
   `VoipGroupManager.h:140` — **not a bug; decide whether to keep it that way**
 
   `VoipMediaChannelDescription` carries only `AudioSource` and `UserId`
@@ -228,7 +228,7 @@ All five landed on `develop` as `4eda2af98..c4bbb77f6`, one fix per commit, buil
   Fixed by reordering — the clear only exists to break the native to managed cycle, which
   works just as well after the instance is gone. Not compiled; C# side, statement reorder.
 
-- [ ] **`DecryptData` ignores the data channel** — `VoipGroupCall.cs:421`
+- [x] **DECIDED, kept as is** — **`DecryptData` ignores the data channel** — `VoipGroupCall.cs:421`
 
   It always passes `new GroupCallDataChannelMain()`, while `EncryptData` distinguishes
   screen sharing from main. Work out whether decrypting a remote screencast needs the
@@ -352,7 +352,7 @@ All five landed on `develop` as `4eda2af98..c4bbb77f6`, one fix per commit, buil
   in flight is serving the live call, and the second descriptor would be for the same one.
   Completes the Start/Stop lifecycle work the destructors began.
 
-- [ ] **Verify `requestMediaChannelDescriptions` gating on `IsConference`** —
+- [x] **DECIDED, confirmed correct** — **`requestMediaChannelDescriptions` gating on `IsConference`** —
   `VoipGroupManager.cpp:69-83`
 
   The C# handler is subscribed unconditionally (`VoipGroupCall.cs:151`, `:296`, `:351`).
@@ -375,10 +375,33 @@ All five landed on `develop` as `4eda2af98..c4bbb77f6`, one fix per commit, buil
   even sees the frame. Removing them means changing the delegate signature in the IDL to
   pass a buffer the managed side writes into. → below.
 
-- [ ] **The E2E delegate signature forces two copies per frame** — `VoipGroupManager.idl:15-16`
+- [x] **The E2E delegate signature forces two copies per frame** — `VoipGroupManager.idl:15-16`
 
-  `IVector<byte>` in and out, on a per-frame path, with a `ToArray()` on the managed side
-  on top. Worth reshaping once someone is willing to touch the IDL and both call sites.
+  Reshaped to `UInt8[]` in and out, since every byte ends up base64 encoded into TDLib
+  JSON and an `IVector` was the wrong shape at both ends. The projection copies once each
+  way and the managed side hands the array straight to TDLib — two COM objects, two RCWs
+  and the `ToArray()` are gone. `ReceiveSignalingData` and the signaling callback got the
+  same treatment; the latter stopped being an event at the same time, since it only ever
+  had one listener, which deleted `SignalingDataEmittedEventArgs` outright.
+
+  It also exposed a live bug in the managed half — see the transform semaphore below.
+
+- [x] **The frame transform waited on a shared semaphore** — `VoipGroupCall.cs:403-432`
+
+  Found while reshaping the delegates above. `new Semaphore(0, 1)` was shared across every
+  invocation, but tgcalls builds one frame transformer per simulcast layer and one per
+  incoming channel, each on its own thread — so a second `Release()` before the first
+  `Wait()` throws `SemaphoreFullException` on TDLib's callback thread, and a waiter can be
+  woken by another frame's answer and return a null result, dropping a good frame.
+
+  **My own P2 change is what exposed it.** Holding `m_lock` across the managed delegate
+  used to serialise every encrypt and decrypt through one mutex, which accidentally made
+  the shared semaphore safe. Taking that lock off the callback path was right, but I did
+  not check what depended on the serialisation.
+
+  Each transform now waits on its own `ManualResetEventSlim`, with a 5s timeout so a stuck
+  TDLib drops the frame rather than wedging a media thread. Not disposed on purpose — a
+  late answer would still `Set()` it.
 
 - [x] **`OnAudioLevelsUpdated` allocates per update** — `VoipGroupManager.cpp:313-329`
 
@@ -439,7 +462,7 @@ worth attention is the coupling, not the mechanism:
   resynchronisation. It is also the reason screen audio can drift out of sync with video
   over a long share. Worth measuring the steady-state depth before deciding anything.
 
-- [ ] **Screencast audio is mono-only by construction** — `options.num_channels = 1`
+- [ ] **DEFERRED to an upstream pass** — **Screencast audio is mono-only by construction** — `options.num_channels = 1`
 
   Fine for speech, lossy for music or a game. Widening it means the descriptor, the
   capture format and `ExternalAudioRecorder` all have to agree, so it is a tgcalls change
@@ -463,7 +486,7 @@ worth attention is the coupling, not the mechanism:
       mistake as the P1 video-sink item: the group `VideoSinkImpl::OnFrame` prunes expired
       weak_ptrs exactly like the 1:1 one (`GroupInstanceCustomImpl.cpp:662-665`), so
       releasing the sink *is* the removal. Left open only as a reminder of the shape.
-- [ ] `enableAEC`/`enableNS`/`enableAGC` hard-coded `true` in 1:1 calls
+- [x] **DECIDED, kept as is** — `enableAEC`/`enableNS`/`enableAGC` hard-coded `true` in 1:1 calls
       (`VoipManager.cpp:46-48`) while group calls honour the `IsNoiseSuppressionEnabled`
       setting. **Needs your call** — it is a product decision, not a defect.
 - [x] `Protocol()` sorted versions lexicographically. **Filed as latent; it was live.**


### PR DESCRIPTION
Pasting 17,000 characters into the composer froze the UI for about ten seconds. It doesn't any more. Nine scoped commits, each independently revertable.

## The one that mattered

`EmojiTextThemeFontFamily` was built emoji-first, so every text input resolved against `ms-appx:///Assets/Emoji/*.ttf` before falling back to the text font. The editor resolves the font once per run and breaks runs at every space, which cost roughly a millisecond per word — 2.7 seconds for that paste.

It was measured identical through `SetText` and through RichEdit's own paste, and identical for one line or for hundreds, which is what ruled out the insertion path and pointed at layout. A plain `RichEditBox` pastes the same text instantly; giving it only this `FontFamily` makes it slow.

Leading with the text font costs the emojis whose base character it already covers — keycaps, `©`, `™`, `▶` — rendering as plain glyphs. **That is confined to input controls.** Message bubbles render from `XamlAutoFontFamily`, untouched, so what gets sent and what gets displayed are unaffected. This trade is the one thing here worth a second opinion.

Seven text inputs were affected in total: three used the resource directly, and four more led with `ContentControlThemeFontFamily`, which is emoji-first as well — including the stories composer and every search box using `NoDeleteTextBoxStyle`.

## The rest

Per keystroke, the composer also: walked the whole document three times (and character format runs break at every space, so one of those was O(words) per character typed); recreated a `CustomEmojiFileSource` for every emoji, each firing `getCustomEmojiStickers` from its constructor; sent `getLinkPreview` to TDLib whatever the text; split the entire message on spaces to look at its first word; and allocated a byte array, a string and a closure to check whether the character typed ends an emoticon.

Two defects turned up on the way: `UpdateBlocks` removed stale blockquote decorations with an index loop that skipped every other element, and pasting a URL over a selection that was *already* a link turned the old URL into the label of a link pointing at the new one — entities aren't resolved until send, so nothing marks a typed URL as a link while composing.

`Profiler` is new: `[Conditional("INSTRUMENTATION")]` scoped timings, the shape that let the font finding be measured rather than guessed at. Four wrong diagnoses preceded it.

## Not done

`formatted-text-box-review.md` lists what the read-through found and didn't fix — 15 items with file and line. The two worth doing first both fail silently and permanently: `_updateLocked` is never cleared if `GetFormattedText` throws, and `_undoGroup` never returns to zero if anything between a `BeginUndoGroup`/`EndUndoGroup` pair does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)