### PR TITLE
Detach the emoji and sticker drawers from their collections on Deactivate

### DIFF
--- a/Telegram/Controls/Drawers/EmojiDrawer.xaml.cs
+++ b/Telegram/Controls/Drawers/EmojiDrawer.xaml.cs
@@ -228,6 +228,17 @@ namespace Telegram.Controls.Drawers
             // so we can safely clean up any kind of anything from here.
             _zoomer.Release();
             Bindings.StopTracking();
+
+            // StopTracking doesn't clear what the bindings already pushed: the collection view
+            // source and the two toolbars still hold a CollectionChanged handler on the view
+            // model's collections, and UnloadObject is about to destroy their native peers.
+            // The view model outlives us (it stays subscribed to the aggregator, and Handle
+            // queues Update on the UI thread), so leaving them attached means the next
+            // ReplaceWith raises into a dead RCW.
+            List.ItemsSource = null;
+            EmojiCollection.Source = null;
+            Toolbar.ItemsSource = null;
+            Toolbar2.ItemsSource = null;
         }
 
         public void LoadVisibleItems()

--- a/Telegram/Controls/Drawers/StickerDrawer.xaml.cs
+++ b/Telegram/Controls/Drawers/StickerDrawer.xaml.cs
@@ -113,6 +113,13 @@ namespace Telegram.Controls.Drawers
             // so we can safely clean up any kind of anything from here.
             _zoomer.Release();
             Bindings.StopTracking();
+
+            // Same as EmojiDrawer: the bindings' last value keeps a CollectionChanged handler
+            // on the view model's collections alive past UnloadObject, and the view model can
+            // still queue an Update from the aggregator.
+            List.ItemsSource = null;
+            StickersSource.Source = null;
+            Toolbar.ItemsSource = null;
         }
 
         public void LoadVisibleItems()

--- a/Telegram/Controls/Messages/EmojiMenuFlyout.xaml.cs
+++ b/Telegram/Controls/Messages/EmojiMenuFlyout.xaml.cs
@@ -66,6 +66,8 @@ namespace Telegram.Controls.Messages
 
         private readonly Popup _popup;
 
+        private EmojiDrawer _drawer;
+
         public event EventHandler<EmojiSelectedEventArgs> EmojiSelected;
         public event EventHandler<AvailableReaction> ItemClick;
 
@@ -88,13 +90,23 @@ namespace Telegram.Controls.Messages
             _areTags = reactions.AreTags;
 
             _popup = new Popup();
-            _popup.Closed += OnClosed;
 
             Initialize(message.ClientService, element, EmojiFlyoutAlignment.Center, viewModel);
         }
 
         private void OnClosed(object sender, object e)
         {
+            _popup.Closed -= OnClosed;
+
+            // The view model is resolved per flyout but stays subscribed to the aggregator,
+            // so it can queue an Update long after the popup is gone. Deactivate detaches the
+            // drawer's collection bindings, which is what keeps that update from raising into
+            // native peers that are no longer alive.
+            _drawer.ItemClick -= OnStatusClick;
+            _drawer.ItemContextRequested -= OnStatusContextRequested;
+            _drawer.Deactivate();
+            _drawer.DataContext = null;
+
             if (_bubble is FrameworkElement element && AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
             {
                 var selector = element.GetParent<SelectorItem>();
@@ -186,6 +198,12 @@ namespace Telegram.Controls.Messages
             viewModel ??= EmojiDrawerViewModel.Create(clientService.Session, _mode);
 
             var view = new EmojiDrawer(_mode);
+            _drawer = view;
+
+            // Subscribed here rather than in the constructors, so that all three of them tear
+            // the drawer down and not just the message one.
+            _popup.Closed += OnClosed;
+
             view.DataContext = viewModel;
             view.VerticalAlignment = VerticalAlignment.Top;
             view.Width = width;


### PR DESCRIPTION
`InvalidComObjectException` — *COM object that has been separated from its underlying RCW cannot be used* — reported by crash telemetry on 12.9.1.

### Frames

```
   0  $8_System::Runtime::InteropServices::McgMarshal.GetInterface+0xfe
   1  $23___Interop::ComCallHelpers.Call+0x19
   2  $23_System::Collections::Specialized::NotifyCollectionChangedEventHandler__Impl.Invoke+0xb0
   3  System::AssemblyLoadEventHandler.InvokeClosedStaticThunk+0x2e
   4  System::EventHandler.Invoke+0x2e
   5  $7_System::Collections::ObjectModel::ObservableCollection$1<System::__UniversalCanon>.OnCollectionChanged+0x2b
   6  $0_Telegram::Collections::MvxObservableCollection$1<System::__Canon>.OnCollectionChanged
      Telegram\Collections\MvxObservableCollection.cs:106
   7  $0_Telegram::Collections::MvxObservableCollection$1<System::__Canon>.ReplaceWith
      Telegram\Collections\MvxObservableCollection.cs:200
   8  $0_Telegram::ViewModels::Drawers::EmojiDrawerViewModel::<Update>d__30.MoveNext
      Telegram\ViewModels\Drawers\EmojiDrawerViewModel.cs:364
   9  System::Runtime::ExceptionServices::ExceptionDispatchInfo.Throw+0x21
  10  System::Runtime::CompilerServices::AsyncMethodBuilderCore::<>c.<ThrowAsync>b__7_0+0x1e
  ...
  16  $0_Telegram::WatchDog.OnUnhandledExceptionDetected
      Telegram\Common\WatchDog.cs:141
```

All 17 frames resolved.

### Cause

`MvxObservableCollection.ReplaceWith` raises a `Reset`, and one of the subscribers on `EmojiDrawerViewModel.Items` is a COM object (`NotifyCollectionChangedEventHandler__Impl.Invoke(__ComObject, …)`) whose RCW is already gone. That subscriber is the XAML side of the drawer:

* `EmojiDrawer.xaml` binds `<CollectionViewSource x:Name="EmojiCollection" Source="{x:Bind ViewModel.Items}" />` and the two toolbars `ItemsSource="{x:Bind ViewModel.InstalledSets}"` / `"{x:Bind ViewModel.StandardSets}"` — all `OneTime`. The native peers subscribe to `INotifyCollectionChanged` on those collections.
* `EmojiDrawer.Deactivate()` only called `Bindings.StopTracking()`. That stops the bindings from pushing new values but leaves the value they already pushed in place, so the peers stay attached. Its own comment notes it runs "right before `XamlMarkupHelper.UnloadObject`", which is exactly what destroys those peers (`StickerPanel.UnloadAtIndex`, `CreateChatPhotoPopup.UnloadAtIndex`).
* `EmojiDrawerViewModel` subscribes to the aggregator **in its constructor**, and `Handle(UpdateInstalledStickerSets)` does `BeginOnUIThread(() => Update())`. `Session.Resolve<EmojiDrawerViewModel>()` returns a new instance per call, so this is not a shared long-lived view model — it is a per-view one kept alive past its view by that queued `Update`.

So an `UpdateInstalledStickerSets` that arrives around the time the drawer is unloaded queues an `Update` that runs after the peers are destroyed, and `Items.ReplaceWith` raises into them. `Update` then does `InstalledSets.ReplaceWith` and `StandardSets.ReplaceWith` on the same code path, which is why all three bindings are cleared rather than just the one in the stack.

`EmojiMenuFlyout` makes it easier to hit: it creates a drawer and (usually) a view model per flyout, and its `OnClosed` never called `Deactivate` at all — nor was `OnClosed` even subscribed in two of its three constructors.

### Changes

* `EmojiDrawer.Deactivate` clears `List.ItemsSource`, `EmojiCollection.Source`, `Toolbar.ItemsSource` and `Toolbar2.ItemsSource`, so nothing native still holds a handler on the view model's collections once `UnloadObject` runs. Every call site of `Deactivate` is immediately followed by `UnloadObject`, so the drawer is never re-activated after this.
* `StickerDrawer.Deactivate` gets the same treatment. It has the same shape — `StickersSource.Source` bound to `ViewModel.Stickers`, `Toolbar.ItemsSource` bound to `ViewModel.SavedStickers`, the same terminal `Deactivate` contract — and `StickerDrawerViewModel.Handle(UpdateInstalledStickerSets)` likewise queues `Update`, which calls `SavedStickers.ReplaceWith`. Same bug, just not the one that got reported.
* `EmojiMenuFlyout` now subscribes `Popup.Closed` in `Initialize` (all three constructors reach it, only one subscribed before) and, on close, unsubscribes the drawer's events, calls `Deactivate` and clears `DataContext` — the same teardown `StickerPanel.UnloadAtIndex` does. `Deactivate` only touches objects the drawer owns and the popup's child tree is still alive at `Closed`, so it is safe from there.

`AnimationDrawer` and `EffectDrawer` share the general pattern but their bound collections are not mutated from an aggregator-queued update in the same way, so they are left alone.

No guard was added inside `EmojiDrawerViewModel.Update`; that would only move the failure.

### Not built

I could not build this — the UWP/.NET Native toolchain isn't available here. The three changed files were checked with Roslyn `CSharpSyntaxTree.ParseText(...).GetDiagnostics()` and parse clean, which catches syntax errors only, not type errors. The XAML is unchanged and unchecked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
