### PR TITLE
Recover from a damaged OCR model archive

### DIFF
--- a/Telegram/Services/TextRecognitionService.cs
+++ b/Telegram/Services/TextRecognitionService.cs
@@ -59,6 +59,9 @@ namespace Telegram.Services
 
         private static readonly SemaphoreSlim _extractLock = new(1, 1);
 
+        // Presence of this file is what marks the model as ready, both here and in TextRecognizer.
+        private const string ModelFileName = "oneocr.onemodel";
+
         private long _fileToken;
 
         private long? _chatId;
@@ -88,7 +91,7 @@ namespace Telegram.Services
         {
             var destination = await ApplicationData.Current.LocalFolder.CreateFolderAsync("Ocr", CreationCollisionOption.OpenIfExists);
 
-            var available = await destination.TryGetItemAsync("oneocr.onemodel");
+            var available = await destination.TryGetItemAsync(ModelFileName);
             if (available != null)
             {
                 return TryCreateRecognizer();
@@ -143,8 +146,12 @@ namespace Telegram.Services
                 var storage = await _clientService.GetFileAsync(document.Document.DocumentValue);
                 if (storage != null)
                 {
-                    await ExtractModelAsync(destination, storage, document.Document.DocumentValue);
-                    return TryCreateRecognizer();
+                    if (await ExtractModelAsync(destination, storage, document.Document.DocumentValue))
+                    {
+                        return TryCreateRecognizer();
+                    }
+
+                    return new TextRecognitionStatusUnavailable();
                 }
                 else
                 {
@@ -169,38 +176,75 @@ namespace Telegram.Services
             return new TextRecognitionStatusUnavailable();
         }
 
-        private async Task ExtractModelAsync(StorageFolder destination, StorageFile file, File document)
+        private async Task<bool> ExtractModelAsync(StorageFolder destination, StorageFile file, File document)
         {
             if (!_extractLock.Wait(0))
             {
                 // Already in progress
-                return;
+                return false;
             }
 
-            using (var zipStream = await file.OpenReadAsync())
-            using (var zipInput = System.IO.WindowsRuntimeStreamExtensions.AsStreamForRead(zipStream))
-            using (var archive = new System.IO.Compression.ZipArchive(zipInput))
+            try
             {
-                foreach (var entry in archive.Entries)
+                using (var zipStream = await file.OpenReadAsync())
+                using (var zipInput = System.IO.WindowsRuntimeStreamExtensions.AsStreamForRead(zipStream))
+                using (var archive = new System.IO.Compression.ZipArchive(zipInput))
                 {
-                    if (string.IsNullOrEmpty(entry.Name))
-                        continue;
-
-                    var entryPath = entry.FullName.Replace('/', '\\');
-                    var entryFile = await destination.CreateFileAsync(entryPath, CreationCollisionOption.ReplaceExisting);
-
-                    using (var entryStream = entry.Open())
-                    using (var outStream = await System.IO.WindowsRuntimeStorageExtensions.OpenStreamForWriteAsync(entryFile))
+                    foreach (var entry in archive.Entries)
                     {
-                        await entryStream.CopyToAsync(outStream);
+                        if (string.IsNullOrEmpty(entry.Name))
+                            continue;
+
+                        var entryPath = entry.FullName.Replace('/', '\\');
+                        var entryFile = await destination.CreateFileAsync(entryPath, CreationCollisionOption.ReplaceExisting);
+
+                        using (var entryStream = entry.Open())
+                        using (var outStream = await System.IO.WindowsRuntimeStorageExtensions.OpenStreamForWriteAsync(entryFile))
+                        {
+                            await entryStream.CopyToAsync(outStream);
+                        }
                     }
                 }
+
+                _clientService.Send(new DeleteFile(document.Id));
+                _aggregator.Publish(new UpdateTextRecognition());
+
+                return true;
             }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
 
-            _clientService.Send(new DeleteFile(document.Id));
-            _aggregator.Publish(new UpdateTextRecognition());
+                // The caller is async void, so anything thrown in here would take the app down.
+                // Drop the local archive as well, so that the next attempt downloads it again
+                // instead of extracting the same damaged copy forever.
+                _clientService.Send(new DeleteFile(document.Id));
+                await TryDeleteModelAsync(destination);
 
-            _extractLock.Release();
+                return false;
+            }
+            finally
+            {
+                _extractLock.Release();
+            }
+        }
+
+        private static async Task TryDeleteModelAsync(StorageFolder destination)
+        {
+            try
+            {
+                // A failure part way through leaves a truncated model behind, and EnsureReadyAsync
+                // would take it for a complete one and never extract again.
+                var item = await destination.TryGetItemAsync(ModelFileName);
+                if (item != null)
+                {
+                    await item.DeleteAsync(StorageDeleteOption.PermanentDelete);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+            }
         }
     }
 }


### PR DESCRIPTION
`InvalidDataException` — "The archive entry was compressed using an unsupported compression method", reported by crash telemetry on 12.9.1, thrown while unpacking the OCR model archive and reaching the app unhandled.

### The message is a red herring

`Inflater.Inflate` maps zlib's `Z_DATA_ERROR` onto `SR.UnsupportedCompression`, whose text is exactly that string, so a corrupt deflate stream is reported as if the compression method were unsupported. Two things in the trace show which one it really is:

- the throw comes from `DeflateStream.CopyToAsyncStream.WriteAsync`, i.e. **mid-entry**, while data is being inflated;
- a genuinely unsupported method is rejected up front by `ZipArchiveEntry.Open()`, which never appears as a failing frame here.

So the archive's local copy held corrupt or truncated deflate data. `Ocr_x64.zip` / `Ocr_arm64.zip` are the app's own files, looked up by exact filename in `Constants.AppChannel`, downloaded through TDLib and unzipped into `LocalFolder\Ocr`. **Why that particular copy was damaged is not established** — this PR does not claim a cause for it, only that the client must survive it.

### Frames

```
   0  $23_System::IO::Compression::Inflater.Inflate+0xd8
   1  $23_System::IO::Compression::Inflater.ReadInflateOutput+0x48
   2  $23_System::IO::Compression::Inflater.InflateVerified+0x2a
   3  $23_System::IO::Compression::Inflater.Inflate+0x61
   4  $23_System::IO::Compression::DeflateStream::CopyToAsyncStream::<WriteAsync>d__6.MoveNext+0x137
  ...
   9  System::IO::Stream::<CopyToAsyncInternal>d__28.MoveNext+0x332
  ...
  15  $23_System::IO::Compression::DeflateStream::CopyToAsyncStream::<CopyFromSourceToDestination>d__5.MoveNext+0x2ea
  ...
  21  $0_Telegram::Services::TextRecognitionService::<ExtractModelAsync>d__9.MoveNext+0x346
  ...
  27  $0_Telegram::Services::TextRecognitionService::<EnsureReadyAsync>d__7.MoveNext+0x74a
      Telegram\Services\TextRecognitionService.cs:143
  ...
  32  $0_Telegram::Controls::Gallery::GalleryContent::<RecognizeText>d__58.MoveNext+0x2eb
      Telegram\Controls\Gallery\GalleryContent.xaml.cs:663
  ...
  40  $0_Telegram::WatchDog.OnUnhandledExceptionDetected+0x79
      Telegram\Common\WatchDog.cs:141
```

41/41 frames resolved, no missing symbols.

### Fix

`ExtractModelAsync` had no `try`/`catch`, and `GalleryContent.RecognizeText` is `async void`, so any I/O or archive error on this path became an unhandled exception. The extraction is now wrapped, and on failure it:

- deletes the archive (`DeleteFile`, the same request the success path already sends), so the next attempt re-downloads instead of extracting the same damaged copy forever;
- deletes a partially written `oneocr.onemodel`. Entries are extracted one by one, so a mid-entry failure can leave a truncated model behind — and `EnsureReadyAsync` treats the mere presence of that file as "ready", which would strand OCR permanently even after a fresh download;
- returns the existing `TextRecognitionStatusUnavailable` to the caller, which already handles it.

### Separate finding: the semaphore leaked

`_extractLock.Release()` sat at the end of the method, outside any `finally`. Any throw during extraction — the one above included — left the static semaphore permanently taken, so every later extraction in that session returned silently at `Wait(0)` ("Already in progress") and OCR stayed broken until the app was restarted. It is now released in a `finally`, which is correct independently of the archive question.

### Not built

Not compiled or run. The file was checked with `CSharpSyntaxTree.ParseText(...).GetDiagnostics()` and parses with no diagnostics; that catches syntax errors only, not type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
