### PR TITLE
Track focus rather than window activation in ChooseCapturePopup

### DIFF
--- a/Telegram/Views/Popups/ChooseCapturePopup.xaml.cs
+++ b/Telegram/Views/Popups/ChooseCapturePopup.xaml.cs
@@ -8,9 +8,7 @@
 using Rg.DiffUtils;
 using Telegram.Controls;
 using Telegram.Controls.Cells;
-using Telegram.Navigation;
 using Telegram.Services;
-using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Controls;
@@ -34,9 +32,6 @@ namespace Telegram.Views.Popups
             ShareSystemAudio.Visibility = canShareAudio
                 ? Visibility.Visible
                 : Visibility.Collapsed;
-
-            Loaded += OnLoaded;
-            Unloaded += OnUnloaded;
         }
 
         class CaptureSessionItemDiffHandler : IDiffHandler<CaptureSessionItem>
@@ -61,20 +56,27 @@ namespace Telegram.Views.Popups
             }
         }
 
-        private void OnLoaded(object sender, RoutedEventArgs e)
+        // The list is only correct for as long as the user stays here: they usually leave to
+        // arrange the window they want to share. Focus follows window activation, and unlike
+        // WindowContext it needs no XamlRoot - which is null by the time the popup unloads, so
+        // detaching from Activated there was itself a crash.
+        private bool _lostFocus;
+
+        protected override void OnLostFocus(RoutedEventArgs e)
         {
-            WindowContext.ForXamlRoot(XamlRoot).Activated += OnActivated;
+            base.OnLostFocus(e);
+            _lostFocus = true;
         }
 
-        private void OnUnloaded(object sender, RoutedEventArgs e)
+        protected override void OnGotFocus(RoutedEventArgs e)
         {
-            WindowContext.ForXamlRoot(XamlRoot).Activated -= OnActivated;
-        }
+            base.OnGotFocus(e);
 
-        private void OnActivated(object sender, WindowActivatedEventArgs e)
-        {
-            if (e.WindowActivationState != CoreWindowActivationState.Deactivated)
+            // Only a pair counts. Enumerating every window on the system is not something to do
+            // on any focus change, and focus arrives here once simply by opening the popup.
+            if (_lostFocus)
             {
+                _lostFocus = false;
                 _items.ReplaceDiff(CaptureSessionService.FindAll());
             }
         }


### PR DESCRIPTION
`NullReferenceException` at `ChooseCapturePopup.xaml.cs:66`, reported by crash telemetry on 12.9.1.

```
   0  Telegram.Views.Popups.ChooseCapturePopup.OnLoaded
      Telegram/Views/Popups/ChooseCapturePopup.xaml.cs:66
```

## Cause

The popup lists capturable windows and refreshes when the user comes back from arranging the one
they want to share. It got that signal from the window:

```csharp
private void OnLoaded(object sender, RoutedEventArgs e)
{
    WindowContext.ForXamlRoot(XamlRoot).Activated += OnActivated;
}

private void OnUnloaded(object sender, RoutedEventArgs e)
{
    WindowContext.ForXamlRoot(XamlRoot).Activated -= OnActivated;
}
```

Both halves are unsafe, for different reasons.

`ForXamlRoot` looks the window up in `WindowContext`'s mapping, and `OnConsolidated` → `OnClosed`
removes it from there while the XAML tree stays alive and interactive — the code even notes
"since we can't call Close directly, Closed event will be never fired". Re-registration is not
possible afterwards, because the mapping is only written from `OnLoading`. So a group-call window
that has been consolidated returns null here and the subscribe throws.

The detach is worse than the reported crash: by the time the popup unloads `XamlRoot` may be null
— and accessing it can throw on its own — so the `-=` may not run at all, leaving the handler
attached to a `WindowContext` that outlives the popup.

This is also the only `ForXamlRoot` call site in the app that dereferences the result directly.
Every other one assigns to a local and null-checks it.

## The fix

Focus tracks window activation just as reliably, and needs neither `WindowContext` nor
`XamlRoot`: `GotFocus` is raised when the window is activated, `LostFocus` when it is
deactivated. So the popup overrides both and refreshes on a **lost-then-got pair**.

The pairing matters. A bare `GotFocus` is not the signal — one arrives simply from opening the
popup — and `CaptureSessionService.FindAll()` enumerates every window on the system, so it should
not run on any focus change.

With this there is nothing to subscribe and nothing to detach, so the unload path that could not
be made safe is gone rather than guarded.

## Build

Not built — a UWP/.NET Native build isn't available here. The file passes
`CSharpSyntaxTree.ParseText(...).GetDiagnostics()`, which confirms it parses and nothing more.
The focus behaviour was verified by Fela on a real device rather than by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
