### PR TITLE
Say something when voice recording cannot be engaged

### DIFF
--- a/Telegram/Controls/Chats/ChatRecordButton.cs
+++ b/Telegram/Controls/Chats/ChatRecordButton.cs
@@ -494,6 +494,13 @@ namespace Telegram.Controls.Chats
                     _recordingAudioVideo = false;
                     UpdateRecordingInterface();
                 }
+                else
+                {
+                    // The locked-mode send button lands here, and this is the only path that can
+                    // swallow it. Reported as "recorded with the locked button, can't be sent"
+                    // (#3262), which nobody has reproduced - so at least record that it happened.
+                    Logger.Warning("Locked recording released before the record runnable ran");
+                }
             }
         }
 
@@ -552,9 +559,12 @@ namespace Telegram.Controls.Chats
 
                 return true;
             }
-            catch
+            catch (Exception ex)
             {
-                // TODO: notify user
+                Logger.Error(ex);
+
+                ToastPopup.Show(this, string.Format(Strings.UnknownErrorCode, ex.Message),
+                    TeachingTipPlacementMode.TopLeft, dismissAfter: TimeSpan.FromSeconds(5));
                 return false;
             }
         }
@@ -571,6 +581,7 @@ namespace Telegram.Controls.Chats
             if (access.CurrentStatus == DeviceAccessStatus.Unspecified)
             {
                 MediaCapture capture = null;
+                Exception failure = null;
                 try
                 {
                     capture = new MediaCapture();
@@ -580,11 +591,27 @@ namespace Telegram.Controls.Chats
                         : StreamingCaptureMode.Audio;
                     await capture.InitializeAsync(settings);
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    failure = ex;
+                }
                 finally
                 {
                     capture?.Dispose();
                     capture = null;
+                }
+
+                // This press is consumed either way: it exists to raise the consent prompt, and
+                // recording starts on the next one. But an outright failure here - no capture
+                // device, one already in use, a driver that refuses - looks identical to that
+                // from the outside, and the button appears to do nothing at all, forever.
+                if (failure != null)
+                {
+                    Logger.Error(failure);
+
+                    this.BeginOnUIThread(() => ToastPopup.Show(this,
+                        string.Format(Strings.UnknownErrorCode, failure.Message),
+                        TeachingTipPlacementMode.TopLeft, dismissAfter: TimeSpan.FromSeconds(5)));
                 }
 
                 return false;


### PR DESCRIPTION
Closes #2093.

When `DeviceAccessInformation` reports `Unspecified`, `CheckDeviceAccessAsync` constructs a
`MediaCapture` to raise the consent prompt, and then:

```csharp
catch { }
finally { capture?.Dispose(); capture = null; }

return false;
```

Every exception is swallowed and `false` is returned regardless. That press is meant to be consumed
— the prompt goes up, recording starts on the next press — but an outright failure looks exactly
the same from outside: no message, no log entry, the button just does nothing. Forever, if the
cause is persistent. The reporter in #2093 has a USB audio interface and asked, in 2020, for an
error message so they could see what was wrong; the `catch` in `CheckAccessAsync` above it still
carried a literal `// TODO: notify user`.

Both paths now log the exception and show it. `Strings.UnknownErrorCode` ("Unknown error: {0}")
already exists, so no new resource is involved.

The success path is unchanged, including still returning `false` after a prompt so the next press
starts the recording.

## Also, one log line for #3262

`ChatRecordBar.ChatRecordLocked_Click` → `ChatRecordButton.Release()` is the locked-mode send, and
`Release()` does nothing unless `_calledRecordRunnable` is set. That is the only path which can
silently drop a locked-mode send, which is exactly what #3262 describes — recorded with the locked
button, cannot be sent. Nobody has reproduced it, so the `else` now records that it happened rather
than leaving the next report as bare as the last.

Worth knowing when reading that condition: `_hasRecordVideo` is `private readonly bool = true` and
never reassigned, so `!_hasRecordVideo` is dead and all four guards of the form
`if (!_hasRecordVideo || _calledRecordRunnable)` are really just `if (_calledRecordRunnable)`. I
have left them alone here — this is not the change to fold that into — but it does obscure the one
condition that matters.

## Verification

Not built or run. Verified by reading: braces balance, no new `using` is required (`ToastPopup`,
`TeachingTipPlacementMode`, `Strings`, `Logger` and `BeginOnUIThread` are all already used in this
file), and the file keeps its encoding and CRLF endings.
