### PR TITLE
Fix ArgumentOutOfRangeException when a pending message is reinserted

### DIFF
--- a/Telegram/ViewModels/DialogViewModel.Handle.cs
+++ b/Telegram/ViewModels/DialogViewModel.Handle.cs
@@ -1554,9 +1554,7 @@ namespace Telegram.ViewModels
             {
                 if (oldIndex != -1)
                 {
-                    // We can't use Move because ListView seems to mess up a lot with this operationg
-                    Items.RemoveAt(oldIndex);
-                    Items.Insert(newIndex, message);
+                    MoveMessageInOrder(message, oldIndex);
                 }
                 else
                 {
@@ -1565,9 +1563,19 @@ namespace Telegram.ViewModels
             }
             else if (force && oldIndex != -1)
             {
-                Items.RemoveAt(oldIndex);
-                Items.Insert(oldIndex, message);
+                MoveMessageInOrder(message, oldIndex);
             }
+        }
+
+        // We can't use Move because ListView seems to mess up a lot with this operationg
+        private void MoveMessageInOrder(MessageViewModel message, int oldIndex)
+        {
+            Items.RemoveAt(oldIndex);
+
+            // MessageCollection.RemoveItem also drops the date or topic separator that the
+            // removal orphans, so any index computed before it can now be past the end:
+            // ask again, against the collection as it is now.
+            Items.Insert(NextIndexOf(message, 0, out _), message);
         }
 
         private int NextIndexOf(MessageViewModel message, long oldMessageId, out int oldIndex)


### PR DESCRIPTION
`ArgumentOutOfRangeException` — "Index must be within the bounds of the List. Parameter name: index", reported by crash telemetry on 12.9.1.0 (X64).

```
   0  System::ThrowHelper.ThrowArgumentOutOfRangeException+0x11
      System.Private.CoreLib\src\System\ThrowHelper.cs:79
   1  $0_Telegram::ViewModels::DialogViewModel.InsertMessageInOrder+0x189
      Telegram\ViewModels\DialogViewModel.Handle.cs:1569
   2  $0_Telegram::ViewModels::DialogViewModel.InsertMessage+0x23e
      Telegram\ViewModels\DialogViewModel.Handle.cs:1536
   3  $0_Telegram::ViewModels::DialogViewModel::<>c__DisplayClass481_0.<PendingMessage_Completed>b__0+0x83
      Telegram\ViewModels\DialogViewModel.Handle.cs:859
   4  $0_Telegram::ViewModels::DialogViewModel::<>c__DisplayClass500_0.<Handle>b__0+0x36c
      Telegram\ViewModels\DialogViewModel.Handle.cs:1430
   5  $0_Telegram::Navigation::DispatcherContext.Dispatch+0x55
      Telegram\Navigation\DispatcherContext.cs:176
   6  $0_Telegram::Navigation::ViewModelBase.BeginOnUIThread+0x77
      Telegram\Navigation\ViewModelBase.cs:207
   7  $0_Telegram::ViewModels::DialogViewModel.Handle+0xa6
      Telegram\ViewModels\DialogViewModel.Handle.cs:1392
   8  $0_Telegram::ViewModels::DialogViewModel.PendingMessage_Completed+0x164
      Telegram\ViewModels\DialogViewModel.Handle.cs:848
   9  $60_Windows::UI::Xaml::DependencyPropertyChangedCallback.Invoke+0x2e
  10  $0_Telegram::ViewModels::DialogPendingMessage.RaiseUpdate+0x74
      Telegram\ViewModels\Dialogs\DialogPendingTextMessage.cs:173
  11  $0_Telegram::ViewModels::DialogPendingMessage.Typing_Tick+0x12d
      Telegram\ViewModels\Dialogs\DialogPendingTextMessage.cs:158
```

15/15 frames resolved. `InsertMessageInOrder` is unchanged between v12.9.1 and `develop`, so the released line numbers still apply.

## Cause

An index contract broken between `NextIndexOf` and `MessageCollection.RemoveItem`.

`InsertMessageInOrder` moves an existing message by removing it and reinserting it:

```csharp
Items.RemoveAt(oldIndex);
Items.Insert(newIndex, message);
```

`newIndex` comes from `NextIndexOf`, which scans the collection *as it is before the removal* and then compensates for exactly one row disappearing (`if (oldIndex != -1 && oldIndex < newIndex) newIndex--`).

`MessageCollection.RemoveItem` removes more than the row it was given. `UpdateSeparatorOnRemove` and `UpdateForumTopicSeparatorOnRemove` call `base.RemoveItem(index - 1)` / `base.RemoveItem(index + 1)` to drop the `MessageHeaderDate` / `MessageHeaderMessageTopic` that the removal orphans. So one `Items.RemoveAt` can shrink the collection by two while the index was adjusted for one, and the following `Insert` lands past the end.

It needs the message to be the only one of its day (so its date header goes with it) and not to be the last row, so that the stale index is actually beyond the new count — a sponsored message sitting below it is the common case. Everything here runs on the UI thread via `BeginOnUIThread`, so this is rare-but-deterministic rather than a race: the crash is reached when a locally pending message completes and is reinserted under its real id.

(The released build attributes the throw to line 1569, the `Insert` in the `force` branch, but `InsertMessage` always passes `force: false`; the two identical `Items.Insert` call sites are tail-merged by the AOT compiler. The failing statement is the one in the `oldIndex != -1` branch.)

## The fix

Recompute the insertion index *after* the removal instead of trusting the pre-removal value:

```csharp
private void MoveMessageInOrder(MessageViewModel message, int oldIndex)
{
    Items.RemoveAt(oldIndex);
    Items.Insert(NextIndexOf(message, 0, out _), message);
}
```

Clamping would also have stopped the exception, but it would silently place the message in the wrong row, so it is not used here.

Both remove-then-insert paths go through the helper. The `force` branch (`InsertMessageInOrder(message, 0, true)`, used when an expired-media content replacement needs a new template) had the same defect for the same reason: it reinserted at `oldIndex`, which is out of bounds once the header ahead of the message has been dropped too.

The recomputed call passes `oldMessageId: 0`, and `RemoveItem` has already dropped the key, so `NextIndexOf` takes the `oldIndexNeeded == false` path — it can't return `-1` and it does no index compensation. Cost is one extra reverse scan, which breaks as soon as the slot is found, only on the move path; no allocations.

`MessageCollection` is deliberately untouched: changing what `RemoveItem` removes would need an audit of every mutation site that indexes into it.

## Testing

Not built — a UWP/.NET Native build isn't available here. The changed file parses cleanly with `CSharpSyntaxTree.ParseText(...).GetDiagnostics()`, which catches syntax errors and nothing more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
