### PR TITLE
Fix D2DERR_WRONG_RESOURCE_DOMAIN in video calls after a GPU device loss

### DIFF
--- a/Telegram.Native.Calls/VoipVideoOutput.h
+++ b/Telegram.Native.Calls/VoipVideoOutput.h
@@ -536,6 +536,10 @@ private:
             return;
         }
 
+        // The effect and the three bitmaps were realized on the device that's being replaced:
+        // using them against a context from the new device fails with D2DERR_WRONG_RESOURCE_DOMAIN.
+        ReleaseShader();
+
         if (m_surface)
         {
             m_resourcesValid = true;
@@ -720,7 +724,7 @@ public:
 
         if (m_disposed.load()) return S_FALSE;
 
-        if (finalSize.cx != m_surfaceSize.cx || finalSize.cy != finalSize.cy)
+        if (finalSize.cx != m_surfaceSize.cx || finalSize.cy != m_surfaceSize.cy)
         {
             result = m_surface->Resize(finalSize);
             if (FAILED(result))


### PR DESCRIPTION
Reported by crash telemetry on 12.9.1 (X64):

```
message  The resource was realized on the wrong render target.
         The resource was realized on the wrong render target.
frames   4/4 resolved

   0  $8_System::Runtime::InteropServices::McgMarshal.ThrowOnExternalCallFailed+0x21
      f:\dd\ndp\fxcore\CoreRT\src\System.Private.Interop\src\Shared\McgMarshal.cs:1189
   1  $60___Interop::ComCallHelpers.Call+0xb8
   2  $60___Interop::ForwardComStubs.Stub_18<System.__Canon>+0x24
   3  $0_Telegram::WatchDog.OnUnhandledExceptionDetected+0x79
      Telegram/Common/WatchDog.cs:141
```

**The stack contains no app code.** The throw comes out of the compositor across a
COM call boundary, and the only Unigram frame is the crash reporter itself. So the
frames do not pinpoint the site. The diagnosis below rests on the exception text —
which is the documented message for `D2DERR_WRONG_RESOURCE_DOMAIN` — plus a read of
the one place in the app that keeps D2D resources across a device swap.

## Cause

When the GPU device is lost, `PlaceholderImageHelper` rebuilds the D2D device and
calls `ICompositionGraphicsDeviceInterop::SetRenderingDevice`, which raises
`CompositionGraphicsDevice.RenderingDeviceReplaced`. That event exists so each
surface can drop the resources it realized on the old device.

`VoipVideoOutput::OnRenderingDeviceReplaced` doesn't drop them. It only sets
`m_resourcesValid = true` again (creating the drawing surface if there isn't one),
and keeps `m_shader` and `m_bitmapY/U/V` — the YUV420 effect and its three input
bitmaps, all created from the *old* device.

The next video frame of the same size then takes the reuse path in `RenderFrame`:
`m_bitmapY/U/V->CopyFromMemory` followed by `d2dContext->DrawImage(m_shader.get())`,
on a `d2dContext` that `m_surface->BeginDraw` handed back from the **new** device.
Mixing resources from two devices on one context is exactly what
`D2DERR_WRONG_RESOURCE_DOMAIN` reports, and its message text is the one above.

The sibling surfaces handle the same event correctly, which is what makes
`VoipVideoOutput` stand out: `FreeformGradientSurface::OnRenderingDeviceReplaced`
nulls `m_bitmap` and re-invalidates, and `MessageBubbleNineGrid` caches no
device-bound D2D resources at all, so redrawing is all it has to do.
`VoipVideoOutput` is the only holder of device-bound resources that survives a
device swap — and the only one gated on an active call, which matches the reports.

## Fix

Call the existing `ReleaseShader()` from the handler, under the `m_deviceMutex` the
handler already holds (`ReleaseShader` is documented as "should be called under
m_deviceMutex"). It nulls the effect and the three bitmaps, so the next frame takes
the `m_shader == nullptr` branch in `RenderFrame` and recreates all of them —
re-registering the effect included — against the new device.

## A second, unrelated bug in the same function

`RenderFrame` had a self-comparison in the surface-resize check:

```cpp
if (finalSize.cx != m_surfaceSize.cx || finalSize.cy != finalSize.cy)
```

The second half compares a value with itself, so it is always false and only a
width change ever resized the drawing surface. A height-only change — a rotation
between two frames of equal width, or a resolution switch that keeps the width —
left the surface at its old height. Corrected to `m_surfaceSize.cy`. It is a
distinct bug, in this PR only because it is two lines away.

## Known limitation, not addressed here

The tail of the chain is inferred rather than read off a frame. `RenderFrame`
returns its `HRESULT`s but the caller drops them, and the render-queue worker wraps
the call in `catch (...) // Meh`, so the D2D failure is swallowed where it happens
and only surfaces later, as a failed compositor commit on the UI thread — which is
where the reported exception is raised. Propagating those failures (and tearing the
surface down on them) would make this class of bug visible at its origin, but that
is a larger change than a crash fix should carry.

## Not built

**This change was not compiled.** No UWP/.NET Native build is available in the
environment it was written in, and for C++ there is not even a syntax-only check
equivalent to the Roslyn parse used on the C# side, so the diff was verified by
reading only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
