### PR TITLE
Fix the Topics tab context menu casting to the wrong item type

### DIFF
--- a/Telegram/Views/Profile/ProfileTopicsTabPage.xaml.cs
+++ b/Telegram/Views/Profile/ProfileTopicsTabPage.xaml.cs
@@ -88,19 +88,30 @@ namespace Telegram.Views.Profile
 
         private void OnContextRequested(UIElement sender, ContextRequestedEventArgs args)
         {
-            var topic = ScrollingHost.ItemFromContainer(sender) as SavedMessagesTopic;
+            if (ScrollingHost.ItemFromContainer(sender) is not ForumTopic topic)
+            {
+                return;
+            }
+
+            var viewModel = ViewModel?.TopicsTab;
+            if (viewModel?.Chat is not Chat chat)
+            {
+                return;
+            }
+
+            // ToggleForumTopicIsPinned and DeleteForumTopic both require CanManageTopics,
+            // as in ForumView's own topic menu.
+            var canManage = viewModel.ClientService.TryGetSupergroup(chat, out Supergroup supergroup)
+                && supergroup.CanManageTopics();
+
             var flyout = new MenuFlyout();
 
-            if (topic.IsPinned)
+            if (canManage)
             {
-                flyout.CreateFlyoutItem(ViewModel.SavedChatsTab.UnpinTopic, topic, Strings.UnpinFromTop, Icons.PinOff);
+                // PinTopic toggles, there's no separate unpin command on the topics side.
+                flyout.CreateFlyoutItem(viewModel.PinTopic, topic, topic.IsPinned ? Strings.UnpinFromTop : Strings.PinToTop, topic.IsPinned ? Icons.PinOff : Icons.Pin);
+                flyout.CreateFlyoutItem(viewModel.DeleteTopic, topic, Strings.Delete, Icons.Delete, destructive: true);
             }
-            else
-            {
-                flyout.CreateFlyoutItem(ViewModel.SavedChatsTab.PinTopic, topic, Strings.PinToTop, Icons.Pin);
-            }
-
-            flyout.CreateFlyoutItem(ViewModel.SavedChatsTab.DeleteTopic, topic, Strings.Delete, Icons.Delete, destructive: true);
 
             flyout.ShowAt(sender, args);
         }


### PR DESCRIPTION
`NullReferenceException` — *Object reference not set to an instance of an object.*
Reported by crash telemetry on 12.9.1.

```
   0  $0_Telegram::Views::Profile::ProfileTopicsTabPage.OnContextRequested+0x75
      Telegram\Views\Profile\ProfileTopicsTabPage.xaml.cs:94
   1  $60_Windows::UI::Xaml::DependencyPropertyChangedCallback.Invoke+0x2e
   2  $60___Interop::Intrinsics.HasThisCall__322<System.__Canon>+0x36
   3  $60___Interop::ReverseComStubs.Stub_3<System.__Canon, System.__Canon>+0x93
```

## Cause

`ProfileTopicsTabPage.OnContextRequested` is a verbatim copy of the one in
`ProfileSavedChatsTabPage` that was never adapted to this page. It does:

```csharp
var topic = ScrollingHost.ItemFromContainer(sender) as SavedMessagesTopic;
...
if (topic.IsPinned)
```

but this list holds `ForumTopic`, not `SavedMessagesTopic` — the page's own
`OnContainerContentChanging` bails with `if (args.Item is not ForumTopic forumTopic)` and
`ListView_ItemClick` casts to `ForumTopic`. So the `as` cast always yields `null` and
`topic.IsPinned` (line 94) throws on **every** right-click in the Topics tab. It is
deterministic, not a race. The same copy also routed every menu item to
`ViewModel.SavedChatsTab` rather than the topics tab's own view model, so even with a
non-null item it would have pinned and deleted the wrong thing.

## Fix

Cast to `ForumTopic` and call the commands on `ViewModel.TopicsTab`
(`ProfileTopicsTabViewModel : TopicListViewModel`):

- **Pin/Unpin** — `TopicListViewModel.PinTopic(ForumTopic)` is a single toggle
  (`ToggleForumTopicIsPinned(..., !topic.IsPinned)`); there is no separate `UnpinTopic`
  on the topics side as there is on the saved chats side, so the two branches collapse
  into one item whose label and icon come from `topic.IsPinned`.
- **Delete** — `TopicListViewModel.DeleteTopic(ForumTopic)`.

Both TDLib calls require `CanManageTopics`, so they are gated on it the same way
`ForumView.Topic_ContextRequested` gates its own pin/delete entries. `MenuFlyout.ShowAt`
already no-ops on an empty flyout, so a member without that right simply gets no menu.

Deliberately not added here: `ForumView`'s menu also offers mute, close/restart, mark as
read, open in new window and select. Those have topics-side equivalents but were never
part of this menu; bringing the two menus to parity is a separate change, not a crash fix.

The obvious null guard around the cast is not the fix — it would swallow the context menu
silently and leave the wrong view model wired. The mapping is what was wrong.

## Not built

**This was not compiled.** `ProfileTopicsTabPage.xaml.cs` parses clean under
`CSharpSyntaxTree.ParseText(...).GetDiagnostics()`, and nothing beyond that was checked:
the command names, signatures and the `CanManageTopics`/`TryGetSupergroup` extensions were
matched by reading `TopicListViewModel`, `ProfileTabsViewModel`, `TdExtensions` and
`ForumView.xaml.cs`, not by the compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
