### PR TITLE
Register the theme before reading its settings

### DIFF
--- a/Telegram/Common/Theme.cs
+++ b/Telegram/Common/Theme.cs
@@ -32,10 +32,16 @@ namespace Telegram.Common
         {
             _isPrimary = Current == null;
 
+            // Publish before anything that can fail. Current is the only handle the app has on
+            // the theme of this view, and it is dereferenced unguarded all over the message
+            // tree; leaving it null because a setting could not be read turns a lost preference
+            // into a crash. ApplicationData is not always reachable this early - share target
+            // activation is driven before the view is initialized.
+            Current ??= this;
+
             try
             {
                 _isolatedStore = ApplicationData.Current.LocalSettings.CreateContainer("Theme", ApplicationDataCreateDisposition.Always);
-                Current ??= this;
 
                 this.Add("MessageFontSize", GetValueOrDefault("MessageFontSize", 14d));
                 this.Add("ThreadStackLayout", new StackLayout());
@@ -43,7 +49,10 @@ namespace Telegram.Common
                 UpdateEmojiSet();
                 UpdateScrolls();
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+            }
 
             if (_isPrimary)
             {


### PR DESCRIPTION
`NullReferenceException` — "Object reference not set to an instance of an object."
Reported by crash telemetry on 12.9.1, all of it through `OnShareTargetActivated`.

```
   0  Telegram.Controls.Chats.ChatBackgroundControl.SyncBackgroundWithChatTheme
      Telegram/Controls/Chats/ChatBackgroundControl.cs:148
   1  Telegram.Controls.Chats.ChatBackgroundControl.Update
      Telegram/Controls/Chats/ChatBackgroundControl.cs:100
   2  Telegram.Views.Host.SharePage..ctor
      Telegram/Views/Host/SharePage.xaml.cs:33
   3  Telegram.App.CreateRootElement
      Telegram/App.xaml.cs:213
   4  Telegram.Navigation.BootStrapper.InitializeFrame
      Telegram/Navigation/BootStrapper.cs:678
   5  Telegram.Navigation.BootStrapper.InternalActivated
      Telegram/Navigation/BootStrapper.cs:239
   6  Telegram.Navigation.BootStrapper.OnShareTargetActivated
      Telegram/Navigation/BootStrapper.cs:214
```

## Cause

`ChatBackgroundControl.cs:148` is

```csharp
var chatBackground = _localFields ? _chatBackground : Theme.Current.ChatBackground;
```

on a freshly constructed control, so `_localFields` is `false` and **`Theme.Current` is
null**.

`Theme.Current` is thread-static and assigned in exactly one place, and that assignment
sat behind a call that can fail:

```csharp
try
{
    _isolatedStore = ApplicationData.Current.LocalSettings.CreateContainer("Theme", ApplicationDataCreateDisposition.Always);
    Current ??= this;
    ...
}
catch { }
```

If `CreateContainer` throws, the catch is silent and the theme never registers itself.
Everything downstream dereferences `Theme.Current` unguarded — `FormattedTextBlock`,
`MessageBubblePanel.MeasureOverride`, `MessageBubble`, `ChatBackgroundControl` — so the
view is left one dereference away from a crash with nothing to show for it.

The constructor did run. `SharePage.xaml` resolves `{StaticResource EmptyHyperlinkButtonStyle}`,
which lives in `CommonStyles.xaml`, a merged dictionary of `Application.Resources` that
comes *after* `<common:Theme />` in the merge list. `InitializeComponent` could not have
returned — and the crash is on the line after it — unless this view's application
resources, the theme among them, had been inflated. So the constructor reached the catch,
which means `CreateContainer` threw.

Why it throws there is the Windows-side half, and it is the same condition as #3320: the
share target view is driven before it is initialized. The log tail confirms it — the
"activated before OnWindowCreated" path that #3320 added fires on this crash. #3320 stopped
the app dying on `WindowContext.Current`; it moved the crash one frame later rather than
removing it, because `ApplicationData` is evidently not reliably reachable that early either.

## The fix

Assign `Current` before the `try`. It depends on nothing inside it, and losing a persisted
preference should not cost the view its theme — the instance is otherwise fully formed
(`Update(Light)`/`Update(Dark)` run after the catch and populate the light/dark settings).

The catch now logs. The whole diagnosis above rests on inferring which call threw, and an
empty catch is exactly what made that inference necessary; the next report should say so
outright.

No guard was added at `ChatBackgroundControl.cs:148`. The value was not legitimately null —
the theme exists and simply failed to publish itself — so guarding there would hide the
same fault at every other unguarded `Theme.Current` in the app.

## Build

Not built. A UWP/.NET Native build was not available here; `Theme.cs` was checked with
`CSharpSyntaxTree.ParseText(...).GetDiagnostics()`, which confirms it parses and nothing
more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
