### PR TITLE
Fix crash when saving business opening hours

### DIFF
--- a/Telegram/Td/Api/TdExtensions.cs
+++ b/Telegram/Td/Api/TdExtensions.cs
@@ -3278,6 +3278,30 @@ namespace Telegram.Td.Api
             return false;
         }
 
+        public static bool AreTheSame(this BusinessOpeningHours x, BusinessOpeningHours y)
+        {
+            if (x == null || y == null)
+            {
+                return x == y;
+            }
+
+            if (string.Equals(x.TimeZoneId, y.TimeZoneId) && x.OpeningHours.Count == y.OpeningHours.Count)
+            {
+                for (int i = 0; i < x.OpeningHours.Count; i++)
+                {
+                    if (x.OpeningHours[i].StartMinute != y.OpeningHours[i].StartMinute
+                        || x.OpeningHours[i].EndMinute != y.OpeningHours[i].EndMinute)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
         public static bool AreTheSame(this BusinessGreetingMessageSettings x, BusinessGreetingMessageSettings y)
         {
             if (x == null || y == null)

--- a/Telegram/ViewModels/Business/BusinessHoursViewModel.cs
+++ b/Telegram/ViewModels/Business/BusinessHoursViewModel.cs
@@ -233,14 +233,22 @@ namespace Telegram.ViewModels.Business
                     FillDay(Saturday);
                     FillDay(Sunday);
                 }
-                //}
-                //{
-                var response = await ClientService.SendAsync(new GetTimeZones());
-                if (response is TimeZones zones)
-                {
-                    TimeZone = zones.TimeZonesValue.FirstOrDefault(x => x.Id == hours.TimeZoneId);
-                }
             }
+
+            var response = await ClientService.SendAsync(new GetTimeZones());
+            if (response is TimeZones zones)
+            {
+                var offset = (int)DateTimeOffset.Now.Offset.TotalSeconds;
+
+                // Zones are identified by IANA name, which Windows doesn't expose, so a user who has
+                // never saved opening hours falls back to the first zone at the current UTC offset.
+                TimeZone = zones.TimeZonesValue.FirstOrDefault(x => x.Id == hours?.TimeZoneId)
+                    ?? zones.TimeZonesValue.FirstOrDefault(x => x.UtcTimeOffset == offset);
+            }
+
+            // Loading splits an interval that crosses midnight into one range per day, and saving
+            // writes the halves back out, so the cached object is round-tripped to compare like for like.
+            _cached = GetSettings();
         }
 
         private bool _isEnabled;
@@ -349,9 +357,66 @@ namespace Telegram.ViewModels.Business
             }
         }
 
-        protected override void ContinueImpl(NavigatingEventArgs args)
+        public override bool HasChanged => !_cached.AreTheSame(GetSettings());
+
+        protected override async void ContinueImpl(NavigatingEventArgs args)
         {
-            throw new NotImplementedException();
+            var settings = GetSettings();
+            if (settings.AreTheSame(_cached))
+            {
+                _completed = true;
+                NavigationService.GoBack(args);
+                return;
+            }
+
+            var response = await ClientService.SendAsync(new SetBusinessOpeningHours(settings));
+            if (response is Ok)
+            {
+                _completed = true;
+                NavigationService.GoBack(args);
+            }
+            else if (response is Error error)
+            {
+                ShowToast(error);
+            }
+        }
+
+        private BusinessOpeningHours _cached;
+        private BusinessOpeningHours GetSettings()
+        {
+            if (!IsEnabled)
+            {
+                return null;
+            }
+
+            var intervals = new List<BusinessOpeningHoursInterval>();
+
+            void FillDay(BusinessDay day)
+            {
+                foreach (var range in day.Ranges)
+                {
+                    // Ranges are relative to the day they belong to, and the end is allowed to spill
+                    // over into the next one, which is what businessOpeningHoursInterval expects.
+                    intervals.Add(new BusinessOpeningHoursInterval(
+                        day.StartMinute + (int)range.Start.TotalMinutes,
+                        day.StartMinute + (int)range.End.TotalMinutes));
+                }
+            }
+
+            FillDay(Monday);
+            FillDay(Tuesday);
+            FillDay(Wednesday);
+            FillDay(Thursday);
+            FillDay(Friday);
+            FillDay(Saturday);
+            FillDay(Sunday);
+
+            if (intervals.Count == 0)
+            {
+                return null;
+            }
+
+            return new BusinessOpeningHours(TimeZone?.Id ?? string.Empty, intervals);
         }
     }
 }


### PR DESCRIPTION
Pressing **Done** in Settings → Telegram Business → Opening Hours crashes the app, 100% of the time. Reported by crash telemetry on 12.9.1.

## Cause

`BusinessHoursPage.xaml` wires the page action to the view model:

```xml
<Button Content="{CustomResource Done}"
        Click="{x:Bind ViewModel.Continue}" ... />
```

`BusinessFeatureViewModelBase.Continue()` calls the abstract `ContinueImpl(null)`, and `BusinessHoursViewModel` never implemented it:

```csharp
protected override void ContinueImpl(NavigatingEventArgs args)
{
    throw new NotImplementedException();
}
```

So the button is live and reachable, and the only thing behind it is the throw. The base class also invokes `ContinueImpl` from `NavigatingFrom` when the user picks *Apply* on the unsaved-changes prompt, which is the second way into it.

## Frames

```
NotImplementedException: The method or operation is not implemented.

   0  $0_Telegram::Views::Settings::SettingsNetworkPage::SettingsNetworkPage_obj9_Bindings.ProcessBinding+0x26
      Telegram\obj\x64\Release\XamlTypeInfo.g.cs:33016
   1  $0_Telegram::Views::Business::BusinessHoursPage::BusinessHoursPage_obj1_Bindings.<Connect>b__19_0+0x39
      Telegram\obj\x64\Release\Views\Business\BusinessHoursPage.g.cs:97
   2  $60_Windows::UI::Xaml::DependencyPropertyChangedCallback.Invoke+0x2e
   3  $60___Interop::Intrinsics.HasThisCall__322<System.__Canon>+0x36
   4  $60___Interop::ReverseComStubs.Stub_6<System.__Canon>+0x70
```

Frame 1 is the generated `x:Bind` `Click` handler for `BusinessHoursPage`, i.e. the Done button. (Frame 0's file attribution is an AOT symbol collision — the exit point renders the same address as `BaseObject.ToJson` — but frame 1 identifies the site unambiguously.) The log tail matches: `ProfilePage` → `BusinessPage` → `BusinessHoursPage`, crash a few seconds after arriving.

## Fix

`ContinueImpl` is implemented the way the other business feature view models do it (`BusinessLocationViewModel`, `BusinessIntroViewModel`, `BusinessAwayViewModel`):

- `GetSettings()` builds a `BusinessOpeningHours` from the seven `BusinessDay` range lists. Ranges are day-relative, so each becomes `day.StartMinute + range.Start/End`, which is what `businessOpeningHoursInterval` wants (an end past midnight is legal — the field is documented as `1-8*24*60`). It returns `null` when the feature is switched off or no day is open, and `setBusinessOpeningHours` documents `null` as "remove the opening hours".
- `ContinueImpl` early-outs and goes back when nothing changed, otherwise sends `SetBusinessOpeningHours`, going back on `Ok` and toasting on `Error`.
- `HasChanged` is overridden. The base class already has `BusinessHoursViewModel => Strings.BusinessHoursUnsavedChanges` in its switch, so the string was in place and only the unimplemented property kept the prompt from firing.
- A new `AreTheSame(BusinessOpeningHours, BusinessOpeningHours)` in `TdExtensions.cs`, next to the other business overloads, backs both of the above.

Two things worth a reviewer's attention, both needed to make Done actually work rather than merely not crash:

1. **The cached value is round-tripped.** Loading splits an interval that crosses midnight into one range per day (`TextStyleRun.GetRelativeRange` clamps to the day), and saving writes those halves back as separate intervals. Comparing against the raw server object would therefore report a change when nothing was touched — spurious unsaved-changes prompt, spurious request. So `_cached` is set to `GetSettings()` once loading has finished, and both sides of the comparison are built the same way.
2. **The time zone is now always resolved.** It used to be fetched only inside `if (hours != null)`, so a user who had never saved opening hours — the main path into this page — had `TimeZone == null` and there would be no `time_zone_id` to send. `GetTimeZones` now runs on every navigation and falls back to the first zone at the current UTC offset. Matching on the offset rather than the identifier is deliberate: the server keys zones by IANA name and Windows exposes its own zone IDs, so there is no direct mapping available here. It is imperfect where several zones share an offset but differ in DST rules; the user can still change it from the Time zone row, and the alternative was a Done button that silently fails.

## Not built

**This was not compiled.** Both changed files were checked with `CSharpSyntaxTree.ParseText(...).GetDiagnostics()` and parse without errors — that catches syntax only, not type errors. In particular `SetBusinessOpeningHours`, `BusinessOpeningHours` and `BusinessOpeningHoursInterval` and their members were matched by reading `td_api.tl` and the generated API, not by compiling against it. It has not been run, so the round-trip behaviour above is reasoned from the code rather than observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
