### PR TITLE
Encode voice messages while they are recorded

### DIFF
--- a/Telegram/Common/Recording/AudioWaveform.cs
+++ b/Telegram/Common/Recording/AudioWaveform.cs
@@ -1,0 +1,179 @@
+//
+// Copyright (c) Fela Ameghino 2015-2026
+//
+// Distributed under the GNU General Public License v3.0. (See accompanying
+// file LICENSE or copy at https://www.gnu.org/licenses/gpl-3.0.txt)
+//
+
+using System;
+
+namespace Telegram.Common.Recording
+{
+    /// <summary>
+    /// Accumulates the waveform of a recording, and the microphone level that drives the blob,
+    /// from the captured samples as they arrive.
+    /// </summary>
+    public sealed partial class AudioWaveform
+    {
+        // Buckets are filled to 200 and then folded in half, doubling the number of samples each
+        // one covers, so the accumulator costs the same whether the recording is 1 or 100 seconds.
+        private const int Capacity = 200;
+
+        // What Telegram's waveform format holds: 100 buckets of 5 bits each.
+        private const int BucketCount = 100;
+        private const int BucketMax = 31;
+
+        // 1200 samples is 25ms at 48kHz, so the blob gets a new level roughly once per frame.
+        private const int LevelInterval = 1200;
+
+        private readonly float[] _buckets = new float[Capacity];
+        private int _count;
+
+        private float _bucketPeak;
+        private int _bucketCount;
+        private int _bucketSize = 1;
+
+        private float _levelPeak;
+        private int _levelCount;
+
+        /// <summary>
+        /// The loudest sample since the last time a level was reported.
+        /// </summary>
+        public float Level { get; private set; }
+
+        /// <summary>
+        /// Folds a block of samples into the waveform. Returns true when <see cref="Level"/> has
+        /// been refreshed, so the caller knows to notify without keeping a clock of its own.
+        /// </summary>
+        public bool Add(ReadOnlySpan<float> samples)
+        {
+            var level = false;
+
+            for (int i = 0; i < samples.Length; i++)
+            {
+                var sample = MathF.Abs(samples[i]);
+
+                if (_bucketPeak < sample)
+                {
+                    _bucketPeak = sample;
+                }
+
+                if (++_bucketCount == _bucketSize)
+                {
+                    _buckets[_count++] = _bucketPeak;
+
+                    // Resetting the peak is what makes each bucket the peak of its own window.
+                    // Without it the waveform is a running maximum and can only ever climb.
+                    _bucketPeak = 0;
+                    _bucketCount = 0;
+
+                    if (_count == Capacity)
+                    {
+                        for (int j = 0; j < Capacity / 2; j++)
+                        {
+                            _buckets[j] = MathF.Max(_buckets[j * 2 + 0], _buckets[j * 2 + 1]);
+                        }
+
+                        _count = Capacity / 2;
+                        _bucketSize *= 2;
+                    }
+                }
+
+                if (_levelPeak < sample)
+                {
+                    _levelPeak = sample;
+                }
+
+                if (++_levelCount >= LevelInterval)
+                {
+                    Level = _levelPeak;
+                    _levelPeak = 0;
+                    _levelCount = 0;
+
+                    level = true;
+                }
+            }
+
+            return level;
+        }
+
+        public void Reset()
+        {
+            Array.Clear(_buckets, 0, _buckets.Length);
+
+            _count = 0;
+            _bucketPeak = 0;
+            _bucketCount = 0;
+            _bucketSize = 1;
+
+            Level = 0;
+            _levelPeak = 0;
+            _levelCount = 0;
+        }
+
+        /// <summary>
+        /// Packs the accumulated buckets into the 5-bit-per-sample waveform that voice notes carry.
+        /// </summary>
+        public unsafe byte[] GetWaveform()
+        {
+            var count = _count;
+            var scaledSamples = new short[BucketCount];
+
+            for (int i = 0; i < count; i++)
+            {
+                var sample = _buckets[i] * short.MaxValue;
+                var index = i * BucketCount / count;
+                if (scaledSamples[index] < sample)
+                {
+                    scaledSamples[index] = (short)sample;
+                }
+            }
+
+            short peak = 0;
+            long sumSamples = 0;
+            for (int i = 0; i < BucketCount; i++)
+            {
+                var sample = scaledSamples[i];
+                if (peak < sample)
+                {
+                    peak = sample;
+                }
+                sumSamples += sample;
+            }
+
+            var calculatedPeak = (ushort)(sumSamples * 1.8 / BucketCount);
+            if (calculatedPeak < 2500)
+            {
+                calculatedPeak = 2500;
+            }
+
+            for (int i = 0; i < BucketCount; i++)
+            {
+                uint sample = (ushort)scaledSamples[i];
+                var minPeak = Math.Min(sample, calculatedPeak);
+                var resultPeak = minPeak * BucketMax / calculatedPeak;
+                scaledSamples[i] = (short)/*clamping:*/ Math.Min(BucketMax, resultPeak);
+            }
+
+            var bitstreamLength = scaledSamples.Length * 5 / 8 + 1;
+            var result = new byte[bitstreamLength];
+
+            fixed (byte* data = result)
+            {
+                static void set_bits(byte* bytes, int bitOffset, int value)
+                {
+                    bytes += bitOffset / 8;
+                    bitOffset %= 8;
+                    *(int*)bytes |= value << bitOffset;
+                }
+
+                for (int i = 0; i < scaledSamples.Length; i++)
+                {
+                    set_bits(data, i * 5, scaledSamples[i] & BucketMax);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/Telegram/Common/Recording/VoiceSink.cs
+++ b/Telegram/Common/Recording/VoiceSink.cs
@@ -1,0 +1,140 @@
+//
+// Copyright (c) Fela Ameghino 2015-2026
+//
+// Distributed under the GNU General Public License v3.0. (See accompanying
+// file LICENSE or copy at https://www.gnu.org/licenses/gpl-3.0.txt)
+//
+
+using System;
+using Telegram.Native.Opus;
+using Windows.Media;
+
+namespace Telegram.Common.Recording
+{
+    /// <summary>
+    /// Encodes captured samples to Ogg/Opus as they arrive, so a voice note needs no transcoding
+    /// once the recording stops.
+    /// </summary>
+    public sealed partial class VoiceSink : IDisposable
+    {
+        // The encoder is built for 48kHz mono and nothing about that is negotiable: the sample
+        // rate is baked into the Opus header and the granule positions.
+        public const uint SampleRate = 48000;
+        public const uint ChannelCount = 1;
+
+        // TG_OPUS_FRAME_SIZE. OpusOutput.WriteFrame consumes whole frames and silently drops
+        // whatever is left over, so it must only ever be handed exact multiples of this.
+        private const int FrameSize = 960;
+        private const int FrameBytes = FrameSize * sizeof(float);
+
+        private readonly OpusOutput _output;
+
+        // One frame, locked and refilled for every 20ms of audio rather than allocated per write.
+        private readonly AudioFrame _frame = new(FrameBytes);
+        private readonly float[] _pending = new float[FrameSize];
+        private int _pendingCount;
+
+        private long _samples;
+
+        // Samples arrive on a capture thread while the recording is stopped from another, and the
+        // encoder underneath is native: a write racing the dispose would be a use-after-free.
+        private readonly object _lock = new();
+        private bool _disposed;
+
+        public VoiceSink(string path)
+        {
+            _output = new OpusOutput(path);
+        }
+
+        public bool IsValid => _output.IsValid;
+
+        /// <summary>
+        /// How much audio has been encoded. Counted from the samples themselves, so it is exact
+        /// and it excludes everything that happened before the first frame arrived.
+        /// </summary>
+        public TimeSpan Duration => TimeSpan.FromSeconds(_samples / (double)SampleRate);
+
+        public void Write(ReadOnlySpan<float> samples)
+        {
+            lock (_lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                while (samples.Length > 0)
+                {
+                    var count = Math.Min(FrameSize - _pendingCount, samples.Length);
+
+                    samples.Slice(0, count).CopyTo(_pending.AsSpan(_pendingCount));
+                    samples = samples.Slice(count);
+
+                    _pendingCount += count;
+
+                    if (_pendingCount == FrameSize)
+                    {
+                        WriteFrame();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Encodes whatever is left in the buffer, padded with silence to a whole frame.
+        /// </summary>
+        public void Complete()
+        {
+            lock (_lock)
+            {
+                if (_disposed || _pendingCount == 0)
+                {
+                    return;
+                }
+
+                Array.Clear(_pending, _pendingCount, FrameSize - _pendingCount);
+                WriteFrame();
+            }
+        }
+
+        private unsafe void WriteFrame()
+        {
+            // Reset first: every path out of here has consumed the buffer, and leaving it full
+            // would spin the caller's loop forever.
+            _pendingCount = 0;
+
+            using (var buffer = _frame.LockBuffer(AudioBufferAccessMode.Write))
+            using (var reference = buffer.CreateReference())
+            {
+                reference.Buffer(out byte* data, out uint capacity);
+
+                if (capacity < FrameBytes)
+                {
+                    return;
+                }
+
+                _pending.AsSpan(0, FrameSize).CopyTo(new Span<float>(data, FrameSize));
+                buffer.Length = FrameBytes;
+            }
+
+            _output.WriteFrame(_frame);
+            _samples += FrameSize;
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+
+                _output.Dispose();
+                _frame.Dispose();
+            }
+        }
+    }
+}

--- a/Telegram/Controls/Chats/ChatRecordButton.cs
+++ b/Telegram/Controls/Chats/ChatRecordButton.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Telegram.Common;
+using Telegram.Common.Recording;
 using Telegram.Entities;
 using Telegram.Services;
 using Telegram.Td;
@@ -733,6 +734,18 @@ namespace Telegram.Controls.Chats
 
             private MediaFrameReader _reader;
 
+            private readonly AudioWaveform _waveform = new();
+
+            // Set only when the capture format can be encoded as it arrives. Otherwise the
+            // recording goes through MediaCapture's own encoder and is transcoded when sent.
+            private VoiceSink _sink;
+
+            private float[] _samples;
+            private uint _channels;
+            private uint _bitsPerSample;
+
+            private bool _paused;
+
             public Recorder()
             {
                 _recordQueue = new ConcurrentQueueWorker(1);
@@ -766,16 +779,14 @@ namespace Telegram.Controls.Chats
 
                     try
                     {
-                        // Create a new temporary file for the recording
-                        var fileName = string.Format(mode == ChatRecordMode.Video
-                            ? "video_{0:yyyy}-{0:MM}-{0:dd}_{0:HH}-{0:mm}-{0:ss}.mp4"
-                            : "voice_{0:yyyy}-{0:MM}-{0:dd}_{0:HH}-{0:mm}-{0:ss}.oga", DateTime.Now);
-                        var file = await ApplicationData.Current.TemporaryFolder.CreateFileAsync(fileName);
-
                         _mode = mode;
-                        _file = file;
                         _chat = chat;
-                        _recorder = new OpusRecorder(file, mode == ChatRecordMode.Video);
+                        _paused = false;
+                        _channels = 0;
+                        _bitsPerSample = 0;
+                        _waveform.Reset();
+
+                        _recorder = new OpusRecorder(mode == ChatRecordMode.Video);
 
                         _recorder.m_mediaCapture = new MediaCapture();
                         _recorder.m_mediaCapture.Failed += OnFailed;
@@ -809,12 +820,33 @@ namespace Telegram.Controls.Chats
 
                         Logger.Debug("Devices initialized, starting");
 
-                        if (PowerSavingPolicy.AreMaterialsEnabled && ApiInfo.CanAnimatePaths)
+                        // For a voice message the reader is the recording, so it always runs. For
+                        // a video message it only feeds the blob, and keeps the gate it had.
+                        var reader = mode == ChatRecordMode.Voice
+                            || (PowerSavingPolicy.AreMaterialsEnabled && ApiInfo.CanAnimatePaths);
+
+                        var streaming = reader && await PrepareReaderAsync() && mode == ChatRecordMode.Voice;
+
+                        _file = await CreateFileAsync(mode, streaming);
+
+                        if (streaming)
                         {
-                            await InitializeQuantumAsync();
+                            _sink = new VoiceSink(_file.Path);
+
+                            if (!_sink.IsValid)
+                            {
+                                throw new InvalidOperationException("Opus encoder couldn't open " + _file.Path);
+                            }
+                        }
+                        else
+                        {
+                            Logger.Info("Recording through MediaCapture, the file will be transcoded when sent");
+                            await _recorder.StartAsync(_file);
                         }
 
-                        await _recorder.StartAsync();
+                        // Started last, so that no sample arrives before there is something to
+                        // write it to.
+                        await StartReaderAsync();
 
                         Logger.Debug("Recording started at " + DateTime.Now);
                     }
@@ -829,6 +861,9 @@ namespace Telegram.Controls.Chats
                             _reader.Dispose();
                             _reader = null;
                         }
+
+                        _sink?.Dispose();
+                        _sink = null;
 
                         _recorder?.Dispose();
                         _recorder = null;
@@ -845,7 +880,24 @@ namespace Telegram.Controls.Chats
                 Logger.Debug(errorEventArgs.Message);
             }
 
-            public async Task InitializeQuantumAsync()
+            private static Task<StorageFile> CreateFileAsync(ChatRecordMode mode, bool streaming)
+            {
+                var fileName = string.Format(mode == ChatRecordMode.Video
+                    ? "video_{0:yyyy}-{0:MM}-{0:dd}_{0:HH}-{0:mm}-{0:ss}.mp4"
+                    : streaming
+                    ? "voice_{0:yyyy}-{0:MM}-{0:dd}_{0:HH}-{0:mm}-{0:ss}.oga"
+                    : "voice_{0:yyyy}-{0:MM}-{0:dd}_{0:HH}-{0:mm}-{0:ss}.wav", DateTime.Now);
+
+                // Unique rather than fail: the name is only second-accurate, and two recordings
+                // within the same second is a tap away.
+                return ApplicationData.Current.TemporaryFolder.CreateFileAsync(fileName, CreationCollisionOption.GenerateUniqueName).AsTask();
+            }
+
+            /// <summary>
+            /// Creates the audio frame reader, and reports whether its samples can be handed to
+            /// the encoder as they are.
+            /// </summary>
+            private async Task<bool> PrepareReaderAsync()
             {
                 try
                 {
@@ -853,29 +905,68 @@ namespace Telegram.Controls.Chats
                     if (frameSource.Value == null)
                     {
                         Logger.Info("No audio frame source was found.");
-                        return;
+                        return false;
                     }
 
-                    var format = frameSource.Value.CurrentFormat;
-                    if (format.Subtype != MediaEncodingSubtypes.Float)
+                    var source = frameSource.Value;
+                    var format = source.CurrentFormat;
+
+                    // The encoder is 48kHz: at any other rate the samples would play back at the
+                    // wrong speed, so ask for one and give up on streaming if there isn't one.
+                    if (format.AudioEncodingProperties?.SampleRate != VoiceSink.SampleRate)
                     {
-                        Logger.Info("No audio frame source was found.");
-                        return;
+                        var match = source.SupportedFormats.FirstOrDefault(x => x.AudioEncodingProperties?.SampleRate == VoiceSink.SampleRate && IsSupportedSubtype(x.Subtype));
+                        if (match != null)
+                        {
+                            await source.SetFormatAsync(match);
+                            format = source.CurrentFormat;
+                        }
                     }
 
-                    var mediaFrameReader = await _recorder.m_mediaCapture.CreateFrameReaderAsync(frameSource.Value);
+                    var reader = await _recorder.m_mediaCapture.CreateFrameReaderAsync(source);
 
-                    // Optionally set acquisition mode. Buffered is the default mode for audio.
-                    mediaFrameReader.AcquisitionMode = MediaFrameReaderAcquisitionMode.Realtime;
-                    mediaFrameReader.FrameArrived += OnAudioFrameArrived;
+                    // Buffered rather than Realtime: a dropped frame used to cost a blob update,
+                    // it now costs a gap in the recording.
+                    reader.AcquisitionMode = MediaFrameReaderAcquisitionMode.Buffered;
+                    reader.FrameArrived += OnAudioFrameArrived;
 
-                    var status = await mediaFrameReader.StartAsync();
+                    _reader = reader;
+
+                    var properties = format.AudioEncodingProperties;
+                    if (properties == null)
+                    {
+                        return false;
+                    }
+
+                    _channels = properties.ChannelCount;
+                    _bitsPerSample = properties.BitsPerSample;
+
+                    return properties.SampleRate == VoiceSink.SampleRate
+                        && IsSupportedSubtype(format.Subtype)
+                        && (_bitsPerSample == 32 || _bitsPerSample == 16)
+                        && _channels > 0;
+                }
+                catch (Exception ex)
+                {
+                    Logger.Info("The audio frame reader couldn't be created: " + ex);
+                    return false;
+                }
+            }
+
+            private async Task StartReaderAsync()
+            {
+                if (_reader == null)
+                {
+                    return;
+                }
+
+                try
+                {
+                    var status = await _reader.StartAsync();
                     if (status != MediaFrameReaderStartStatus.Success)
                     {
                         Logger.Info("The MediaFrameReader couldn't start.");
                     }
-
-                    _reader = mediaFrameReader;
                 }
                 catch
                 {
@@ -883,32 +974,27 @@ namespace Telegram.Controls.Chats
                 }
             }
 
-            private readonly float[] _compressedWaveformSamples = new float[200];
-            private int _compressedWaveformPosition = 0;
-
-            private float _currentPeak;
-            private int _currentPeakCount;
-            private int _peakCompressionFactor = 1;
-
-            private float _micLevelPeak = 0;
-            private int _micLevelPeakCount = 0;
-
-            private ulong _lastUpdateTime;
+            private static bool IsSupportedSubtype(string subtype)
+            {
+                // 32-bit float and 16-bit PCM are the two the sink knows how to read.
+                return string.Equals(subtype, MediaEncodingSubtypes.Float, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(subtype, MediaEncodingSubtypes.Pcm, StringComparison.OrdinalIgnoreCase);
+            }
 
             private unsafe void OnAudioFrameArrived(MediaFrameReader sender, MediaFrameArrivedEventArgs args)
             {
                 using var reference = sender.TryAcquireLatestFrame();
-                if (reference?.SourceKind != MediaFrameSourceKind.Audio)
+                if (reference?.SourceKind != MediaFrameSourceKind.Audio || _paused)
                 {
                     return;
                 }
 
-                if (Logger.TickCount - _lastUpdateTime < 64)
+                // The reader can be running with a format we never managed to read, in which case
+                // there is nothing to say about how to interpret its bytes.
+                if (_channels == 0 || _bitsPerSample == 0)
                 {
                     return;
                 }
-
-                _lastUpdateTime = Logger.TickCount;
 
                 using var frame = reference.AudioMediaFrame.GetAudioFrame();
 
@@ -918,116 +1004,77 @@ namespace Telegram.Controls.Chats
                 // Get the buffer from the AudioFrame
                 bufferReference.Buffer(out byte* buffer, out uint capacity);
 
-                var samples = (float*)buffer;
-                var count = capacity / 4;
+                var samples = ReadSamples(buffer, Math.Min(audioBuffer.Length, capacity));
 
-                for (int i = 0; i < count; i++)
+                // Every frame is folded in, and only the notification is rate-limited: this
+                // callback is the recording now, so it can't afford to skip one.
+                if (_waveform.Add(samples))
                 {
-                    var sample = samples[i];
-                    if (sample < 0)
-                    {
-                        sample = Math.Abs(sample);
-                    }
-
-                    _currentPeak = Math.Max(_currentPeak, sample);
-                    _currentPeakCount++;
-
-                    if (_currentPeakCount == _peakCompressionFactor)
-                    {
-                        _compressedWaveformSamples[_compressedWaveformPosition++] = _currentPeak;
-
-                        _currentPeakCount = 0;
-
-                        if (_compressedWaveformPosition == _compressedWaveformSamples.Length)
-                        {
-                            for (int j = 0; j < _compressedWaveformSamples.Length / 2; j++)
-                            {
-                                _compressedWaveformSamples[j] = Math.Max(_compressedWaveformSamples[j * 2 + 0], _compressedWaveformSamples[j * 2 + 1]);
-                            }
-
-                            _compressedWaveformPosition = _compressedWaveformSamples.Length / 2;
-                            _peakCompressionFactor *= 2;
-                        }
-
-                    }
-
-                    if (_micLevelPeak < sample)
-                    {
-                        _micLevelPeak = sample;
-                    }
-
-                    _micLevelPeakCount += 1;
-
-                    if (_micLevelPeakCount >= 1200)
-                    {
-                        QuantumProcessed?.Invoke(_micLevelPeak);
-
-                        _micLevelPeak = 0;
-                        _micLevelPeakCount = 0;
-                    }
+                    QuantumProcessed?.Invoke(_waveform.Level);
                 }
+
+                _sink?.Write(samples);
             }
 
-            public unsafe byte[] GetWaveform()
+            /// <summary>
+            /// Presents the captured buffer as mono 32-bit float, which is what both the waveform
+            /// and the encoder read.
+            /// </summary>
+            private unsafe ReadOnlySpan<float> ReadSamples(byte* buffer, uint length)
             {
-                var count = _compressedWaveformPosition;
-                var scaledSamples = new short[100];
+                var channels = (int)_channels;
+                var count = (int)(length / (_bitsPerSample / 8 * _channels));
 
-                for (int i = 0; i < count; i++)
+                // Mono float is the common case and needs no conversion at all.
+                if (_bitsPerSample == 32 && channels == 1)
                 {
-                    var sample = _compressedWaveformSamples[i] * short.MaxValue;
-                    var index = i * 100 / count;
-                    if (scaledSamples[index] < sample)
+                    return new ReadOnlySpan<float>(buffer, count);
+                }
+
+                if (_samples == null || _samples.Length < count)
+                {
+                    _samples = new float[count];
+                }
+
+                var target = _samples.AsSpan(0, count);
+
+                if (_bitsPerSample == 32)
+                {
+                    var source = (float*)buffer;
+
+                    for (int i = 0; i < count; i++)
                     {
-                        scaledSamples[index] = (short)sample;
+                        var sum = 0f;
+                        for (int j = 0; j < channels; j++)
+                        {
+                            sum += source[i * channels + j];
+                        }
+
+                        target[i] = sum / channels;
+                    }
+                }
+                else
+                {
+                    var source = (short*)buffer;
+
+                    for (int i = 0; i < count; i++)
+                    {
+                        var sum = 0f;
+                        for (int j = 0; j < channels; j++)
+                        {
+                            sum += source[i * channels + j] / 32768f;
+                        }
+
+                        target[i] = sum / channels;
                     }
                 }
 
-                short peak = 0;
-                long sumSamples = 0;
-                for (int i = 0; i < 100; i++)
-                {
-                    var sample = scaledSamples[i];
-                    if (peak < sample)
-                    {
-                        peak = sample;
-                    }
-                    sumSamples += sample;
-                }
+                return target;
+            }
 
-                var calculatedPeak = (ushort)(sumSamples * 1.8 / 100.0);
-                if (calculatedPeak < 2500)
-                {
-                    calculatedPeak = 2500;
-                }
-
-                for (int i = 0; i < 100; i++)
-                {
-                    uint sample = (ushort)scaledSamples[i];
-                    var minPeak = Math.Min(sample, calculatedPeak);
-                    var resultPeak = minPeak * 31 / calculatedPeak;
-                    scaledSamples[i] = (short)/*clamping:*/ Math.Min(31, resultPeak);
-                }
-
-                var bitstreamLength = scaledSamples.Length * 5 / 8 + 1;
-                var result = new byte[bitstreamLength];
-
-                fixed (byte* data = result)
-                {
-                    static void set_bits(byte* bytes, int bitOffset, int value)
-                    {
-                        bytes += bitOffset / 8;
-                        bitOffset %= 8;
-                        *(int*)bytes |= value << bitOffset;
-                    }
-
-                    for (int i = 0; i < scaledSamples.Length; i++)
-                    {
-                        set_bits(data, i * 5, scaledSamples[i] & 31);
-                    }
-                }
-
-                return result;
+            public byte[] GetWaveform()
+            {
+                return _waveform.GetWaveform();
             }
 
             public async Task<ChatRecordResult> PauseAsync()
@@ -1044,6 +1091,21 @@ namespace Telegram.Controls.Chats
                     if (recorder == null)
                     {
                         Logger.Debug("recorder or file == null, abort");
+
+                        // Setting it is what releases the caller: it awaits this task.
+                        tsc.SetResult(null);
+                        return;
+                    }
+
+                    if (_sink != null)
+                    {
+                        // Nothing to pause: the frames keep arriving and are dropped, which keeps
+                        // the device warm and resuming instant.
+                        _paused = !_paused;
+
+                        tsc.SetResult(_paused
+                            ? new ChatRecordResult(_sink.Duration, GetWaveform())
+                            : null);
                         return;
                     }
 
@@ -1132,10 +1194,36 @@ namespace Telegram.Controls.Chats
                         QuantumProcessed?.Invoke(0);
                     }
 
-                    var result = await recorder.StopAsync();
-                    var duration = result?.RecordDuration ?? TimeSpan.Zero;
+                    var sink = _sink;
+                    var waveform = Array.Empty<byte>();
 
-                    Logger.Debug("recorder stopped, duration: " + result?.RecordDuration);
+                    TimeSpan duration;
+
+                    if (sink != null)
+                    {
+                        sink.Complete();
+
+                        // Counted from the samples that were actually encoded, so it matches the
+                        // file rather than the moment the user pressed the button.
+                        duration = sink.Duration;
+                        waveform = GetWaveform();
+
+                        sink.Dispose();
+
+                        await recorder.StopAsync();
+                    }
+                    else
+                    {
+                        var result = await recorder.StopAsync();
+                        duration = result?.RecordDuration ?? TimeSpan.Zero;
+
+                        if (mode == ChatRecordMode.Voice)
+                        {
+                            waveform = GetWaveform();
+                        }
+                    }
+
+                    Logger.Debug("recorder stopped, duration: " + duration);
 
                     if (cancel == true || duration.TotalMilliseconds < 700)
                     {
@@ -1158,7 +1246,7 @@ namespace Telegram.Controls.Chats
 
                         if (cancel == false)
                         {
-                            Send(viewModel, mode, chat, file, recorder._mirroringPreview, (int)duration.TotalSeconds);
+                            Send(viewModel, mode, chat, file, recorder._mirroringPreview, duration, waveform, sink != null);
                         }
                     }
 
@@ -1166,10 +1254,11 @@ namespace Telegram.Controls.Chats
                     _file = null;
 
                     _reader = null;
+                    _sink = null;
                 });
             }
 
-            private async void Send(ComposeViewModel viewModel, ChatRecordMode mode, Chat chat, StorageFile file, bool mirroring, int duration)
+            private async void Send(ComposeViewModel viewModel, ChatRecordMode mode, Chat chat, StorageFile file, bool mirroring, TimeSpan duration, byte[] waveform, bool encoded)
             {
                 var selfDestructType = IsViewOnce
                         ? new MessageSelfDestructTypeImmediately()
@@ -1222,9 +1311,14 @@ namespace Telegram.Controls.Chats
                 }
                 else
                 {
+                    // Already Ogg/Opus when the sink wrote it, so there is nothing to convert.
+                    var conversion = encoded
+                        ? ConversionType.Copy
+                        : ConversionType.Opus;
+
                     try
                     {
-                        _dispatcherQueue.TryEnqueue(() => _ = viewModel.SendVoiceNoteAsync(file, duration, null, selfDestructType));
+                        _dispatcherQueue.TryEnqueue(() => _ = viewModel.SendVoiceNoteAsync(file, conversion, duration, waveform, null, selfDestructType));
                     }
                     catch { }
                 }
@@ -1236,7 +1330,6 @@ namespace Telegram.Controls.Chats
             {
                 private readonly bool m_isVideo;
 
-                private readonly StorageFile m_file;
                 private LowLagMediaRecording m_lowLag;
                 private bool m_paused;
 
@@ -1250,9 +1343,8 @@ namespace Telegram.Controls.Chats
                 //// Rotation Helper to simplify handling rotation compensation for the camera streams
                 //public CameraRotationHelper _rotationHelper;
 
-                public OpusRecorder(StorageFile file, bool video)
+                public OpusRecorder(bool video)
                 {
-                    m_file = file;
                     m_isVideo = video;
                     InitializeSettings();
                 }
@@ -1280,7 +1372,7 @@ namespace Telegram.Controls.Chats
                     return desiredDevice ?? allVideoDevices.FirstOrDefault();
                 }
 
-                public async Task StartAsync()
+                public async Task StartAsync(StorageFile file)
                 {
                     MediaEncodingProfile profile;
                     if (m_isVideo)
@@ -1295,7 +1387,7 @@ namespace Telegram.Controls.Chats
                         profile.Audio.ChannelCount = 1;
                     }
 
-                    m_lowLag = await m_mediaCapture.PrepareLowLagRecordToStorageFileAsync(profile, m_file);
+                    m_lowLag = await m_mediaCapture.PrepareLowLagRecordToStorageFileAsync(profile, file);
                     await m_lowLag.StartAsync();
                 }
 
@@ -1326,8 +1418,12 @@ namespace Telegram.Controls.Chats
                     MediaCaptureStopResult result = null;
                     try
                     {
-                        result = await m_lowLag.StopWithResultAsync();
-                        await m_lowLag.FinishAsync();
+                        // Null when the sink did the recording: there is only the device to close.
+                        if (m_lowLag != null)
+                        {
+                            result = await m_lowLag.StopWithResultAsync();
+                            await m_lowLag.FinishAsync();
+                        }
                     }
                     catch { }
                     finally

--- a/Telegram/Controls/Chats/ChatRecordButton.cs
+++ b/Telegram/Controls/Chats/ChatRecordButton.cs
@@ -820,12 +820,12 @@ namespace Telegram.Controls.Chats
 
                         Logger.Debug("Devices initialized, starting");
 
-                        // For a voice message the reader is the recording, so it always runs. For
-                        // a video message it only feeds the blob, and keeps the gate it had.
+                        // For a voice message the reader is the recording, so it always runs. A
+                        // video message animates the same blob and keeps the gate it had.
                         var reader = mode == ChatRecordMode.Voice
                             || (PowerSavingPolicy.AreMaterialsEnabled && ApiInfo.CanAnimatePaths);
 
-                        var streaming = reader && await PrepareReaderAsync() && mode == ChatRecordMode.Voice;
+                        var streaming = reader && await PrepareReaderAsync(mode);
 
                         _file = await CreateFileAsync(mode, streaming);
 
@@ -897,7 +897,7 @@ namespace Telegram.Controls.Chats
             /// Creates the audio frame reader, and reports whether its samples can be handed to
             /// the encoder as they are.
             /// </summary>
-            private async Task<bool> PrepareReaderAsync()
+            private async Task<bool> PrepareReaderAsync(ChatRecordMode mode)
             {
                 try
                 {
@@ -913,7 +913,11 @@ namespace Telegram.Controls.Chats
 
                     // The encoder is 48kHz: at any other rate the samples would play back at the
                     // wrong speed, so ask for one and give up on streaming if there isn't one.
-                    if (format.AudioEncodingProperties?.SampleRate != VoiceSink.SampleRate)
+                    //
+                    // Only ever for a voice message. A video message records through MediaCapture,
+                    // and renegotiating the format of the source it is about to record from would
+                    // change what lands in the mp4 for the sake of a blob.
+                    if (mode == ChatRecordMode.Voice && format.AudioEncodingProperties?.SampleRate != VoiceSink.SampleRate)
                     {
                         var match = source.SupportedFormats.FirstOrDefault(x => x.AudioEncodingProperties?.SampleRate == VoiceSink.SampleRate && IsSupportedSubtype(x.Subtype));
                         if (match != null)
@@ -941,7 +945,8 @@ namespace Telegram.Controls.Chats
                     _channels = properties.ChannelCount;
                     _bitsPerSample = properties.BitsPerSample;
 
-                    return properties.SampleRate == VoiceSink.SampleRate
+                    return mode == ChatRecordMode.Voice
+                        && properties.SampleRate == VoiceSink.SampleRate
                         && IsSupportedSubtype(format.Subtype)
                         && (_bitsPerSample == 32 || _bitsPerSample == 16)
                         && _channels > 0;

--- a/Telegram/Telegram.csproj
+++ b/Telegram/Telegram.csproj
@@ -212,6 +212,8 @@
     <Compile Include="Common\NativeMethodChecker.cs" />
     <Compile Include="Common\PageBlockHelper.cs" />
     <Compile Include="Common\Profiler.cs" />
+    <Compile Include="Common\Recording\AudioWaveform.cs" />
+    <Compile Include="Common\Recording\VoiceSink.cs" />
     <Compile Include="Common\RichHtml.cs" />
     <Compile Include="Common\SliderHelper.cs" />
     <Compile Include="Common\TdThroughput.cs" />

--- a/Telegram/ViewModels/ComposeViewModel.cs
+++ b/Telegram/ViewModels/ComposeViewModel.cs
@@ -724,7 +724,7 @@ namespace Telegram.ViewModels
             }
         }
 
-        public async Task SendVoiceNoteAsync(StorageFile file, int duration, FormattedText caption, MessageSelfDestructType selfDestructType)
+        public async Task SendVoiceNoteAsync(StorageFile file, ConversionType conversion, TimeSpan duration, byte[] waveform, FormattedText caption, MessageSelfDestructType selfDestructType)
         {
             var options = await PickMessageSendOptionsAsync();
             if (options == null)
@@ -734,7 +734,7 @@ namespace Telegram.ViewModels
 
             // TODO: 172 selfDestructType
             var reply = GetReply(true);
-            var input = new InputMessageVoiceNote(new InputVoiceNote(await file.ToGeneratedAsync(ConversionType.Opus), duration, Array.Empty<byte>()), caption, selfDestructType);
+            var input = new InputMessageVoiceNote(new InputVoiceNote(await file.ToGeneratedAsync(conversion), (int)Math.Round(duration.TotalSeconds), waveform), caption, selfDestructType);
 
             await SendMessageAsync(reply, input, options);
         }

--- a/chat-record-rewrite.md
+++ b/chat-record-rewrite.md
@@ -1,0 +1,371 @@
+# Voice/video message recording — rewrite plan
+
+Findings from a read-through of `Telegram/Controls/Chats/ChatRecordButton.cs`,
+`Telegram/Controls/Chats/ChatRecordBar.xaml{,.cs}`, both hosts (`Views/ChatView.xaml{,.cs}`,
+`Controls/Stories/StoriesWindow.xaml{,.cs}`), the send path
+(`ComposeViewModel.SendVoiceNoteAsync`/`SendVideoNoteAsync`, `GenerationService.TranscodeOpusAsync`),
+the native encoder (`Telegram.Native/Opus/OpusOutput.{h,cpp,idl}`) and the TDLib file-generation
+and upload machinery in `Libraries/tdlib/td/telegram/files/`.
+
+Tasks are ordered so each one can land and be reviewed on its own. Check an item off in the
+same commit as its fix.
+
+---
+
+## How it works today
+
+One file, `ChatRecordButton.cs` (1355 lines), holds four things that never should have shared a
+type:
+
+1. **The button** — pointer capture, click modes, the press-and-hold vs tap-to-switch-mode timer,
+   restriction toasts, accessibility.
+2. **The state machine** — `_recordingAudioVideo`, `_recordingLocked`, `_recordingStopped`,
+   `_recordingPaused`, `_calledRecordRunnable`, `_recordAudioVideoRunnableStarted`,
+   `_enqueuedLocking`, `recordInterfaceState`, folded into `UpdateRecordingInterface()` (:324).
+3. **The capture engine** — `Recorder` (:712) and `OpusRecorder` (:1235): `MediaCapture`,
+   `LowLagMediaRecording`, `MediaFrameReader`, the amplitude meter and the waveform compressor.
+4. **The send policy** — `Send()` (:1172) builds `VideoGeneration` and calls into the view model.
+
+`ChatRecordBar` then drives the whole visual side off four `EventHandler`s from the button, and
+reaches back into it (`ControlledButton.StopRecording`, `.LockRecording`, `.PauseRecording`,
+`.IsViewOnce`) — so the two are mutually dependent and neither can be tested or reused alone.
+
+The **voice** pipeline is: `MediaCapture` → `PrepareLowLagRecordToStorageFileAsync` with
+`MediaEncodingProfile.CreateWav` (:1292) → a `.oga`-named file that actually holds **WAV** →
+`InputVoiceNote` with `ConversionType.Opus` → at send time `GenerationService.TranscodeOpusAsync`
+(:332) → `OpusOutput.Transcode` reads the WAV back off disk and encodes to Ogg/Opus.
+
+The **video** pipeline is: `MediaCapture` → `MediaEncodingProfile.CreateMp4(VideoEncodingQuality.Auto)`
+→ full-resolution mp4 → `VideoGeneration` crops/scales/flips to
+`Options.SuggestedVideoNoteLength` (384) at send time.
+
+In parallel, a second reader (`MediaFrameReader`, :848) pulls float32 audio frames off the same
+`MediaCapture` purely to drive the blob amplitude and accumulate the waveform.
+
+Nothing is uploaded until the user releases the button, and for voice nothing is even *encoded*
+until then.
+
+---
+
+## What's wrong
+
+### The engine
+
+- **The mic is recorded twice and encoded three times.** The frame reader already has every
+  float32 sample in memory (:898) while `LowLagMediaRecording` writes the same audio to a WAV on
+  disk, which is then read back and re-encoded at send time. `OpusOutput` already exposes
+  `WriteFrame(AudioFrame)` (`OpusOutput.h:100`) — a streaming encode entry point that **nothing in
+  C# calls**. The whole WAV round-trip is avoidable.
+- **The waveform we compute is thrown away.** `GetWaveform()` produces a proper 5-bit/100-sample
+  waveform, and `SendVoiceNoteAsync` sends `Array.Empty<byte>()` (`ComposeViewModel.cs:737`). Only
+  the pause preview ever uses it.
+- **…and it isn't computed at all under power saving.** `InitializeQuantumAsync` is gated on
+  `PowerSavingPolicy.AreMaterialsEnabled && ApiInfo.CanAnimatePaths` (:812) — an *animation*
+  setting deciding whether the *waveform data* exists.
+- **The clock starts before the mic does.** `_start = DateTime.Now` is set from `RecordingStarting`
+  (:370), which fires before `MediaCapture.InitializeAsync` and `PrepareLowLagRecordToStorageFileAsync`
+  — several hundred ms of device init. The elapsed label counts time that was never recorded, and
+  the sent duration comes from `MediaCaptureStopResult.RecordDuration` instead, so the two disagree.
+  Then `(int)duration.TotalSeconds` (:1161) truncates, so a 5.9 s note ships as 5 s.
+- **Video records at whatever the camera gives.** `CreateMp4(VideoEncodingQuality.Auto)` on a 1080p
+  webcam writes a 1080p file for a 60-second clip, then re-encodes it to 384×384. Recording near
+  the target size makes the send-time transcode nearly free.
+- **The camera is picked by panel, not by the user.** `FindCameraDeviceByPanelAsync(Panel.Front)`
+  (:785) ignores `MediaDeviceTracker`/`MediaDeviceList`, which calls already use for selection and
+  hot-plug. There is no mic selection at all.
+- **Mid-recording failure is a dead end.** `MediaCapture.Failed` only logs (:843). Unplug the mic
+  and the UI stays "recording" forever; `RecordingFailed` is raised only from `Start`'s catch.
+- **`RecordingTooShort` has no subscribers.** Release under 700 ms silently discards the recording
+  with no feedback (:1152).
+- **Video notes are not length-limited.** The bar draws a 60 s `SelfDestructTimer` ring
+  (`ChatRecordBar.xaml.cs:182`) but nothing stops the recording when it fills.
+
+### The lifetime
+
+- **`Recorder.Current` is a `[ThreadStatic]` singleton** (:722) that every loaded `ChatRecordButton`
+  on the thread subscribes to in `OnLoaded` (:162). ChatView and StoriesWindow both host one. A
+  recording started in one drives `_recordingAudioVideo = true` in *all* of them, and
+  `QuantumProcessed` is a single `Action` field (:169) — last one loaded wins, and the first one to
+  unload nulls it out from under the other. `IsViewOnce` is likewise shared global state.
+- **`SetControlledButton` never unsubscribes** (`ChatRecordBar.xaml.cs:141`) — five handlers,
+  including `ManipulationDelta`, wired for the life of the bar with no teardown path.
+- **`_recordingPaused` is never reset** when a recording ends (:401 resets the other two flags), so
+  a pause in one recording leaks into the elapsed maths of the next.
+- **`StopRecording(false)` is a trap.** It maps to `Stop(null, null)` (:633), and `Stop` neither
+  deletes nor sends on a null `cancel` (:1140) — the temp file leaks; had it sent, `viewModel` is
+  null and it would throw. No caller passes `false` today, which is the only reason it's invisible.
+
+### The input model
+
+- **Permissions are done the old way.** `CheckDeviceAccessAsync` (:562) uses
+  `DeviceAccessInformation` plus a throwaway `MediaCapture` to trigger the consent prompt, and then
+  **returns false unconditionally** (:590) — the first press after granting never records, it just
+  primes the prompt. `MediaDevicePermissions.CheckAccessAsync` (`Common/MediaDevicePermissions.cs`)
+  already does this properly with `AppCapability` and is what calls use.
+- **Press-and-hold vs mode switch is a 300 ms race.** `_timer` (:128) plus `_calledRecordRunnable`
+  and `_recordAudioVideoRunnableStarted` encode "did the hold outlive the tick" across three
+  handlers (`OnClick`, `OnRelease`, `OnPointerCaptureLost`). It also means every recording is
+  delayed 300 ms *before* device init even starts.
+- **`Elapsed` uses `DateTime.Now`** — wall clock, so a DST or NTP step during a recording moves the
+  timer.
+- The `_timer.Tick` handler is an unremovable lambda (:130), against the project rule.
+
+---
+
+## Upload while recording — worth designing for, not worth blocking on
+
+Not a must-have on desktop, so it sits at the end of the plan as its own task. It still belongs
+*here*, in the architecture section, because it decides where the bytes go: if the sink writes to a
+path we choose and the session owns the hand-off to the view model, streaming upload later is an
+added sink, not a reshape. Design for it, ship without it.
+
+**TDLib supports it, through file generation — verified in the vendored source.** The chain is:
+
+1. `InputFileGenerated(originalPath, conversion, expectedSize)` → TDLib raises
+   `UpdateFileGenerationStart` with a `DestinationPath` (under
+   `LocalFolder\<sessionId>`, per `ClientService.cs:629` — so a `StorageFile` opens there fine).
+2. The app writes bytes into that path and reports progress with
+   `SetFileGenerationProgress(generationId, expectedSize, localPrefixSize)`.
+3. `FileManager::on_partial_generate` (`files/FileManager.cpp:4956`) turns each report into a
+   `PartialLocalFileLocation`, calls `run_upload` on the first one, and pushes every later one into
+   the uploader via `FileUploadManager::update_local_file_location` (:4985).
+4. `FileUploader::on_update_local_location` (`files/FileUploader.cpp:119`) accepts a *partial*
+   location, takes the ready prefix, and inits its parts manager with an approximate size
+   (`local_is_ready_ = false`) — i.e. it uploads the growing prefix.
+5. `FinishFileGeneration` closes it out; the same `InputFile` then goes into `sendMessage`.
+
+`run_upload` only does something if an upload is already pending, so the recorder has to kick one
+with `PreliminaryUploadFile` at record start. Cancel is `CancelPreliminaryUploadFile` +
+`FinishFileGeneration(error)`.
+
+The app has **never** called `SetFileGenerationProgress` — every conversion in `GenerationService`
+runs to completion and then reports. This is new plumbing, and it is the one genuinely new
+subsystem in this plan.
+
+**Ogg/Opus is safe to stream; mp4 needs proving first.** `OpusOutput` writes ogg pages
+sequentially and never seeks backwards (`writeOggPage`, `OpusOutput.cpp:142`) — an uploaded prefix
+can never be invalidated. Media Foundation's mp4 sink is a different matter: if it patches earlier
+bytes when finalizing, every uploaded part before that point is garbage. So voice gets streaming
+upload; video gets it only after a measurement says it's safe (Task 5).
+
+---
+
+## The shape to move to
+
+One engine, two sinks — no AudioGraph, and voice and video differ only in what consumes the frames:
+
+```
+ChatRecordSession            state machine + policy. No XAML, no MediaCapture.
+  ├─ ChatRecordEngine        MediaCapture: device init, permission, start/pause/resume/stop,
+  │                          MediaFrameReader for audio (level + waveform + samples)
+  │    ├─ VoiceSink          audio frames in, a file and a waveform out
+  │    └─ VideoSink          audio+video in, a file out
+  └─ hosts                   ChatRecordButton (input only), ChatRecordBar (render only)
+```
+
+Ogg/Opus and mp4 are each a sink's own business — the session, the engine and the hosts never name
+a container or a codec.
+
+`ChatRecordSession` is owned by the host (one per ChatView / StoriesWindow), not by a thread-static
+singleton, and exposes a single observable state (`Idle | Starting | Recording | Paused | Stopping`)
+plus `Elapsed`, `Level` and `Waveform`. The button raises intents (`RequestStart(mode)`,
+`RequestLock`, `RequestStop(cancel)`); the bar renders state. Neither reaches into the other.
+
+The session hands the finished value object (`inputFile`, exact `duration`, `waveform`, `mirrored`)
+to the view model — the capture layer stops knowing about `ComposeViewModel`, `VideoGeneration` and
+`MessageSelfDestructType`.
+
+**Why not AudioGraph.** It would have given voice a cheaper, faster-starting engine, but it means a
+second capture stack to keep alive, and the same `MediaFrameReader` we already run for the level
+meter can hand us exactly the frames `OpusOutput.WriteFrame` wants. The WAV round-trip dies either
+way, which was the actual win. (`SoundEffects` still uses AudioGraph; out of scope here, but if it
+gets rewritten too, nothing in recording will depend on it.)
+
+Two things must change about that reader for it to become the audio *source* rather than a meter:
+
+- **`MediaFrameReaderAcquisitionMode.Realtime` (:869) drops frames under load.** Fine for a blob,
+  catastrophic for a recording — it has to be `Buffered`, and the encode has to move off the
+  callback thread.
+- **The float32 requirement is a silent bail-out today.** `InitializeQuantumAsync` gives up if the
+  source format isn't `MediaEncodingSubtypes.Float` (:860), which currently costs only the
+  waveform. As the audio source it costs everything, so it needs `SetFormatAsync` (which
+  `SharingMode.SharedReadOnly` forbids — see Task 5.1) or an int16 path through the sink.
+- **The 64 ms throttle drops whole frames, and it drops them first.** `OnAudioFrameArrived` returns
+  before touching the buffer (:906). Harmless for a meter; it silently discards audio the moment
+  the same callback feeds the encoder. The throttle has to move off frame *acquisition* and onto
+  level *reporting*.
+
+### The blob keeps working — it gets better
+
+It survives untouched, because nothing about how it's driven changes. `UpdateLevel`
+(`CompositionBlobVisual.cs:141`) only writes two floats and a `MathF.Max`; every Composition call
+happens in `OnRendering`, ticked by `CompositionVSync(30)` off `CompositionTarget.Rendering` on the
+UI thread. So the capture thread posting levels is safe today and stays safe — the audio side and
+the render side are already decoupled by that vsync, which is exactly why the reader can take on a
+second job without the blob noticing.
+
+What improves is the signal. Today the level and the waveform are both accumulated *only* from
+frames that survive the 64 ms gate, so both are built from a decimated slice of the audio: the
+`_micLevelPeakCount >= 1200` counter (:961) means "25 ms of audio" in principle, but those 25 ms
+are drawn from a stream with most frames thrown away, so updates arrive in bursts several times
+further apart than the 33 ms blob tick. Process every frame and the peak is a true peak over a
+continuous window, landing at roughly one update per rendered frame.
+
+Two knock-on moves:
+
+- The reader currently only exists when `PowerSavingPolicy.AreMaterialsEnabled && ApiInfo.CanAnimatePaths`
+  (:812). As the audio source it must always run — so that gate moves to the bar, which already
+  tests the same condition to choose `StartAnimating()` vs `Clear()`
+  (`ChatRecordBar.xaml.cs:226`). Skip the level *notification* when the blob isn't animating; keep
+  accumulating the waveform regardless.
+- Keep `QuantumProcessed?.Invoke(0)` on stop (:1132) — that's what settles the blob back down.
+
+---
+
+## Task 1 — Extract the state machine, no behaviour change
+
+- [ ] **1.1** Move the flag soup and `UpdateRecordingInterface` into `ChatRecordSession` with an
+  explicit enum state and one transition method. Keep the existing engine (`Recorder`) behind it
+  verbatim so the diff is mechanical and testable against the current behaviour.
+- [ ] **1.2** One session per host, created by ChatView/StoriesWindow and passed to both the button
+  and the bar. Drop `[ThreadStatic] Recorder.Current` and `Recorder.Release()`
+  (`Navigation/WindowContext.cs:297`).
+- [ ] **1.3** Pair every `+=` in `SetControlledButton` with a `-=`, and replace the `_timer.Tick`
+  lambda with a named method.
+- [ ] **1.4** Delete `StopRecording(bool)`'s null-`cancel` path: `Cancel()` and `Complete()` as two
+  methods, no tri-state.
+
+## Task 2 — Voice: encode straight to Opus, no WAV — **done, unbuilt**
+
+- [x] **2.1** Drop `LowLagMediaRecording` from the voice path. The `MediaFrameReader` becomes the
+  source: `Buffered` acquisition, frames into `VoiceSink` (`OpusOutput.WriteFrame(AudioFrame)`) on
+  a worker.
+  - **Trap:** `WriteFrame` slices the buffer into `TG_OPUS_FRAME_SIZE` (960 sample) chunks and
+    silently drops the remainder (`OpusOutput.h:110`). Whatever the device quantum is, the C# side
+    must accumulate to a multiple of 960 or the tail of every buffer is lost.
+  - Handle a non-float source format, per the note above.
+- [x] **2.2** Retire `ConversionType.Opus` for recordings (the file is already Ogg). Keep
+  `TranscodeOpusAsync` only if some other caller reaches it — check.
+- [x] **2.3** Duration from the sample count, not `MediaCaptureStopResult`, and rounded rather than
+  truncated. ~~Start the elapsed clock when the first frame arrives, on `Environment.TickCount64`.~~
+  The *sent* duration is now exact; the elapsed label still counts from the button press, because
+  `_start` lives in the state machine that Task 1 extracts.
+- [x] **2.4** Send the waveform: `GetWaveform()` into `InputVoiceNote` (`ComposeViewModel.cs:737`),
+  and compute it unconditionally — untie it from `PowerSavingPolicy.AreMaterialsEnabled`.
+- [ ] **2.5** Mic selection through `MediaDeviceTracker`, including device-change handling
+  mid-recording.
+- [x] **2.6** Restructure `OnAudioFrameArrived`: every frame is encoded and folded into the
+  waveform; only the `QuantumProcessed` notification is rate-limited. Move the animation gate to
+  the bar. The blob must look the same or smoother — check it against a recording made before the
+  change, not just "it still wobbles".
+
+**How it landed.** Two new classes under `Telegram/Common/Recording/`. `VoiceSink` owns the
+`OpusOutput`, buffers samples to whole 960-sample frames and counts what it encoded — that count is
+the duration. `AudioWaveform` folds the same samples into the 100-bucket waveform and the blob
+level. `Recorder` picks the path after the device is initialized: `PrepareReaderAsync` reports
+whether the frame source can be encoded as it stands, and only then is there a sink.
+
+**The fallback is not optional.** The encoder is 48kHz mono and `MediaFrameSource` hands over
+whatever the endpoint runs at. `SetFormatAsync` is attempted, but if the source stays at 44.1kHz —
+or reports a subtype that isn't Float or PCM, or a depth that isn't 32 or 16 — the recording goes
+back through `MediaCapture` and `ConversionType.Opus`, which resamples for us. Wrong-speed audio is
+not a trade worth making, and I have no device survey to say how common that is. Both paths now
+carry a waveform.
+
+**A bug fixed on the way.** The old accumulator never reset `_currentPeak` after storing a bucket
+(`ChatRecordButton.cs:932` before this change), so each bucket held the running maximum of the whole
+recording and the waveform could only ever climb. Telegram's own implementation resets it. Nothing
+showed, because the waveform was discarded at send time anyway.
+
+**Two more, while in there.** `PauseAsync` never set its `TaskCompletionSource` when the recorder
+was already gone, so the caller awaited forever; and the temporary file was created with the default
+collision option, so two recordings in the same second threw.
+
+**Not verified on a device.** The pure logic — framing, ordering, padding, the waveform, the level
+cadence — is covered by a throwaway test project and passes. Everything touching `MediaCapture` is
+read-and-reasoned only. The two things most worth watching on first run: whether `Buffered`
+acquisition really delivers every frame through `TryAcquireLatestFrame`, and which path the log
+says it took.
+
+## Task 3 — Permissions and start-up
+
+- [ ] **3.1** Replace `CheckAccessAsync`/`CheckDeviceAccessAsync` (:534–613) with
+  `MediaDevicePermissions.CheckAccessAsync`, so the first press after granting actually records.
+  Keep the Xbox special case if it's still needed — verify.
+- [ ] **3.2** Start the engine on press and discard on an early release, instead of waiting 300 ms
+  to learn whether it was a hold. The mode-switch tap then cancels a session that already began
+  warming the device, and the felt latency drops by the whole timer plus init.
+- [ ] **3.3** `MediaCapture.Failed` must fail the session and reset the UI (:843), not just log.
+- [ ] **3.4** Give `RecordingTooShort` a consumer — a toast, matching the Android/desktop wording.
+
+## Task 4 — Video
+
+- [ ] **4.1** Record near the target: pick the camera format closest to
+  `Options.SuggestedVideoNoteLength` and set the encoding profile to it, so the send-time
+  `VideoGeneration` is a crop, not a full re-encode. This is what makes release-to-sent fast for
+  video, streaming upload or not.
+- [ ] **4.2** Camera selection through `MediaDeviceTracker` instead of `Panel.Front` (:785).
+- [ ] **4.3** Enforce the 60 s limit the `SelfDestructTimer` ring already promises — stop and send
+  when it fills.
+- [ ] **4.4** Preview: `CaptureElement` (`ChatRecordBar.xaml.cs:158`) pins `MediaCapture` to the UI
+  thread and forces the "last frame" to go through `RenderTargetBitmap` + a PNG on disk
+  (`SaveLastFrameAsync`). With a frame reader in play for 4.1 anyway, the preview can be a
+  Composition surface — mirroring, the round crop and the last-frame grab all become free.
+- [ ] **4.5** `_mirroringPreview` decides both the preview transform *and* the encoded flip
+  (:1210). Confirm that a non-mirrored external camera still sends the right way round — the
+  preview is hard-coded to `ScaleX = -1` (`ChatRecordBar.xaml.cs:165`) regardless.
+
+## Task 5 — The bar and the leftovers
+
+- [ ] **5.1** Decide the sharing mode. `MediaCaptureSharingMode.SharedReadOnly` (:1267) forbids
+  both `SetFormatAsync` on the audio frame source (Task 2.1) and stream properties on the camera
+  (Task 4.1). Exclusive mode buys both and costs failing when another app holds the device.
+- [ ] **5.2** Reset the pause state on stop (:401) and stop `Elapsed` advancing while paused.
+- [ ] **5.3** The lock/pause/view-once visuals are ~250 lines of hand-built keyframe pairs that
+  duplicate each other forward and backward (`Pause_Click`, both branches). Fold into one
+  parameterised helper.
+- [ ] **5.4** `Visibility` toggling plus a `Popup` plus expression animations bound to
+  `root.Size` — check the whole bar against `layout-cycle-audit.md` while it's open.
+
+## Task 6 — Streaming upload — *optional, after the rest works*
+
+Nice to have, not required. It depends on Task 2 (a sink we control byte-for-byte) and is the only
+part of this plan that can fail on someone else's terms, so it goes last and can be dropped without
+touching anything above it.
+
+- [ ] **6.1** New conversion type in `GenerationService` that doesn't transcode — it registers the
+  `DestinationPath` with the live session and keeps the generation open. Needs a rendezvous for the
+  case where `UpdateFileGenerationStart` arrives after the mic already produced frames (buffer, or
+  hold the first frames).
+- [ ] **6.2** At record start: `PreliminaryUploadFile(InputFileGenerated(...), FileTypeVoiceNote)`
+  with an estimated `expectedSize` (~6 KB/s at the encoder's 48 kbps), then
+  `SetFileGenerationProgress` on a cadence — every ogg page flush is too chatty, once or twice a
+  second is enough.
+- [ ] **6.3** On release: `FinishFileGeneration`, then send with the same `InputFile`. On cancel:
+  `CancelPreliminaryUploadFile` + `FinishFileGeneration(error)` + delete.
+- [ ] **6.4** The cases that make this fiddly, all of which need deciding before coding:
+  offline/failed upload at release; the user paused (the file stops growing but the upload is
+  live); recording discarded under 700 ms; app suspended mid-recording; a second recording started
+  before the first upload finished. Every one of them has to degrade to today's
+  upload-on-release behaviour rather than lose a recording.
+- [ ] **6.5** Verify against a known answer: record a fixed 10 s tone, confirm the uploaded voice
+  note plays back identically to the same file sent the old way. A prefix-upload bug produces a
+  file that is *almost* right, which is exactly the failure mode that survives a casual test.
+- [ ] **6.6** Video, only if 6.1–6.5 land: record an mp4 with `LowLagMediaRecording`, hash the
+  first N bytes at intervals during the recording, hash the same ranges of the finished file, and
+  see whether MF's mp4 sink ever rewrites what it already wrote. If it doesn't, video reuses the
+  same path. If it does, video keeps upload-on-release — owning the mp4 muxing to fix that is a
+  separate project, not this one.
+
+---
+
+## Decisions for you
+
+1. **Exclusive capture mode (5.1)?** Both the voice format fix and recording video at target size
+   need it. The cost is failing when another app holds the mic or camera, where today we'd share.
+2. **How far does the preview rework go (4.4)?** Composition-surface preview is the better end
+   state and makes 4.1 cheap, but it's the largest single piece here.
+3. **Does Task 6 get built at all?** Tasks 1–5 stand on their own: the encode win, the waveform,
+   the permission fix, the latency fix, video at target size. Streaming upload adds real
+   complexity — five degradation paths in 6.4 — for an improvement most desktop users will read as
+   "sends fast", which 4.1 and 2.1 already deliver.


### PR DESCRIPTION
First milestone of the recording rewrite planned in `chat-record-rewrite.md`, which is
included here. This is Task 2 — the voice capture path. Nothing about video, the button,
the bar or the state machine changes.

## What was happening

A voice message was captured twice and encoded three times. The `MediaFrameReader` already
had every sample in memory to drive the blob, while `LowLagMediaRecording` wrote the same
audio to a WAV — in a file named `.oga` — which was read back off disk and re-encoded to
Opus at send time through `ConversionType.Opus`.

`OpusOutput.WriteFrame(AudioFrame)` has been in the native layer the whole time with no
caller in C#. It has one now.

## What changed

Two new classes under `Telegram/Common/Recording/`:

- **`VoiceSink`** owns the `OpusOutput`, accumulates samples into whole 960-sample frames
  and counts what it encoded. `WriteFrame` consumes only whole frames and silently drops
  the remainder, so it is only ever handed exact multiples.
- **`AudioWaveform`** folds the same samples into the 100-bucket waveform and the blob
  level, in one pass.

`Recorder` picks the path once the device is up: `PrepareReaderAsync` reports whether the
frame source can be encoded as it stands, and only then is there a sink.

Along the way:

- **Waveforms are sent.** They were computed and then dropped for `Array.Empty<byte>()`.
- **The waveform was wrong anyway.** The old accumulator never reset the bucket peak, so
  every bucket held the running maximum of the whole recording and the waveform could only
  climb. Telegram's own implementation resets it. Nothing showed, because it was discarded.
- **Duration is exact.** Counted from the encoded samples instead of `MediaCaptureStopResult`,
  and rounded instead of truncated — a 5.9s note used to be sent as 5s.
- **The reader stopped dropping frames.** `Realtime` acquisition and a 64ms gate that
  returned *before* touching the buffer were fine for a blob and would have cut holes in a
  recording. It is `Buffered` now, every frame is folded in, and only the level
  notification is rate-limited. Side effect: the blob and the waveform now see a continuous
  stream instead of roughly one frame in every few.
- `PauseAsync` never set its `TaskCompletionSource` when the recorder was already gone, so
  the caller awaited forever. The temp file used the default collision option, so two
  recordings in the same second threw.

## The fallback, which is not optional

The encoder is 48kHz mono and a `MediaFrameSource` hands over whatever the endpoint runs
at. `SetFormatAsync` is attempted, but if the source stays at 44.1kHz — or reports a
subtype that isn't Float or PCM, or a depth that isn't 32 or 16 — the recording goes back
through `MediaCapture` and `ConversionType.Opus`, which resamples for us. Wrong-speed audio
is not a trade worth making, and I have no device survey to say how common that is. Both
paths carry a waveform. The log line says which one ran.

## What I could and couldn't verify

The pure logic is covered by a throwaway test project: framing across 200 random chunkings
(order preserved, nothing lost, padded to a whole frame), the waveform length and decay,
the level cadence, and a 10-minute recording. All pass. Every API shape I wasn't certain of
was checked against `Windows.winmd` rather than recalled.

Everything touching `MediaCapture` is read-and-reasoned only — I don't build this project.
Two things worth watching on first run:

1. Whether `Buffered` acquisition really delivers every frame through
   `TryAcquireLatestFrame`. If it doesn't, recordings get gaps.
2. Which path the log reports on your mics.

Worth a listen against a voice message sent by the old build — a prefix or framing bug
produces a file that is *almost* right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
