### PR TITLE
Stop the gallery from taking input while it closes

### DIFF
--- a/Telegram/Controls/Gallery/GalleryWindow.xaml.cs
+++ b/Telegram/Controls/Gallery/GalleryWindow.xaml.cs
@@ -576,9 +576,20 @@ namespace Telegram.Controls.Gallery
                                     Hide();
                                 }
 
-                                animation.Completed += handler;
                                 animation.Configuration = new DirectConnectedAnimationConfiguration();
                                 translate = animation.TryStart(element);
+
+                                if (translate)
+                                {
+                                    animation.Completed += handler;
+                                }
+                                else
+                                {
+                                    // Completed never fires for an animation that didn't start, so the
+                                    // handler would pin the window through the animation service, and
+                                    // the prepared animation would be picked up by the next gallery.
+                                    animation.Cancel();
+                                }
                             }
                         }
                     }
@@ -593,16 +604,25 @@ namespace Telegram.Controls.Gallery
             if (translate)
             {
                 _layout.StartAnimation("Offset.Y", CreateScalarAnimation(_layout.Offset.Y, ActualSize.Y, false));
-                batch.Completed += (s, args) =>
-                {
-                    Hide();
-                };
             }
 
+            // The fade always runs, so hiding on its batch is the one path that is taken no
+            // matter which closing animation was used: the connected animation may never start.
+            batch.Completed += OnClosingCompleted;
             batch.End();
 
             Dispose();
             Unload();
+        }
+
+        private void OnClosingCompleted(object sender, CompositionBatchCompletedEventArgs args)
+        {
+            if (sender is CompositionScopedBatch batch)
+            {
+                batch.Completed -= OnClosingCompleted;
+            }
+
+            Hide();
         }
 
         private void Preview_ImageOpened(object sender, RoutedEventArgs e)
@@ -834,6 +854,11 @@ namespace Telegram.Controls.Gallery
                 ViewModel.Aggregator.Unsubscribe(this);
                 ViewModel.PlaybackStopped();
             }
+
+            // Closing is animated and Hide() only runs when the animation completes, so the
+            // window is still on screen after this point. Nothing below it can serve a click
+            // without a view model, so stop taking input rather than guarding every handler.
+            IsHitTestVisible = false;
 
             DataContext = null;
             Bindings.StopTracking();
@@ -1434,7 +1459,15 @@ namespace Telegram.Controls.Gallery
 
         private void Caption_TextEntityClick(object sender, TextEntityClickEventArgs e)
         {
-            var delegato = new MessageDelegate(ViewModel);
+            // A focused hyperlink can still be invoked from the keyboard or by automation
+            // while the window closes, neither of which hit tests.
+            var viewModel = ViewModel;
+            if (viewModel == null)
+            {
+                return;
+            }
+
+            var delegato = new MessageDelegate(viewModel);
             if (e.Type is TextEntityTypeBotCommand && e.Text is string command)
             {
                 delegato.SendBotCommand(command);


### PR DESCRIPTION
### The crash

`NullReferenceException` — *Object reference not set to an instance of an object.*
Reported by crash telemetry on 12.9.1.0 (X64).

```
   0  $0_Telegram::ViewModels::MessageDelegate..ctor+0x11
      Telegram\ViewModels\MessageDelegate.cs:44
   1  $0_Telegram::Controls::Gallery::GalleryWindow.Caption_TextEntityClick+0x4c
      Telegram\Controls\Gallery\GalleryWindow.xaml.cs:1437
   2  $0_Telegram::Controls::Messages::MessageTextBlock.OnBlockTextEntityClick+0x37
      Telegram\Controls\Messages\MessageTextBlock.cs:390
   3  $0_Telegram::Controls::FormattedTextBlock.Entity_Click+0x86
      Telegram\Controls\FormattedTextBlock.cs:2024
   4  $60_Windows::UI::Xaml::DependencyPropertyChangedCallback.Invoke+0x2e
   5  $60___Interop::Intrinsics.HasThisCall__322<System.__Canon>+0x36
   6  $60___Interop::ReverseComStubs.Stub_3<System.__Canon, System.__Canon>+0x93
```

All frames resolved. `MessageDelegate.cs:44` is the base constructor call,
`: base(viewModel.ClientService, viewModel.Settings, viewModel.Aggregator)`, so the
`viewModel` passed in was null.

### The cause

Closing the gallery is animated, and the window keeps accepting input between
`DataContext = null` and the deferred `Hide()`.

`OnBackRequestedOverride` calls `Unload()` **synchronously**, and `Unload()` sets
`DataContext = null`. The actual `Hide()` is deferred to the completion of the closing
animation — either the scoped batch's `Completed`, or the connected animation's. So for
the length of that animation the window is still on screen and still hit-testable while
`ViewModel` (`DataContext as GalleryViewModelBase`) is already null. A click on a caption
hyperlink landing in that gap runs `Caption_TextEntityClick` with `ViewModel == null`,
which it passes straight into a constructor that dereferences it. The caption also lives
outside `ScrollingHost`, so the gallery's tap-to-close handler does not consume the click.

That this state is reachable is not news to the file — roughly ten other handlers in it
already use `ViewModel?.` or an explicit null check (`Preview_ImageOpened` is the closest
example). `Caption_TextEntityClick` is the one that passes it on unguarded.

### The fix

**1. The closing window stops taking input.** `Unload()` now sets `IsHitTestVisible = false`.
It is set on the window itself, which is the `ContentControl` hosted as the popup's child
and therefore the outermost element of the gallery's tree — the XAML's own `LayoutRoot` is
the inner `CarouselViewer`, not the root. This closes the whole "input after unload" family
rather than one handler at a time.

`Caption_TextEntityClick` is guarded as well, in the style the file already uses, because
hit-testing is not the only way in: a hyperlink that already has focus can still be invoked
from the keyboard (Enter) or through UI Automation, and neither goes through hit-testing.

**2. `Hide()` is now reachable on every path.** Separate bug in the same method, which could
leave the gallery on screen forever:

```csharp
animation.Completed += handler;                  // handler calls Hide()
animation.Configuration = new DirectConnectedAnimationConfiguration();
translate = animation.TryStart(element);         // false -> no batch.Completed -> no Hide()
```

`Completed` was subscribed before `TryStart`, and the batch's `Hide()` was registered only
inside `if (translate)`. When `TryStart` returned false, the connected animation never ran
so its `Completed` never fired, and `translate` was false so the batch never hid the window
either — no `Hide()` at all. The subscription also outlived the attempt: with `-=` living
inside the handler, an animation that never starts keeps the handler, and the animation
service keeps the prepared animation, pinning the window.

Now `Hide()` hangs off the fade batch, which is started unconditionally on every path, and
`Completed` is subscribed only when `TryStart` actually succeeded (the prepared animation is
cancelled otherwise, so it is not left behind for the next gallery to pick up under the same
key). The batch handler is a named method with a matching `-=`, replacing the lambda that
could not be unsubscribed.

### Build

**Not built.** `CSharpSyntaxTree.ParseText(...).GetDiagnostics()` on the changed file returns
no diagnostics, so it parses — that is a syntax check only, not a compile and not a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
