### PR TITLE
Snapshot the collections before diffing them off-thread

### DIFF
--- a/Telegram/Collections/SearchCollection.cs
+++ b/Telegram/Collections/SearchCollection.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading;
 using System.Threading.Tasks;
@@ -111,7 +112,13 @@ namespace Telegram.Collections
                     var token = Cancel();
 
                     await incremental.LoadMoreItemsAsync(0);
-                    var diff = await Task.Run(() => DiffUtil.CalculateDiff(this, source, DefaultDiffHandler, DefaultOptions));
+                    // The diff runs on the thread pool, but both collections belong to the UI thread
+                    // and keep growing while it runs - reading one as another thread appends to it is
+                    // what threw out of Array.Copy. Snapshot first; the diff only needs the sequences.
+                    var oldItems = this.ToArray();
+                    var newItems = source.ToArray();
+
+                    var diff = await Task.Run(() => DiffUtil.CalculateDiff(oldItems, newItems, DefaultDiffHandler, DefaultOptions));
 
                     if (token.IsCancellationRequested)
                     {

--- a/Telegram/Controls/Chats/ChatTextBox.cs
+++ b/Telegram/Controls/Chats/ChatTextBox.cs
@@ -1409,7 +1409,11 @@ namespace Telegram.Controls.Chats
                     var token = Cancel();
 
                     await incremental.LoadMoreItemsAsync(0);
-                    var diff = await Task.Run(() => DiffUtil.CalculateDiff(this, source, DefaultDiffHandler, DefaultOptions));
+                    // Snapshot on the UI thread: the diff runs on the pool, and these keep growing.
+                    var oldItems = this.ToArray();
+                    var newItems = source.ToArray();
+
+                    var diff = await Task.Run(() => DiffUtil.CalculateDiff(oldItems, newItems, DefaultDiffHandler, DefaultOptions));
 
                     if (token.IsCancellationRequested)
                     {
@@ -1439,7 +1443,11 @@ namespace Telegram.Controls.Chats
                     _loading = true;
 
                     var token = Cancel();
-                    var diff = await Task.Run(() => DiffUtil.CalculateDiff(this, source, DefaultDiffHandler, DefaultOptions));
+                    // Snapshot on the UI thread: the diff runs on the pool, and these keep growing.
+                    var oldItems = this.ToArray();
+                    var newItems = source.ToArray();
+
+                    var diff = await Task.Run(() => DiffUtil.CalculateDiff(oldItems, newItems, DefaultDiffHandler, DefaultOptions));
 
                     if (token.IsCancellationRequested)
                     {
@@ -1467,7 +1475,11 @@ namespace Telegram.Controls.Chats
                     _loading = true;
 
                     var token = Cancel();
-                    var diff = await Task.Run(() => DiffUtil.CalculateDiff(this, source, DefaultDiffHandler, DefaultOptions));
+                    // Snapshot on the UI thread: the diff runs on the pool, and these keep growing.
+                    var oldItems = this.ToArray();
+                    var newItems = source.ToArray();
+
+                    var diff = await Task.Run(() => DiffUtil.CalculateDiff(oldItems, newItems, DefaultDiffHandler, DefaultOptions));
 
                     if (token.IsCancellationRequested)
                     {
@@ -1502,7 +1514,11 @@ namespace Telegram.Controls.Chats
 
                 if (result.Count > 0 && !token.IsCancellationRequested)
                 {
-                    var diff = await Task.Run(() => DiffUtil.CalculateDiff(this, _source, DefaultDiffHandler, DefaultOptions));
+                    // Snapshot on the UI thread: the diff runs on the pool, and these keep growing.
+                    var oldItems = this.ToArray();
+                    var newItems = _source.ToArray();
+
+                    var diff = await Task.Run(() => DiffUtil.CalculateDiff(oldItems, newItems, DefaultDiffHandler, DefaultOptions));
 
                     if (token.IsCancellationRequested)
                     {


### PR DESCRIPTION
`ArgumentException` — "Value does not fall within the expected range." Reported by crash
telemetry on 12.9.1.

```
   0  System.Array.CopyImpl
   1  System.Array.Copy
   2  System.Collections.Generic.LowLevelList`1.CopyTo
   3  System.Collections.ObjectModel.Collection`1.CopyTo
   4  Rg.DiffUtils.DiffUtil.CalculateDiff<T>
   5  Telegram.Collections.SearchCollection`2.<UpdateImpl>b__0
      Telegram/Collections/SearchCollection.cs:114
```

## Cause

`SearchCollection.UpdateImpl` computes its diff on the thread pool:

```csharp
await incremental.LoadMoreItemsAsync(0);
var diff = await Task.Run(() => DiffUtil.CalculateDiff(this, source, DefaultDiffHandler, DefaultOptions));
```

Both arguments are collections the **UI thread** owns and is still appending to, and
`CalculateDiff` begins by copying them — which is exactly the frame that threw. The pool thread
runs `Array.Copy` over a list whose backing array and count are being replaced underneath it.

The guard meant to prevent this is a plain `bool`:

- `UpdateImpl` sets `_loading = true` before awaiting, and `LoadMoreItemsAsync` returns early
  while it is set.
- But `LoadMoreItemsAsync` also **clears** `_loading` when it finishes. One that was already in
  flight when `UpdateImpl` set the flag hands the door back while the diff is still running, and
  the next scroll appends to the very collection being copied.

That interleaving needs a load to be in flight at the moment an update starts, which is why it is
rare — and the report has about half a minute of continuous scrolling behind it, with
`ProfilePage.OnViewChanging` firing every few hundred milliseconds while the profile's media tab
paged in.

## The fix

Snapshot both collections on the UI thread and diff the snapshots. `CalculateDiff` only ever
needed the sequences; the indices it returns stay valid because items are appended rather than
inserted, so `ReplaceDiff` and `UpdateItems` are unaffected. Nothing else has to be synchronised,
and the cross-thread read is gone by construction rather than guarded.

Two arrays per update, on a path that runs when the query or sender changes — not a hot path.

The same lines were copied into `ChatTextBox`'s autocomplete, so all four sites are changed.
**Only the first is evidenced by a crash**; the others are the same code with a smaller, shorter
lived collection behind it.

## Not fixed here

`_loading` remains a plain `bool` written by two different async methods, so it is still an
unreliable guard for anything else that depends on it. It no longer has memory-safety
consequences, which is why this change stops where it does.

## Build

Not built — a UWP/.NET Native build isn't available here. Both files pass
`CSharpSyntaxTree.ParseText(...).GetDiagnostics()`, which confirms they parse and nothing more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
