### PR TITLE
Normalize the ASTA "application is busy" message

### DIFF
--- a/Telegram/Common/ExceptionSerializer.cs
+++ b/Telegram/Common/ExceptionSerializer.cs
@@ -16,6 +16,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using Telegram.Native;
 using Telegram.Services;
 using Windows.ApplicationModel;
@@ -482,6 +483,12 @@ namespace Telegram.Common
 
                 var part = parts[i];
 
+                if (TryTranslateAstaCall(part, out string asta))
+                {
+                    builder.Append(asta);
+                    continue;
+                }
+
                 var index = part.IndexOf('(');
                 if (index > 0)
                 {
@@ -495,6 +502,33 @@ namespace Telegram.Common
             }
 
             return builder.ToString();
+        }
+
+        // The labels around the IID and the method index are localised, but the GUID and the number
+        // that follows it are not, so the two are matched structurally rather than by their wording.
+        private static readonly Regex _astaCall = new(@"(\{[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\})[^)0-9]{0,64}([0-9]+)", RegexOptions.Compiled);
+
+        // RPC_E_SERVERCALL_RETRYLATER carries a detail sentence naming the ASTA thread, and that id is
+        // different on every hang, so each report would otherwise land in a group of its own. Only the
+        // IID and the method index say anything about which call hung, so they're all that's kept.
+        private static bool TryTranslateAstaCall(string text, out string translated)
+        {
+            // "ASTA" is left untranslated in every locale seen, and restricts the match to this message.
+            if (text.Contains("ASTA"))
+            {
+                var match = _astaCall.Match(text);
+                if (match.Success)
+                {
+                    translated = string.Format(CultureInfo.InvariantCulture,
+                        "The message filter indicated that the application is busy. A COM call (IID: {0}, method index: {1}) to an ASTA appears deadlocked and was timed out.",
+                        match.Groups[1].Value.ToUpperInvariant(),
+                        match.Groups[2].Value);
+                    return true;
+                }
+            }
+
+            translated = null;
+            return false;
         }
 
         private static string TranslateText(string text)


### PR DESCRIPTION
This is a crash **reporting** change, not a crash fix: the hang it is about is unaffected.

### The message

`RPC_E_SERVERCALL_RETRYLATER` is reported as a single line that looks like this:

```
The message filter indicated that the application is busy. A COM call (IID: {18DA40A4-3276-5448-9166-6A83278D2D1B}, method index: 3) to an ASTA (thread 16276) appears deadlocked and was timed out.
```

The thread id at the end is a fresh number on every hang. Since the grouping hash includes the
message, one fault reports under a new group every single time, and the detail sentence is
localized on top of that, so it also splits per display language. Looking at the distinct message
variants of this family over the last four weeks, the first sentence arrives in English in nearly
all of them (it comes from the runtime's own resources), while the sentence after it — the one
naming the IID, the method index and the thread — arrives in the Windows display language: eight
languages and ten sentence templates.

### Why a `case` in `TranslateText` cannot fix it

`TranslateText` maps a fixed localized string onto its English wording. Here the string is never
fixed: the thread id varies within a single language, so every locale would need an unbounded
number of cases. `TranslateMessage` also cuts each line at the first `(` and only translates the
part before it, and in this message the first `(` opens the `IID:` group, so the translated prefix
would be `…is busy. Un appel COM` — never a stable key either.

So the family needs the variable parts stripped rather than a translation table, and this adds a
special case ahead of the existing per-line and `(` handling. Nothing else changes, and the
`switch` is untouched, so it does not collide with #3357.

### What the rule keeps and what it drops

Recognition is structural, not lexical: the line must contain `ASTA` (untranslated in every
variant observed) and a braced GUID followed by a number. The labels differ per language —
"method index", "индекс метода", "index de méthode", "método de indexado", "yöntem dizini",
"方法索引" — but the GUID and the number are always in the same structural position, and in two
of the templates (Turkish, Chinese) the thread id is even mentioned *before* the IID, which a
label-based match would have got wrong.

* **Dropped: the thread id.** It changes on every occurrence and carries no signal.
* **Dropped: the localized wording.** Replaced by one canonical English sentence.
* **Kept: the IID and the method index.** They say which call hung, and they come from a small
  set — six IIDs across all the variants — so they collapse the family to a handful of groups
  rather than to one, which is a better trade than throwing the only diagnostic content away.

Output shape:

```
The message filter indicated that the application is busy. A COM call (IID: {…}, method index: N) to an ASTA appears deadlocked and was timed out.
```

Checked against every distinct variant of this family from the last four weeks: all of them are
recognized, and they normalize into 6 distinct strings — one per IID (the method index turned out
to be constant per IID in this data, so it costs nothing to keep and would distinguish the case
where it is not). A line the pattern does not match falls through to the existing code path and
comes out exactly as it does today.

### Not built

The UWP/.NET Native app was not built here. The file parses — verified with
`CSharpSyntaxTree.ParseText(...).GetDiagnostics()`, which catches syntax errors and nothing more,
not type errors. The regex and the rewrite were exercised against the real message variants in a
scratch .NET console program (and cross-checked in Python), not inside the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
