### PR TITLE
Fix the invite link never arriving on ChatInviteLinksPage

### DIFF
--- a/Telegram/ViewModels/Chats/ChatInviteLinksViewModel.cs
+++ b/Telegram/ViewModels/Chats/ChatInviteLinksViewModel.cs
@@ -76,6 +76,10 @@ namespace Telegram.ViewModels.Chats
                 {
                     if (ClientService.TryGetSupergroup(chat, out Supergroup supergroup))
                     {
+                        // Handle(UpdateSupergroupFullInfo) matches on this, and it's the only
+                        // way InviteLink ever arrives when full info isn't cached yet.
+                        _supergroupId = supergroup.Id;
+
                         _channel = supergroup.IsChannel;
                         _canCreateJoinRequests = !supergroup.IsPublic();
 
@@ -95,8 +99,10 @@ namespace Telegram.ViewModels.Chats
                             ClientService.Send(new GetSupergroupFullInfo(supergroup.Id));
                         }
                     }
-                    else
+                    else if (ClientService.TryGetBasicGroup(chat, out BasicGroup basicGroup))
                     {
+                        _basicGroupId = basicGroup.Id;
+
                         _channel = false;
                         _canCreateJoinRequests = true;
 
@@ -106,7 +112,7 @@ namespace Telegram.ViewModels.Chats
                         }
                         else
                         {
-                            ClientService.Send(new GetBasicGroupFullInfo(supergroup.Id));
+                            ClientService.Send(new GetBasicGroupFullInfo(basicGroup.Id));
                         }
                     }
                 }

--- a/Telegram/Views/Chats/ChatInviteLinksPage.xaml
+++ b/Telegram/Views/Chats/ChatInviteLinksPage.xaml
@@ -82,6 +82,7 @@
                                                                  VerticalAlignment="Center"
                                                                  Width="36"
                                                                  Height="32"
+                                                                 IsEnabled="{x:Bind ConvertHasInviteLink(ViewModel.InviteLink), Mode=OneWay}"
                                                                  Grid.Column="2" />
 
                                             <Button Click="CopyLink_Click"
@@ -92,6 +93,7 @@
                                                     Padding="0"
                                                     Height="32"
                                                     Width="32"
+                                                    IsEnabled="{x:Bind ConvertHasInviteLink(ViewModel.InviteLink), Mode=OneWay}"
                                                     Grid.Column="3" />
                                             <Button Click="ShareLink_Click"
                                                     Content="&#xE914;"
@@ -101,6 +103,7 @@
                                                     Padding="0"
                                                     Height="32"
                                                     Width="32"
+                                                    IsEnabled="{x:Bind ConvertHasInviteLink(ViewModel.InviteLink), Mode=OneWay}"
                                                     Grid.Column="4" />
                                         </Grid>
                                     </controls:HeaderedControl>

--- a/Telegram/Views/Chats/ChatInviteLinksPage.xaml.cs
+++ b/Telegram/Views/Chats/ChatInviteLinksPage.xaml.cs
@@ -144,6 +144,13 @@ namespace Telegram.Views.Chats
             return inviteLink?.InviteLink.Replace("https://", string.Empty);
         }
 
+        // TDLib only fills in the primary invite link for the creator, so it stays null
+        // for anyone else and the header buttons would act on nothing.
+        private bool ConvertHasInviteLink(ChatInviteLink inviteLink)
+        {
+            return inviteLink != null;
+        }
+
         private string ConvertNewLinkFooter(int count, bool channel)
         {
             if (count > 0)


### PR DESCRIPTION
Two `NullReferenceException` groups reported by crash telemetry on 12.9.1, both from the same root: the primary invite link never arrives on `ChatInviteLinksPage`, so the header's copy and share buttons act on `null`.

### Frames

Share:

```
NullReferenceException — Object reference not set to an instance of an object.
   0  $0_Telegram::ViewModels::Chats::ChatInviteLinksViewModel::<ShareLink>d__29.MoveNext+0x62
      Telegram\ViewModels\Chats\ChatInviteLinksViewModel.cs:176
   1  System::Runtime::ExceptionServices::ExceptionDispatchInfo.Throw+0x21
   2  System::Runtime::CompilerServices::AsyncMethodBuilderCore::<>c.<ThrowAsync>b__7_0+0x1e
   3  System::Action$1<System::UInt64>.Invoke+0x28
   4  System::Threading::WinRTSynchronizationContext::Invoker.InvokeCore+0x33
```

Copy:

```
NullReferenceException — Object reference not set to an instance of an object.
   0  $0_Telegram::Views::Chats::ChatInviteLinksPage.CopyLink_Click+0x79
      Telegram\Views\Chats\ChatInviteLinksPage.xaml.cs:175
   1  $60_Windows::UI::Xaml::DependencyPropertyChangedCallback.Invoke+0x2e
   2  $60___Interop::Intrinsics.HasThisCall__322<System.__Canon>+0x36
   3  $60___Interop::ReverseComStubs.Stub_6<System.__Canon>+0x70
```

Both lines were verified against the 12.9.1 tree; they land on `inviteLink.InviteLink` in `ShareLink` and on `ViewModel.CopyLink(ViewModel.InviteLink)` respectively.

### Cause

`ChatInviteLinksViewModel` declares `_supergroupId` and `_basicGroupId`, but **nothing in the file ever assigns them** — the only other references are the two comparisons in the update handlers. So `Handle(UpdateSupergroupFullInfo)` and `Handle(UpdateBasicGroupFullInfo)` compare the incoming id against `0` and never match.

That makes the "full info will arrive by push" fallback in `OnNavigatedToAsync` dead code: when neither the supergroup's username nor its cached full info is available, the view model sends `GetSupergroupFullInfo` / `GetBasicGroupFullInfo` and then silently drops the answer. `InviteLink` stays `null` forever, and the header's copy and share buttons dereference it — two separate crash groups, one root.

There is a second bug in the same block: `GetBasicGroupFullInfo(supergroup.Id)` was called inside the `else` branch of `TryGetSupergroup`, where `supergroup` is by definition `null` — a guaranteed NRE on that path — and it passed a supergroup id where a basic group id is wanted.

### Fix

- Assign `_supergroupId` / `_basicGroupId` in `OnNavigatedToAsync`, so the update handlers match and `InviteLink` populates when the full info arrives.
- Take the basic group branch through `TryGetBasicGroup`, and request `GetBasicGroupFullInfo` with the basic group's own id.
- A `null` `InviteLink` is also *legitimate*: TDLib only fills in the primary link for the creator, so it stays `null` for anyone without invite rights. The page's own converters already treat it as nullable (`inviteLink?.InviteLink`); the click handlers did not. Rather than a bare guard in the handlers — which would leave a live-looking header that does nothing — the copy, share and overflow buttons are now disabled while `InviteLink` is `null`, through the same `x:Bind` function-converter pattern the page already uses for its content and footer. The overflow button is included because its only menu item, revoke, has the same dereference.

### Not built

Not compiled and not run: `.NET Native` isn't available here. Both edited `.cs` files were checked with `CSharpSyntaxTree.ParseText(...).GetDiagnostics()` and parse clean, which catches syntax only, not type errors. The XAML was not checked at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
