### PR TITLE
Give the DWrite custom font collection a valid key

### DIFF
--- a/Telegram.Native/PlaceholderImageHelper.cpp
+++ b/Telegram.Native/PlaceholderImageHelper.cpp
@@ -95,8 +95,9 @@ namespace winrt::Telegram::Native::implementation
             , m_index(0)
         {
             auto keys = static_cast<const wchar_t* const*>(collectionKey);
+            auto count = collectionKeySize / sizeof(const wchar_t*);
 
-            m_filenames = std::vector<const wchar_t*>(keys, keys + 2);
+            m_filenames = std::vector<const wchar_t*>(keys, keys + count);
             m_factory.copy_from(factory);
         }
 
@@ -130,7 +131,31 @@ namespace winrt::Telegram::Native::implementation
     class CustomFontLoader
         : public winrt::implements<CustomFontLoader, IDWriteFontCollectionLoader>
     {
+        // DWrite keeps its own copy of the collection key and hands it back to
+        // CreateEnumeratorFromKey whenever it needs to rebuild the collection, so the strings the
+        // key points at have to live as long as the loader is registered, not as long as the call
+        // that creates the collection.
+        hstring m_paths[2];
+        const wchar_t* m_key[2];
+
     public:
+        CustomFontLoader(hstring const& fontPath, hstring const& emojiPath)
+            : m_paths{ fontPath, emojiPath }
+            , m_key{ m_paths[0].c_str(), m_paths[1].c_str() }
+        {
+        }
+
+        void const* Key() const noexcept
+        {
+            return m_key;
+        }
+
+        // Byte count, as DWrite expects: it copies collectionKeySize bytes out of the key.
+        uint32_t KeySize() const noexcept
+        {
+            return static_cast<uint32_t>(sizeof(m_key));
+        }
+
         IFACEMETHODIMP2 CreateEnumeratorFromKey(
             IDWriteFactory* factory,
             void const* collectionKey,
@@ -989,19 +1014,13 @@ namespace winrt::Telegram::Native::implementation
 
         m_customEmoji = winrt::make_self<CustomEmojiInlineObject>();
 
-        hstring path1 = Package::Current().InstalledLocation().Path() + L"\\Assets\\Fonts\\Telegram.ttf";
-        hstring path2 = Package::Current().InstalledLocation().Path() + L"\\Assets\\Emoji\\apple.ttf";
+        hstring path = Package::Current().InstalledLocation().Path();
 
-        auto keySize = path1.size() + path2.size();
-        const wchar_t* keys[]
-        {
-            path1.c_str(),
-            path2.c_str()
-        };
+        auto loader = winrt::make_self<CustomFontLoader>(path + L"\\Assets\\Fonts\\Telegram.ttf", path + L"\\Assets\\Emoji\\apple.ttf");
+        m_customLoader = loader.as<IDWriteFontCollectionLoader>();
 
-        m_customLoader = winrt::make_self<CustomFontLoader>();
         ReturnIfFailed(result, m_dwriteFactory->RegisterFontCollectionLoader(m_customLoader.get()));
-        ReturnIfFailed(result, m_dwriteFactory->CreateCustomFontCollection(m_customLoader.get(), keys, keySize, m_fontCollection.put()));
+        ReturnIfFailed(result, m_dwriteFactory->CreateCustomFontCollection(m_customLoader.get(), loader->Key(), loader->KeySize(), m_fontCollection.put()));
         ReturnIfFailed(result, m_dwriteFactory->GetSystemFontCollection(m_systemCollection.put()));
 
         for (auto familyName : { L"Cascadia Mono", L"Consolas" })

--- a/Telegram.Native/PlaceholderImageHelper.h
+++ b/Telegram.Native/PlaceholderImageHelper.h
@@ -302,6 +302,16 @@ namespace winrt::Telegram::Native::implementation
             m_nineGridCache.clear();
             m_svgCacheList.clear();
             m_svgCacheIndex.clear();
+
+            // The DWrite factory is shared process-wide, so a loader that is never unregistered
+            // stays on it for the rest of the session, one per window thread. The collection goes
+            // first: the loader has to stay registered for as long as anything built from it lives.
+            if (m_customLoader && m_dwriteFactory)
+            {
+                m_fontCollection = nullptr;
+                m_dwriteFactory->UnregisterFontCollectionLoader(m_customLoader.get());
+                m_customLoader = nullptr;
+            }
         }
 
         HRESULT HandleDeviceLost()


### PR DESCRIPTION
`PlaceholderImageHelper::CreateDeviceIndependentResources` builds the custom DWrite font collection (Telegram.ttf + apple.ttf) with a collection key that is wrong in two independent ways.

### 1. The key size is a character count, not a byte count

```cpp
auto keySize = path1.size() + path2.size();
const wchar_t* keys[] { path1.c_str(), path2.c_str() };
...
CreateCustomFontCollection(m_customLoader.get(), keys, keySize, m_fontCollection.put());
```

`collectionKeySize` is the size of the key **in bytes**. `keySize` here is the summed *character* length of the two package paths — around 240 — while `keys` is a two-element array of pointers, i.e. 16 bytes on x64. DWrite copies `collectionKeySize` bytes out of the key, so it reads roughly 224 bytes past the end of a stack array on every construction of the helper, and the amount over-read varies with the length of the install path. The key DWrite ends up storing is part pointers, part unrelated stack contents.

### 2. The key points at locals

The two pointers in the key are `hstring::c_str()` of `path1`/`path2`, which are locals of `CreateDeviceIndependentResources`. The whole reason DWrite keeps a copy of the key is so it can hand it back to `IDWriteFontCollectionLoader::CreateEnumeratorFromKey` when it needs the collection's files again — and `CustomFontFileEnumerator` dereferences those pointers in `MoveNext` via `CreateFontFileReference`. By then the strings are gone. `MoveNext` reports `hasCurrentFile = FALSE` on failure rather than an error, so the failure mode there would be a silently empty font collection, not a diagnostic.

`CustomFontFileEnumerator` also ignored `collectionKeySize` entirely and assumed exactly two entries (`std::vector<const wchar_t*>(keys, keys + 2)`), which is what let the mismatched size go unnoticed.

**On severity, honestly:** the out-of-bounds read happens unconditionally, once per `PlaceholderImageHelper`. The dangling pointers are latent — the app creates a fresh `CustomFontLoader` per helper, so each `CreateCustomFontCollection` call is a distinct (loader, key) pair that DWrite builds synchronously while the locals are still alive. I did not find a path that re-enters `CreateEnumeratorFromKey` from the stored key today. It is a contract violation waiting on DWrite's caching behaviour rather than a demonstrated use-after-free.

### Fix

The paths and the array of pointers into them become members of `CustomFontLoader`, built once in its constructor, so the key's lifetime matches the loader's — the loader is kept alive by the registration and by `m_customLoader`. The size passed is `sizeof` that array. `CustomFontFileEnumerator` derives its count from `collectionKeySize` instead of hardcoding 2. No per-call allocation is added; the storage is created once alongside the loader, and the call site now reads `InstalledLocation().Path()` once instead of twice.

### Also fixed: the loader was never unregistered

`RegisterFontCollectionLoader` had no matching `UnregisterFontCollectionLoader`. The DWrite factory is `DWRITE_FACTORY_TYPE_SHARED`, i.e. process-wide, while `PlaceholderHelper.Foreground` is `[ThreadStatic]` and `PlaceholderHelper.Release()` disposes and nulls it when a window thread shuts down — so every window/thread cycle left a loader and a custom collection registered on the shared factory for the rest of the session. `Close()` now releases the collection and unregisters the loader, guarded so the explicit-dispose and destructor paths are idempotent. This is contained to `Close()`: `Release()` runs from `WindowContext.OnShutdownCompleted`, after which the thread-static is null and the next access constructs a fresh helper.

### Provenance

**Found by reading the font-collection setup while triaging unrelated crashes — not from a crash report.** This is not known to have caused any reported crash, and no crash data was used to identify or diagnose it.

### Not built

**This change has not been compiled.** No UWP/C++ toolchain was available here, and unlike the C# side there is no syntax-only check for C++ either, so the diff has been re-read rather than verified by a compiler. Worth a careful look at the `CustomFontLoader` constructor's member-initializer order (`m_paths` is declared before `m_key` so the `c_str()` values are taken from the already-initialised members) and at `loader.as<IDWriteFontCollectionLoader>()`, which mirrors the existing `enumerator.as<IDWriteFontFileEnumerator>()` in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
