### PR TITLE
Guard the geolocation access request in SendLocationPopup

### DIFF
--- a/Telegram/Views/Popups/SendLocationPopup.xaml.cs
+++ b/Telegram/Views/Popups/SendLocationPopup.xaml.cs
@@ -83,7 +83,18 @@ namespace Telegram.Views.Popups
 
         private async void FindLocation()
         {
-            var accessStatus = await Geolocator.RequestAccessAsync();
+            GeolocationAccessStatus accessStatus;
+
+            try
+            {
+                accessStatus = await Geolocator.RequestAccessAsync();
+            }
+            catch
+            {
+                // All the remote procedure calls must be wrapped in a try-catch block
+                accessStatus = GeolocationAccessStatus.Denied;
+            }
+
             if (accessStatus == GeolocationAccessStatus.Allowed)
             {
                 if (_geolocator == null)


### PR DESCRIPTION
Fixes a crash reported by crash telemetry on 12.9.1.

### Cause

`SendLocationPopup.FindLocation` opens with an unguarded `await Geolocator.RequestAccessAsync()`. That is a remote procedure call into the Windows Geolocation Service (`lfsvc`), and when that service is set to **Disabled** — a common change made by "debloat"/privacy scripts — the call legitimately fails with `ERROR_SERVICE_DISABLED` (`0x80070422`) instead of returning `GeolocationAccessStatus.Denied`.

The method is `async void`, so there is nothing between that throw and the unhandled-exception handler: opening the location picker on such a machine terminates the app.

The file already knows this is required. Both `GetGeopositionAsync()` calls a few lines below are wrapped, carrying the comment *"All the remote procedure calls must be wrapped in a try-catch block"*, and `LocationService.StartTrackingAsync` wraps its own `RequestAccessAsync` for the same reason. This one call site was simply missed.

The exception message in the report is the localized (ru) form of `ERROR_SERVICE_DISABLED`:

> Указанная служба не может быть запущена, так как отключена либо она сама, либо все связанные с ней устройства.

### Frames

```
   4  System::Runtime::CompilerServices::TaskAwaiter$1<...AccessStatus>.GetResult+0x10
   5  $0_Telegram::Views::Popups::SendLocationPopup::<FindLocation>d__15.MoveNext+0x80
      Telegram\Views\Popups\SendLocationPopup.xaml.cs
   6  System::Runtime::ExceptionServices::ExceptionDispatchInfo.Throw+0x21
   7  System::Runtime::CompilerServices::AsyncMethodBuilderCore::<>c.<ThrowAsync>b__7_0+0x1e
   8  System::Action$1<System::UInt64>.Invoke+0x28
   9  System::Threading::WinRTSynchronizationContext::Invoker.InvokeCore+0x33
  10  $8_System::Runtime::InteropServices::McgMarshal.ThrowOnExternalCallFailed+0x21
  11  $60___Interop::ComCallHelpers.Call+0xb8
  12  $60___Interop::ForwardComStubs.Stub_18<System.__Canon>+0x24
  13  $0_Telegram::WatchDog.OnUnhandledExceptionDetected+0x79
      Telegram\Common\WatchDog.cs:141
```

All 14 frames resolved. The log tail shows `ContentPopup.ShowQueuedAsync SendLocationPopup` followed 2.6 s later by the crash, with `HRESULT: 0x80070422` in the state header — i.e. it dies while the popup is coming up, not later during tracking.

**Caveat on the exact line:** the crash record's line number for frame 5 came back as a symbolicator placeholder, so the *method* is confirmed (`<FindLocation>d__15.MoveNext`) but the specific line is inferred. It is a safe inference: `FindLocation` contains exactly one `await` whose result is an access-status enum, and frame 4 is `TaskAwaiter<...AccessStatus>.GetResult`, which cannot be either of the `GetGeopositionAsync()` awaits (those return `Geoposition`, and both are inside `try`/`catch` anyway).

### The fix

Wrap `RequestAccessAsync()` the same way its neighbours in the same method are wrapped, and treat a throw as "access not allowed" — which is the truth on a machine whose location service is off. The popup then takes the path it already takes for a denial: the map shimmer stays and nothing else runs. No restructuring, no behaviour change on machines where the service works.

```diff
         private async void FindLocation()
         {
-            var accessStatus = await Geolocator.RequestAccessAsync();
+            GeolocationAccessStatus accessStatus;
+
+            try
+            {
+                accessStatus = await Geolocator.RequestAccessAsync();
+            }
+            catch
+            {
+                // All the remote procedure calls must be wrapped in a try-catch block
+                accessStatus = GeolocationAccessStatus.Denied;
+            }
+
             if (accessStatus == GeolocationAccessStatus.Allowed)
```

### Not built

I could not build this here. The file parses clean under `CSharpSyntaxTree.ParseText(...).GetDiagnostics()` — that confirms syntax only, not types, and the change has not been compiled or run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
