### PR TITLE
Fix InvalidCastException opening the gift variants popup on Windows 10

### DIFF
--- a/Telegram/Common/ApiInfo.cs
+++ b/Telegram/Common/ApiInfo.cs
@@ -52,6 +52,11 @@ namespace Telegram.Common
         private static bool? _canCreateThemeShadow;
         public static bool CanCreateThemeShadow => IsWindows11 && (_canCreateThemeShadow ??= ApiInformation.IsPropertyPresent("Windows.UI.Xaml.UIElement", "Shadow"));
 
+        // ListViewItemPresenter's Selected*BorderBrush properties live on IListViewItemPresenter4,
+        // added in UniversalApiContract 13.0 (22621), so setting them throws on anything older.
+        private static bool? _canSetSelectedBorderBrush;
+        public static bool CanSetSelectedBorderBrush => _canSetSelectedBorderBrush ??= ApiInformation.IsPropertyPresent("Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter", "SelectedBorderBrush");
+
         private static bool? _canAnimatePaths;
         public static bool CanAnimatePaths => _canAnimatePaths ??= IsBuildOrGreater(19043);
 

--- a/Telegram/Views/Gifts/Popups/GiftVariantsPopup.xaml.cs
+++ b/Telegram/Views/Gifts/Popups/GiftVariantsPopup.xaml.cs
@@ -108,8 +108,7 @@ namespace Telegram.Views.Gifts.Popups
                     content.UpdateSymbol(_clientService, _selectedBackdrop, symbol);
                 }
 
-                var presenter = VisualTreeHelper.GetChild(args.ItemContainer, 0) as ListViewItemPresenter;
-                if (presenter != null)
+                if (ApiInfo.CanSetSelectedBorderBrush && VisualTreeHelper.GetChild(args.ItemContainer, 0) is ListViewItemPresenter presenter)
                 {
                     var brush = new SolidColorBrush(color);
 


### PR DESCRIPTION
Reported by crash telemetry on 12.9.1.

`InvalidCastException`: `Unable to cast object of type 'EETypeRva:0x001D0A68(Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter)' to type 'EETypeRva:0x000C4198'.`

```
   0  $8_System::Runtime::InteropServices::McgMarshal.GetInterface+0x112
      McgMarshal.cs:1266
   1  $60___Interop::ComCallHelpers.Call+0x3a
   2  $60___Interop::ForwardComStubs.Stub_9<System.__Canon, System.__Canon>+0x5a
   3  $0_Telegram::Views::Gifts::Popups::GiftVariantsPopup.OnContainerContentChanging+0x250
      Telegram\Views\Gifts\Popups\GiftVariantsPopup.xaml.cs:116
   4  $60_Windows::UI::Xaml::DependencyPropertyChangedCallback.Invoke+0x2e
   5  $60___Interop::Intrinsics.HasThisCall__322<System.__Canon>+0x36
   6  $60___Interop::ReverseComStubs.Stub_3<System.__Canon, System.__Canon>+0x93
   7  $8_System::Runtime::InteropServices::McgMarshal.ThrowOnExternalCallFailed+0x21
      McgMarshal.cs:1189
   8  $60___Interop::ComCallHelpers.Call+0xce
   9  $60___Interop::ForwardComStubs.Stub_94<System.__Canon>+0x47
  10  $60_Windows::UI::Xaml::FrameworkElement.MeasureOverride+0x1e
  11  $60_Windows::UI::Xaml::FrameworkElement.global::Windows.UI.Xaml.IFrameworkElementOverrides.MeasureOverride+0xa
  12  $60___Interop::ReverseComStubs.Stub_27+0x40
```

## Cause

`GiftVariantsPopup.OnContainerContentChanging` sets three properties on the container's `ListViewItemPresenter`:

```csharp
presenter.SelectedBorderBrush = brush;
presenter.SelectedPointerOverBorderBrush = brush;
presenter.SelectedPressedBorderBrush = brush;
```

All three are declared on `IListViewItemPresenter4`, which the SDK idl marks `[contract(Windows.Foundation.UniversalApiContract, 13.0)]` — it is absent from the 10.0.19041 headers and present from 10.0.22621 on. On a system that doesn't implement contract 13, the `QueryInterface` behind the setter fails, `McgMarshal.GetInterface` throws, and the exception surfaces through the `ContainerContentChanging` handler while the first container is being realized under `MeasureOverride`.

There is nothing intermittent about it: the popup fails to open on every affected system.

`ApiInfo.IsWindows11` would not have been the right guard either — it is `IsBuildOrGreater(22000)`, i.e. 21H2, one release before these properties existed.

## The fix

A new `ApiInfo.CanSetSelectedBorderBrush`, cached like its neighbours, checks `ApiInformation.IsPropertyPresent` for the property itself rather than a build number, and the assignment block is guarded on it. These are the only uses of those three properties in the repo, so nothing else changes. Where the API is missing the selection border keeps its default brush, which is the intended degraded behaviour.

The `as` + null check became an `is` pattern only because the guard had to move in front of it; the `VisualTreeHelper.GetChild` call is now also skipped when the properties aren't there.

## Not built

Not compiled or run — a .NET Native build wasn't available here. Both changed files were checked with `CSharpSyntaxTree.ParseText(...).GetDiagnostics()`, which confirms they still parse and nothing more; it does not check types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
