### PR TITLE
Give a recording an owner

### DIFF
--- a/Telegram/Common/MediaDevicePermissions.cs
+++ b/Telegram/Common/MediaDevicePermissions.cs
@@ -24,6 +24,15 @@ namespace Telegram.Common
         AudioAndVideo
     }
 
+    /// <summary>
+    /// What the devices are wanted for. It only picks the wording of the denial.
+    /// </summary>
+    public enum MediaDevicePurpose
+    {
+        Call,
+        Record
+    }
+
     public partial class MediaDevicePermissions
     {
         public static bool IsUnsupported(XamlRoot xamlRoot)
@@ -40,7 +49,7 @@ namespace Telegram.Common
             return true;
         }
 
-        public static async Task<bool> CheckAccessAsync(XamlRoot xamlRoot, MediaDeviceAccess requestedAccess, ElementTheme requestedTheme = ElementTheme.Default)
+        public static async Task<bool> CheckAccessAsync(XamlRoot xamlRoot, MediaDeviceAccess requestedAccess, ElementTheme requestedTheme = ElementTheme.Default, MediaDevicePurpose purpose = MediaDevicePurpose.Call)
         {
             string[] capabilities;
 
@@ -74,45 +83,52 @@ namespace Telegram.Common
             {
                 if (audio != AppCapabilityAccessStatus.Allowed && video != AppCapabilityAccessStatus.Allowed)
                 {
-                    ShowPopup(xamlRoot, MediaDeviceAccess.AudioAndVideo, requestedTheme);
+                    ShowPopup(xamlRoot, MediaDeviceAccess.AudioAndVideo, purpose, requestedTheme);
                     return false;
                 }
                 else if (audio != AppCapabilityAccessStatus.Allowed)
                 {
-                    ShowPopup(xamlRoot, MediaDeviceAccess.Audio, requestedTheme);
+                    ShowPopup(xamlRoot, MediaDeviceAccess.Audio, purpose, requestedTheme);
                     return false;
                 }
                 else if (video != AppCapabilityAccessStatus.Allowed)
                 {
-                    ShowPopup(xamlRoot, MediaDeviceAccess.Video, requestedTheme);
+                    ShowPopup(xamlRoot, MediaDeviceAccess.Video, purpose, requestedTheme);
                     return false;
                 }
             }
             else if (requestedAccess == MediaDeviceAccess.Audio && audio != AppCapabilityAccessStatus.Allowed)
             {
-                ShowPopup(xamlRoot, MediaDeviceAccess.Audio, requestedTheme);
+                ShowPopup(xamlRoot, MediaDeviceAccess.Audio, purpose, requestedTheme);
                 return false;
             }
             else if (requestedAccess == MediaDeviceAccess.Video && video != AppCapabilityAccessStatus.Allowed)
             {
-                ShowPopup(xamlRoot, MediaDeviceAccess.Video, requestedTheme);
+                ShowPopup(xamlRoot, MediaDeviceAccess.Video, purpose, requestedTheme);
                 return false;
             }
 
             return true;
         }
 
-        private static async void ShowPopup(XamlRoot xamlRoot, MediaDeviceAccess requestedAccess, ElementTheme requestedTheme = ElementTheme.Default)
+        private static async void ShowPopup(XamlRoot xamlRoot, MediaDeviceAccess requestedAccess, MediaDevicePurpose purpose, ElementTheme requestedTheme = ElementTheme.Default)
         {
             var popup = new MessagePopup
             {
                 Title = Strings.AppName,
-                Message = requestedAccess switch
-                {
-                    MediaDeviceAccess.Audio => Strings.PermissionNoAudioCalls,
-                    MediaDeviceAccess.Video => Strings.PermissionNoVideoCalls,
-                    _ => Strings.PermissionNoAudioVideoCalls
-                },
+                Message = purpose == MediaDevicePurpose.Record
+                    ? requestedAccess switch
+                    {
+                        MediaDeviceAccess.Audio => Strings.PermissionNoAudio,
+                        MediaDeviceAccess.Video => Strings.PermissionNoCamera,
+                        _ => Strings.PermissionNoAudioVideo
+                    }
+                    : requestedAccess switch
+                    {
+                        MediaDeviceAccess.Audio => Strings.PermissionNoAudioCalls,
+                        MediaDeviceAccess.Video => Strings.PermissionNoVideoCalls,
+                        _ => Strings.PermissionNoAudioVideoCalls
+                    },
                 PrimaryButtonText = Strings.Settings,
                 SecondaryButtonText = Strings.OK,
                 RequestedTheme = requestedTheme

--- a/Telegram/Common/Recording/ChatRecordEngine.cs
+++ b/Telegram/Common/Recording/ChatRecordEngine.cs
@@ -1,0 +1,801 @@
+//
+// Copyright (c) Fela Ameghino 2015-2026
+//
+// Distributed under the GNU General Public License v3.0. (See accompanying
+// file LICENSE or copy at https://www.gnu.org/licenses/gpl-3.0.txt)
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Telegram.Entities;
+using Telegram.Services;
+using Telegram.Td.Api;
+using Telegram.ViewModels;
+using Windows.Devices.Enumeration;
+using Windows.Foundation;
+using Windows.Media;
+using Windows.Media.Capture;
+using Windows.Media.Capture.Frames;
+using Windows.Media.Devices;
+using Windows.Media.MediaProperties;
+using Windows.Storage;
+
+namespace Telegram.Common.Recording
+{
+    public enum ChatRecordMode
+    {
+        Voice,
+        Video
+    }
+
+    public partial class ChatRecordResult
+    {
+        public ChatRecordResult(TimeSpan duration, IList<byte> waveform)
+        {
+            Duration = duration;
+            Waveform = waveform;
+        }
+
+        public TimeSpan Duration { get; }
+
+        public IList<byte> Waveform { get; }
+    }
+
+    /// <summary>
+    /// Captures a voice or video message. One per <see cref="ChatRecordSession"/>, and never
+    /// shared: two of these on the same thread used to mean two chats fighting over one recording.
+    /// </summary>
+    public partial class ChatRecordEngine
+    {
+        public event EventHandler RecordingFailed;
+        public event EventHandler RecordingStarting;
+        public event EventHandler RecordingStarted;
+        public event EventHandler RecordingStopped;
+        public event EventHandler RecordingTooShort;
+
+        public Action<float> QuantumProcessed;
+
+        private readonly ConcurrentQueueWorker _recordQueue;
+        private readonly DispatcherQueue _dispatcherQueue;
+
+        private OpusRecorder _recorder;
+        private StorageFile _file;
+        private ChatRecordMode _mode;
+        private Chat _chat;
+
+        private MediaFrameReader _reader;
+
+        private readonly AudioWaveform _waveform = new();
+
+        // Set only when the capture format can be encoded as it arrives. Otherwise the
+        // recording goes through MediaCapture's own encoder and is transcoded when sent.
+        private VoiceSink _sink;
+
+        private float[] _samples;
+        private uint _channels;
+        private uint _bitsPerSample;
+
+        private bool _paused;
+
+        public ChatRecordEngine()
+        {
+            _recordQueue = new ConcurrentQueueWorker(1);
+            _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+        }
+
+        public bool IsViewOnce { get; set; }
+
+        public async void Start(ChatRecordMode mode, Chat chat)
+        {
+            Logger.Debug("Start invoked, mode: " + mode);
+
+            await _recordQueue.Enqueue(async () =>
+            {
+                Logger.Debug("Enqueued start invoked");
+
+                if (_recorder != null)
+                {
+                    Logger.Debug("_recorder != null, abort");
+
+                    RecordingFailed?.Invoke(this, EventArgs.Empty);
+                    return;
+                }
+
+                RecordingStarting?.Invoke(this, EventArgs.Empty);
+
+                try
+                {
+                    _mode = mode;
+                    _chat = chat;
+                    _paused = false;
+                    _channels = 0;
+                    _bitsPerSample = 0;
+                    _waveform.Reset();
+
+                    _recorder = new OpusRecorder(mode == ChatRecordMode.Video);
+
+                    _recorder.m_mediaCapture = new MediaCapture();
+                    _recorder.m_mediaCapture.Failed += OnFailed;
+
+                    if (mode == ChatRecordMode.Video)
+                    {
+                        var cameraDevice = await _recorder.FindCameraDeviceByPanelAsync(Windows.Devices.Enumeration.Panel.Front);
+                        if (cameraDevice != null)
+                        {
+                            // Figure out where the camera is located
+                            if (cameraDevice.EnclosureLocation == null || cameraDevice.EnclosureLocation.Panel == Windows.Devices.Enumeration.Panel.Unknown)
+                            {
+                                // No information on the location of the camera, assume it's an external camera, not integrated on the device
+                                _recorder._externalCamera = true;
+                            }
+                            else
+                            {
+                                // Camera is fixed on the device
+                                _recorder._externalCamera = false;
+
+                                // Only mirror the preview if the camera is on the front panel
+                                _recorder._mirroringPreview = cameraDevice.EnclosureLocation.Panel == Windows.Devices.Enumeration.Panel.Front;
+                            }
+
+                            _recorder.settings.VideoDeviceId = cameraDevice.Id;
+                        }
+                    }
+
+                    await _recorder.m_mediaCapture.InitializeAsync(_recorder.settings);
+                    RecordingStarted?.Invoke(this, EventArgs.Empty);
+
+                    Logger.Debug("Devices initialized, starting");
+
+                    // For a voice message the reader is the recording, so it always runs. A
+                    // video message animates the same blob and keeps the gate it had.
+                    var reader = mode == ChatRecordMode.Voice
+                        || (PowerSavingPolicy.AreMaterialsEnabled && ApiInfo.CanAnimatePaths);
+
+                    var streaming = reader && await PrepareReaderAsync(mode);
+
+                    _file = await CreateFileAsync(mode, streaming);
+
+                    if (streaming)
+                    {
+                        _sink = new VoiceSink(_file.Path);
+
+                        if (!_sink.IsValid)
+                        {
+                            throw new InvalidOperationException("Opus encoder couldn't open " + _file.Path);
+                        }
+                    }
+                    else
+                    {
+                        Logger.Info("Recording through MediaCapture, the file will be transcoded when sent");
+                        await _recorder.StartAsync(_file);
+                    }
+
+                    // Started last, so that no sample arrives before there is something to
+                    // write it to.
+                    await StartReaderAsync();
+
+                    Logger.Debug("Recording started at " + DateTime.Now);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Debug("Failed to initialize devices, abort: " + ex);
+
+                    if (_reader != null)
+                    {
+                        _reader.FrameArrived -= OnAudioFrameArrived;
+
+                        _reader.Dispose();
+                        _reader = null;
+                    }
+
+                    _sink?.Dispose();
+                    _sink = null;
+
+                    _recorder?.Dispose();
+                    _recorder = null;
+
+                    _file = null;
+
+                    RecordingFailed?.Invoke(this, EventArgs.Empty);
+                }
+            });
+        }
+
+        private void OnFailed(MediaCapture sender, MediaCaptureFailedEventArgs errorEventArgs)
+        {
+            Logger.Error(errorEventArgs.Message);
+
+            // The microphone was unplugged, or the driver gave up. Tearing down here is what stops
+            // the UI sitting in a recording state that can never end, and leaves the engine able
+            // to start again.
+            Cancel();
+            RecordingFailed?.Invoke(this, EventArgs.Empty);
+        }
+
+        private static Task<StorageFile> CreateFileAsync(ChatRecordMode mode, bool streaming)
+        {
+            var fileName = string.Format(mode == ChatRecordMode.Video
+                ? "video_{0:yyyy}-{0:MM}-{0:dd}_{0:HH}-{0:mm}-{0:ss}.mp4"
+                : streaming
+                ? "voice_{0:yyyy}-{0:MM}-{0:dd}_{0:HH}-{0:mm}-{0:ss}.oga"
+                : "voice_{0:yyyy}-{0:MM}-{0:dd}_{0:HH}-{0:mm}-{0:ss}.wav", DateTime.Now);
+
+            // Unique rather than fail: the name is only second-accurate, and two recordings
+            // within the same second is a tap away.
+            return ApplicationData.Current.TemporaryFolder.CreateFileAsync(fileName, CreationCollisionOption.GenerateUniqueName).AsTask();
+        }
+
+        /// <summary>
+        /// Creates the audio frame reader, and reports whether its samples can be handed to
+        /// the encoder as they are.
+        /// </summary>
+        private async Task<bool> PrepareReaderAsync(ChatRecordMode mode)
+        {
+            try
+            {
+                var frameSource = _recorder.m_mediaCapture.FrameSources.FirstOrDefault(x => x.Value.Info.MediaStreamType == MediaStreamType.Audio);
+                if (frameSource.Value == null)
+                {
+                    Logger.Info("No audio frame source was found.");
+                    return false;
+                }
+
+                var source = frameSource.Value;
+                var format = source.CurrentFormat;
+
+                // The encoder is 48kHz: at any other rate the samples would play back at the
+                // wrong speed, so ask for one and give up on streaming if there isn't one.
+                //
+                // Only ever for a voice message. A video message records through MediaCapture,
+                // and renegotiating the format of the source it is about to record from would
+                // change what lands in the mp4 for the sake of a blob.
+                if (mode == ChatRecordMode.Voice && format.AudioEncodingProperties?.SampleRate != VoiceSink.SampleRate)
+                {
+                    var match = source.SupportedFormats.FirstOrDefault(x => x.AudioEncodingProperties?.SampleRate == VoiceSink.SampleRate && IsSupportedSubtype(x.Subtype));
+                    if (match != null)
+                    {
+                        await source.SetFormatAsync(match);
+                        format = source.CurrentFormat;
+                    }
+                }
+
+                var reader = await _recorder.m_mediaCapture.CreateFrameReaderAsync(source);
+
+                // Buffered rather than Realtime: a dropped frame used to cost a blob update,
+                // it now costs a gap in the recording.
+                reader.AcquisitionMode = MediaFrameReaderAcquisitionMode.Buffered;
+                reader.FrameArrived += OnAudioFrameArrived;
+
+                _reader = reader;
+
+                var properties = format.AudioEncodingProperties;
+                if (properties == null)
+                {
+                    return false;
+                }
+
+                _channels = properties.ChannelCount;
+                _bitsPerSample = properties.BitsPerSample;
+
+                return mode == ChatRecordMode.Voice
+                    && properties.SampleRate == VoiceSink.SampleRate
+                    && IsSupportedSubtype(format.Subtype)
+                    && (_bitsPerSample == 32 || _bitsPerSample == 16)
+                    && _channels > 0;
+            }
+            catch (Exception ex)
+            {
+                Logger.Info("The audio frame reader couldn't be created: " + ex);
+                return false;
+            }
+        }
+
+        private async Task StartReaderAsync()
+        {
+            if (_reader == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var status = await _reader.StartAsync();
+                if (status != MediaFrameReaderStartStatus.Success)
+                {
+                    Logger.Info("The MediaFrameReader couldn't start.");
+                }
+            }
+            catch
+            {
+                // A task was canceled.
+            }
+        }
+
+        private static bool IsSupportedSubtype(string subtype)
+        {
+            // 32-bit float and 16-bit PCM are the two the sink knows how to read.
+            return string.Equals(subtype, MediaEncodingSubtypes.Float, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(subtype, MediaEncodingSubtypes.Pcm, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private unsafe void OnAudioFrameArrived(MediaFrameReader sender, MediaFrameArrivedEventArgs args)
+        {
+            using var reference = sender.TryAcquireLatestFrame();
+            if (reference?.SourceKind != MediaFrameSourceKind.Audio || _paused)
+            {
+                return;
+            }
+
+            // The reader can be running with a format we never managed to read, in which case
+            // there is nothing to say about how to interpret its bytes.
+            if (_channels == 0 || _bitsPerSample == 0)
+            {
+                return;
+            }
+
+            using var frame = reference.AudioMediaFrame.GetAudioFrame();
+
+            using var audioBuffer = frame.LockBuffer(AudioBufferAccessMode.Read);
+            using var bufferReference = audioBuffer.CreateReference();
+
+            // Get the buffer from the AudioFrame
+            bufferReference.Buffer(out byte* buffer, out uint capacity);
+
+            var samples = ReadSamples(buffer, Math.Min(audioBuffer.Length, capacity));
+
+            // Every frame is folded in, and only the notification is rate-limited: this
+            // callback is the recording now, so it can't afford to skip one.
+            if (_waveform.Add(samples))
+            {
+                QuantumProcessed?.Invoke(_waveform.Level);
+            }
+
+            _sink?.Write(samples);
+        }
+
+        /// <summary>
+        /// Presents the captured buffer as mono 32-bit float, which is what both the waveform
+        /// and the encoder read.
+        /// </summary>
+        private unsafe ReadOnlySpan<float> ReadSamples(byte* buffer, uint length)
+        {
+            var channels = (int)_channels;
+            var count = (int)(length / (_bitsPerSample / 8 * _channels));
+
+            // Mono float is the common case and needs no conversion at all.
+            if (_bitsPerSample == 32 && channels == 1)
+            {
+                return new ReadOnlySpan<float>(buffer, count);
+            }
+
+            if (_samples == null || _samples.Length < count)
+            {
+                _samples = new float[count];
+            }
+
+            var target = _samples.AsSpan(0, count);
+
+            if (_bitsPerSample == 32)
+            {
+                var source = (float*)buffer;
+
+                for (int i = 0; i < count; i++)
+                {
+                    var sum = 0f;
+                    for (int j = 0; j < channels; j++)
+                    {
+                        sum += source[i * channels + j];
+                    }
+
+                    target[i] = sum / channels;
+                }
+            }
+            else
+            {
+                var source = (short*)buffer;
+
+                for (int i = 0; i < count; i++)
+                {
+                    var sum = 0f;
+                    for (int j = 0; j < channels; j++)
+                    {
+                        sum += source[i * channels + j] / 32768f;
+                    }
+
+                    target[i] = sum / channels;
+                }
+            }
+
+            return target;
+        }
+
+        public byte[] GetWaveform()
+        {
+            return _waveform.GetWaveform();
+        }
+
+        public async Task<ChatRecordResult> PauseAsync()
+        {
+            Logger.Debug("Pause invoked");
+
+            var tsc = new TaskCompletionSource<ChatRecordResult>();
+
+            _ = _recordQueue.Enqueue(async () =>
+            {
+                Logger.Debug("Enqueued pause invoked");
+
+                var recorder = _recorder;
+                if (recorder == null)
+                {
+                    Logger.Debug("recorder or file == null, abort");
+
+                    // Setting it is what releases the caller: it awaits this task.
+                    tsc.SetResult(null);
+                    return;
+                }
+
+                if (_sink != null)
+                {
+                    // Nothing to pause: the frames keep arriving and are dropped, which keeps
+                    // the device warm and resuming instant.
+                    _paused = !_paused;
+
+                    tsc.SetResult(_paused
+                        ? new ChatRecordResult(_sink.Duration, GetWaveform())
+                        : null);
+                    return;
+                }
+
+                var paused = await recorder.PauseAsync();
+                if (paused != null)
+                {
+                    tsc.SetResult(new ChatRecordResult(paused.RecordDuration, GetWaveform()));
+
+                    if (_reader != null)
+                    {
+                        try
+                        {
+                            await _reader.StopAsync();
+                        }
+                        catch
+                        {
+                            // A task was canceled.
+                        }
+                    }
+                }
+                else
+                {
+                    tsc.SetResult(null);
+
+                    if (_reader != null)
+                    {
+                        try
+                        {
+                            await _reader.StartAsync();
+                        }
+                        catch
+                        {
+                            // A task was canceled.
+                        }
+                    }
+                }
+            });
+
+            return await tsc.Task;
+        }
+
+        /// <summary>
+        /// Stops the recording and sends it, unless it was too short to be one.
+        /// </summary>
+        public void Complete(ComposeViewModel viewModel)
+        {
+            Stop(viewModel, discard: false);
+        }
+
+        /// <summary>
+        /// Stops the recording and throws it away.
+        /// </summary>
+        public void Cancel()
+        {
+            Stop(null, discard: true);
+        }
+
+        private async void Stop(ComposeViewModel viewModel, bool discard)
+        {
+            Logger.Debug("Stop invoked, discard: " + discard);
+
+            await _recordQueue.Enqueue(async () =>
+            {
+                Logger.Debug("Enqueued stop invoked");
+
+                var recorder = _recorder;
+                var file = _file;
+                var mode = _mode;
+                var chat = _chat;
+
+                var reader = _reader;
+
+                if (recorder == null || file == null || chat == null)
+                {
+                    Logger.Debug("recorder or file == null, abort");
+                    return;
+                }
+
+                if (recorder.m_mediaCapture != null)
+                {
+                    recorder.m_mediaCapture.Failed -= OnFailed;
+                }
+
+                RecordingStopped?.Invoke(this, EventArgs.Empty);
+
+                Logger.Debug("stopping reader");
+
+                if (reader != null)
+                {
+                    try
+                    {
+                        await reader.StopAsync();
+                    }
+                    catch
+                    {
+                        // A task was canceled.
+                    }
+
+                    reader.FrameArrived -= OnAudioFrameArrived;
+                    reader.Dispose();
+
+                    QuantumProcessed?.Invoke(0);
+                }
+
+                var sink = _sink;
+                var waveform = Array.Empty<byte>();
+
+                TimeSpan duration;
+
+                if (sink != null)
+                {
+                    sink.Complete();
+
+                    // Counted from the samples that were actually encoded, so it matches the
+                    // file rather than the moment the user pressed the button.
+                    duration = sink.Duration;
+                    waveform = GetWaveform();
+
+                    sink.Dispose();
+
+                    await recorder.StopAsync();
+                }
+                else
+                {
+                    var result = await recorder.StopAsync();
+                    duration = result?.RecordDuration ?? TimeSpan.Zero;
+
+                    if (mode == ChatRecordMode.Voice)
+                    {
+                        waveform = GetWaveform();
+                    }
+                }
+
+                Logger.Debug("recorder stopped, duration: " + duration);
+
+                if (discard || duration.TotalMilliseconds < 700)
+                {
+                    try
+                    {
+                        await file.DeleteAsync();
+                    }
+                    catch { }
+
+                    Logger.Debug("recording canceled or too short, abort");
+
+                    if (!discard)
+                    {
+                        RecordingTooShort?.Invoke(this, EventArgs.Empty);
+                    }
+                }
+                else
+                {
+                    Logger.Debug("sending recorded file");
+                    Send(viewModel, mode, chat, file, recorder._mirroringPreview, duration, waveform, sink != null);
+                }
+
+                _recorder = null;
+                _file = null;
+
+                _reader = null;
+                _sink = null;
+            });
+        }
+
+        private async void Send(ComposeViewModel viewModel, ChatRecordMode mode, Chat chat, StorageFile file, bool mirroring, TimeSpan duration, byte[] waveform, bool encoded)
+        {
+            var selfDestructType = IsViewOnce
+                    ? new MessageSelfDestructTypeImmediately()
+                    : null;
+
+            IsViewOnce = false;
+
+            if (mode == ChatRecordMode.Video)
+            {
+                var props = await file.Properties.GetVideoPropertiesAsync();
+                var width = props.GetWidth();
+                var height = props.GetHeight();
+                var x = 0d;
+                var y = 0d;
+
+                if (width > height)
+                {
+                    x = (width - height) / 2;
+                    width = height;
+                }
+                else if (height > width)
+                {
+                    y = (height - width) / 2;
+                    height = width;
+                }
+
+                var length = viewModel.ClientService.Options.SuggestedVideoNoteLength;
+                var videoBitrate = viewModel.ClientService.Options.SuggestedVideoNoteVideoBitrate;
+                var audioBitrate = viewModel.ClientService.Options.SuggestedVideoNoteAudioBitrate;
+
+                var video = await StorageMedia.CreateAsync(file);
+                var generation = new VideoGeneration
+                {
+                    Transcode = true,
+                    Transform = true,
+                    CropRectangle = new Rect(x, y, width, height),
+                    OutputSize = new Size(length, length),
+                    Flip = mirroring ? ImageFlip.Horizontal : ImageFlip.None,
+                    Width = (uint)length,
+                    Height = (uint)length,
+                    VideoBitrate = (uint)videoBitrate * 1000,
+                    AudioBitrate = (uint)audioBitrate * 1000
+                };
+
+                try
+                {
+                    _dispatcherQueue.TryEnqueue(() => _ = viewModel.SendVideoNoteAsync(video as StorageVideo, generation, selfDestructType));
+                }
+                catch { }
+            }
+            else
+            {
+                // Already Ogg/Opus when the sink wrote it, so there is nothing to convert.
+                var conversion = encoded
+                    ? ConversionType.Copy
+                    : ConversionType.Opus;
+
+                try
+                {
+                    _dispatcherQueue.TryEnqueue(() => _ = viewModel.SendVoiceNoteAsync(file, conversion, duration, waveform, null, selfDestructType));
+                }
+                catch { }
+            }
+        }
+
+        public MediaCapture MediaSource => _recorder?.m_mediaCapture;
+
+        internal sealed class OpusRecorder
+        {
+            private readonly bool m_isVideo;
+
+            private LowLagMediaRecording m_lowLag;
+            private bool m_paused;
+
+            public MediaCapture m_mediaCapture;
+            public MediaCaptureInitializationSettings settings;
+
+            // Information about the camera device
+            public bool _mirroringPreview;
+            public bool _externalCamera;
+
+            //// Rotation Helper to simplify handling rotation compensation for the camera streams
+            //public CameraRotationHelper _rotationHelper;
+
+            public OpusRecorder(bool video)
+            {
+                m_isVideo = video;
+                InitializeSettings();
+            }
+
+            private void InitializeSettings()
+            {
+                // We're forcing CPU because "Auto" seems to be failing on some devices.
+                settings = new MediaCaptureInitializationSettings();
+                settings.MediaCategory = MediaCategory.Media;
+                settings.AudioProcessing = m_isVideo ? AudioProcessing.Default : SettingsService.Current.Diagnostics.ForceRawAudio ? AudioProcessing.Raw : AudioProcessing.Default;
+                settings.MemoryPreference = MediaCaptureMemoryPreference.Cpu;
+                settings.SharingMode = MediaCaptureSharingMode.SharedReadOnly;
+                settings.StreamingCaptureMode = m_isVideo ? StreamingCaptureMode.AudioAndVideo : StreamingCaptureMode.Audio;
+            }
+
+            public async Task<DeviceInformation> FindCameraDeviceByPanelAsync(Windows.Devices.Enumeration.Panel desiredPanel)
+            {
+                // Get available devices for capturing pictures
+                var allVideoDevices = await DeviceInformation.FindAllAsync(DeviceClass.VideoCapture);
+
+                // Get the desired camera by panel
+                DeviceInformation desiredDevice = allVideoDevices.FirstOrDefault(x => x.EnclosureLocation != null && x.EnclosureLocation.Panel == desiredPanel);
+
+                // If there is no device mounted on the desired panel, return the first device found
+                return desiredDevice ?? allVideoDevices.FirstOrDefault();
+            }
+
+            public async Task StartAsync(StorageFile file)
+            {
+                MediaEncodingProfile profile;
+                if (m_isVideo)
+                {
+                    profile = MediaEncodingProfile.CreateMp4(VideoEncodingQuality.Auto);
+                }
+                else
+                {
+                    profile = MediaEncodingProfile.CreateWav(AudioEncodingQuality.High);
+                    profile.Audio.BitsPerSample = 16;
+                    profile.Audio.SampleRate = 48000;
+                    profile.Audio.ChannelCount = 1;
+                }
+
+                m_lowLag = await m_mediaCapture.PrepareLowLagRecordToStorageFileAsync(profile, file);
+                await m_lowLag.StartAsync();
+            }
+
+            public async Task<MediaCapturePauseResult> PauseAsync()
+            {
+                try
+                {
+                    if (m_paused)
+                    {
+                        m_paused = false;
+                        await m_lowLag.ResumeAsync();
+                        return null;
+                    }
+                    else
+                    {
+                        m_paused = true;
+                        return await m_lowLag.PauseWithResultAsync(MediaCapturePauseBehavior.RetainHardwareResources);
+                    }
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+
+            public async Task<MediaCaptureStopResult> StopAsync()
+            {
+                MediaCaptureStopResult result = null;
+                try
+                {
+                    // Null when the sink did the recording: there is only the device to close.
+                    if (m_lowLag != null)
+                    {
+                        result = await m_lowLag.StopWithResultAsync();
+                        await m_lowLag.FinishAsync();
+                    }
+                }
+                catch { }
+                finally
+                {
+                    m_mediaCapture?.Dispose();
+                    m_mediaCapture = null;
+                }
+                return result;
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    m_lowLag = null;
+
+                    m_mediaCapture.Dispose();
+                    m_mediaCapture = null;
+                }
+                catch { }
+            }
+        }
+    }
+}

--- a/Telegram/Common/Recording/ChatRecordSession.cs
+++ b/Telegram/Common/Recording/ChatRecordSession.cs
@@ -1,0 +1,282 @@
+//
+// Copyright (c) Fela Ameghino 2015-2026
+//
+// Distributed under the GNU General Public License v3.0. (See accompanying
+// file LICENSE or copy at https://www.gnu.org/licenses/gpl-3.0.txt)
+//
+
+using System;
+using System.Threading.Tasks;
+using Telegram.Services;
+using Telegram.Td.Api;
+using Telegram.ViewModels;
+using Windows.Media.Capture;
+
+namespace Telegram.Common.Recording
+{
+    public enum ChatRecordState
+    {
+        Idle,
+        Recording,
+
+        /// <summary>
+        /// Recording, and no longer held by the pointer.
+        /// </summary>
+        Locked
+    }
+
+    /// <summary>
+    /// Owns a recording from the moment it is asked for to the moment it is sent or thrown away:
+    /// the state, the clock, and the engine underneath. One per chat.
+    /// </summary>
+    /// <remarks>
+    /// This is deliberately not a control. What is left in <c>ChatRecordButton</c> is input, and
+    /// what is left in <c>ChatRecordBar</c> is animation.
+    /// </remarks>
+    public partial class ChatRecordSession
+    {
+        private readonly ChatRecordEngine _engine = new();
+        private readonly DispatcherQueue _dispatcherQueue;
+
+        // The engine reports from its own queue, so these are written off the UI thread and read
+        // on it, exactly as they were when they lived in the button.
+        private bool _recording;
+        private bool _locked;
+        private bool _paused;
+
+        // Set when a recording is asked to lock before it has actually begun: Ctrl+R does not wait
+        // for the microphone.
+        private bool _lockRequested;
+
+        // .NET Native has no Environment.TickCount64.
+        private ulong _resumedAt;
+        private TimeSpan _accumulated;
+
+        public ChatRecordSession()
+        {
+            _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+
+            _engine.RecordingStarting += OnEngineStarting;
+            _engine.RecordingStarted += OnEngineStarted;
+            _engine.RecordingStopped += OnEngineStopped;
+            _engine.RecordingFailed += OnEngineStopped;
+            _engine.RecordingTooShort += OnEngineTooShort;
+
+            _engine.QuantumProcessed = OnQuantumProcessed;
+        }
+
+        public ChatRecordState State { get; private set; }
+
+        public ChatRecordMode Mode { get; private set; }
+
+        public bool IsRecording => _recording;
+
+        public bool IsLocked => _locked;
+
+        public bool IsPaused => _paused;
+
+        public bool IsViewOnce
+        {
+            get => _engine.IsViewOnce;
+            set => _engine.IsViewOnce = value;
+        }
+
+        /// <summary>
+        /// How long the recording has been running, from a monotonic clock and frozen while
+        /// paused. Not the same number as the duration that gets sent, which is counted from the
+        /// samples: this one includes the time the microphone took to open.
+        /// </summary>
+        public TimeSpan Elapsed => _paused
+            ? _accumulated
+            : _accumulated + TimeSpan.FromMilliseconds(Logger.TickCount - _resumedAt);
+
+        public byte[] GetWaveform()
+        {
+            return _engine.GetWaveform();
+        }
+
+        public event EventHandler RecordingStarting;
+        public event EventHandler<MediaCapture> RecordingStarted;
+        public event EventHandler RecordingStopped;
+        public event EventHandler RecordingLocked;
+        public event EventHandler RecordingTooShort;
+
+        public event EventHandler<float> QuantumProcessed;
+
+        /// <summary>
+        /// Begins capturing. The caller is expected to have settled permissions and chat rights
+        /// already: by the time this runs the answer is yes.
+        /// </summary>
+        public void Start(ChatRecordMode mode, Chat chat)
+        {
+            Mode = mode;
+
+            LifetimeService.Current.Playback.Pause();
+
+            _engine.Start(mode, chat);
+            Update();
+        }
+
+        /// <summary>
+        /// Locks as soon as the recording begins, for the paths that don't hold a pointer down.
+        /// </summary>
+        public void RequestLock()
+        {
+            _lockRequested = true;
+        }
+
+        public void Lock()
+        {
+            _lockRequested = false;
+            _locked = true;
+
+            Update();
+        }
+
+        public void Complete(ComposeViewModel viewModel)
+        {
+            _engine.Complete(viewModel);
+
+            _recording = false;
+            Update();
+        }
+
+        public void Cancel()
+        {
+            _engine.Cancel();
+
+            _recording = false;
+            Update();
+        }
+
+        /// <summary>
+        /// Pauses or resumes. Returns the recording so far when it pauses, and null when it
+        /// resumes.
+        /// </summary>
+        public async Task<ChatRecordResult> TogglePauseAsync()
+        {
+            // Flipped before awaiting so the clock stops at the moment of the click rather than
+            // when the engine gets around to it.
+            _paused = !_paused;
+
+            if (_paused)
+            {
+                _accumulated = Elapsed;
+            }
+            else
+            {
+                _resumedAt = Logger.TickCount;
+            }
+
+            var result = await _engine.PauseAsync();
+            if (result != null)
+            {
+                // The engine knows how much audio it actually holds, which is the number the
+                // waveform preview is labelled with.
+                _accumulated = result.Duration;
+            }
+
+            return result;
+        }
+
+        private void OnEngineStarting(object sender, EventArgs e)
+        {
+            if (!_recording)
+            {
+                _recording = true;
+                Update();
+
+                if (_lockRequested)
+                {
+                    Lock();
+                }
+            }
+        }
+
+        private void OnEngineStarted(object sender, EventArgs e)
+        {
+            // The device is open, which is the expensive part of starting. Restarting the clock
+            // here keeps the label from counting time no microphone was listening for — the bar
+            // is already on screen by now, it just wasn't ticking against anything real.
+            _accumulated = TimeSpan.Zero;
+            _resumedAt = Logger.TickCount;
+
+            // Read here rather than in the callback: by the time that runs the recording may
+            // already have been torn down.
+            var mediaCapture = _engine.MediaSource;
+
+            if (_recording && mediaCapture != null)
+            {
+                _dispatcherQueue.TryEnqueue(() => RecordingStarted?.Invoke(this, mediaCapture));
+            }
+        }
+
+        private void OnEngineStopped(object sender, EventArgs e)
+        {
+            if (_recording)
+            {
+                _recording = false;
+                Update();
+            }
+        }
+
+        private void OnEngineTooShort(object sender, EventArgs e)
+        {
+            _dispatcherQueue.TryEnqueue(() => RecordingTooShort?.Invoke(this, EventArgs.Empty));
+        }
+
+        private void OnQuantumProcessed(float amplitude)
+        {
+            // Raised on the capture thread, ~40 times a second. Marshalling would allocate a
+            // closure for each one, and there is nothing to marshal for: the only listener hands
+            // the level to CompositionBlobVisual, which stores it and lets its own vsync tick pick
+            // it up on the UI thread.
+            QuantumProcessed?.Invoke(this, amplitude);
+        }
+
+        /// <summary>
+        /// The one transition. Everything that used to be spread across a chain of booleans and an
+        /// integer interface state resolves here.
+        /// </summary>
+        private void Update()
+        {
+            var state = (_recording, _locked) switch
+            {
+                (true, true) => ChatRecordState.Locked,
+                (true, false) => ChatRecordState.Recording,
+                _ => ChatRecordState.Idle
+            };
+
+            if (state == State)
+            {
+                return;
+            }
+
+            State = state;
+
+            switch (state)
+            {
+                case ChatRecordState.Recording:
+                    _paused = false;
+
+                    _accumulated = TimeSpan.Zero;
+                    _resumedAt = Logger.TickCount;
+
+                    _dispatcherQueue.TryEnqueue(() => RecordingStarting?.Invoke(this, EventArgs.Empty));
+                    break;
+
+                case ChatRecordState.Locked:
+                    _dispatcherQueue.TryEnqueue(() => RecordingLocked?.Invoke(this, EventArgs.Empty));
+                    break;
+
+                case ChatRecordState.Idle:
+                    _locked = false;
+                    _paused = false;
+                    _lockRequested = false;
+
+                    _dispatcherQueue.TryEnqueue(() => RecordingStopped?.Invoke(this, EventArgs.Empty));
+                    break;
+            }
+        }
+    }
+}

--- a/Telegram/Controls/Chats/ChatRecordBar.xaml.cs
+++ b/Telegram/Controls/Chats/ChatRecordBar.xaml.cs
@@ -11,6 +11,7 @@ using System.Numerics;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Telegram.Common;
+using Telegram.Common.Recording;
 using Telegram.Composition;
 using Telegram.Controls.Media;
 using Telegram.Native.Controls;
@@ -75,17 +76,22 @@ namespace Telegram.Controls.Chats
 
             _elapsedTimer = new DispatcherTimer();
             _elapsedTimer.Interval = TimeSpan.FromMilliseconds(100);
-            _elapsedTimer.Tick += (s, args) =>
-            {
-                ElapsedLabel.Text = ControlledButton.Elapsed.ToString("m\\:ss\\.ff");
-            };
+            _elapsedTimer.Tick += OnElapsedTimerTick;
 
             _blobVisual = new CompositionBlobVisual(Blob, 160, 160, 4);
+
+            Loaded += OnLoaded;
+            Unloaded += OnUnloaded;
         }
 
         protected override void OnDisconnectVisualChildren()
         {
             _blobVisual.StopAnimating();
+        }
+
+        private void OnElapsedTimerTick(object sender, object e)
+        {
+            ElapsedLabel.Text = ControlledButton.Elapsed.ToString("m\\:ss\\.ff");
         }
 
         private void ElapsedPanel_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -109,7 +115,7 @@ namespace Telegram.Controls.Chats
 
         private void ButtonCancelRecording_Click(object sender, RoutedEventArgs e)
         {
-            ControlledButton.StopRecording(true);
+            ControlledButton.Cancel();
         }
 
         private void OnQuantumProcessed(object sender, float amplitude)
@@ -119,7 +125,7 @@ namespace Telegram.Controls.Chats
 
         private void ChatRecordLocked_Click(object sender, RoutedEventArgs e)
         {
-            ControlledButton.Release();
+            ControlledButton.Complete();
         }
 
         private ChatRecordButton _controlledButton;
@@ -131,12 +137,30 @@ namespace Telegram.Controls.Chats
 
         private void SetControlledButton(ChatRecordButton value)
         {
-            if (_controlledButton != null)
+            if (_controlledButton == value)
             {
                 return;
             }
 
+            Detach();
             _controlledButton = value;
+
+            if (IsLoaded)
+            {
+                Attach();
+            }
+        }
+
+        private bool _attached;
+
+        private void Attach()
+        {
+            if (_controlledButton == null || _attached)
+            {
+                return;
+            }
+
+            _attached = true;
 
             _controlledButton.RecordingStarting += OnRecordingStarting;
             _controlledButton.RecordingStarted += OnRecordingStarted;
@@ -146,11 +170,38 @@ namespace Telegram.Controls.Chats
             _controlledButton.ManipulationDelta += OnManipulationDelta;
         }
 
-        private async void OnRecordingStarted(object sender, EventArgs e)
+        private void Detach()
+        {
+            if (_controlledButton == null || !_attached)
+            {
+                return;
+            }
+
+            _attached = false;
+
+            _controlledButton.RecordingStarting -= OnRecordingStarting;
+            _controlledButton.RecordingStarted -= OnRecordingStarted;
+            _controlledButton.RecordingStopped -= OnRecordingStopped;
+            _controlledButton.RecordingLocked -= OnRecordingLocked;
+            _controlledButton.QuantumProcessed -= OnQuantumProcessed;
+            _controlledButton.ManipulationDelta -= OnManipulationDelta;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            Attach();
+        }
+
+        private void OnUnloaded(object sender, RoutedEventArgs e)
+        {
+            Detach();
+        }
+
+        private async void OnRecordingStarted(object sender, MediaCapture mediaCapture)
         {
             try
             {
-                if (sender is not MediaCapture mediaCapture || mediaCapture.MediaCaptureSettings.StreamingCaptureMode == StreamingCaptureMode.Audio)
+                if (mediaCapture == null || mediaCapture.MediaCaptureSettings.StreamingCaptureMode == StreamingCaptureMode.Audio)
                 {
                     return;
                 }
@@ -548,7 +599,7 @@ namespace Telegram.Controls.Chats
             if (point.X < -80)
             {
                 e.Complete();
-                ControlledButton.StopRecording(true);
+                ControlledButton.Cancel();
                 return;
             }
 
@@ -560,7 +611,7 @@ namespace Telegram.Controls.Chats
             if (point.Y < -120)
             {
                 e.Complete();
-                ControlledButton.LockRecording();
+                ControlledButton.Lock();
             }
         }
 
@@ -620,7 +671,7 @@ namespace Telegram.Controls.Chats
         {
             _elapsedTimer.Stop();
 
-            var result = await ControlledButton.PauseRecording();
+            var result = await ControlledButton.TogglePauseAsync();
             if (result != null)
             {
                 _blobVisual.StopAnimating();

--- a/Telegram/Controls/Chats/ChatRecordButton.cs
+++ b/Telegram/Controls/Chats/ChatRecordButton.cs
@@ -7,25 +7,12 @@
 
 using Microsoft.UI.Xaml.Controls;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Telegram.Common;
 using Telegram.Common.Recording;
-using Telegram.Entities;
-using Telegram.Services;
 using Telegram.Td;
-using Telegram.Td.Api;
 using Telegram.ViewModels;
-using Windows.Devices.Enumeration;
-using Windows.Foundation;
-using Windows.Media;
 using Windows.Media.Capture;
-using Windows.Media.Capture.Frames;
-using Windows.Media.Devices;
-using Windows.Media.MediaProperties;
-using Windows.Storage;
-using Windows.System;
 using Windows.System.Display;
 using Windows.System.Profile;
 using Windows.UI.Composition;
@@ -36,35 +23,10 @@ using Windows.UI.Xaml.Input;
 
 namespace Telegram.Controls.Chats
 {
-    public enum ChatRecordMode
-    {
-        Voice,
-        Video
-    }
-
-    public partial class ChatRecordResult
-    {
-        public ChatRecordResult(TimeSpan duration, IList<byte> waveform)
-        {
-            Duration = duration;
-            Waveform = waveform;
-        }
-
-        public TimeSpan Duration { get; }
-
-        public IList<byte> Waveform { get; }
-    }
-
-    public partial class ChatRecordStartedEventArgs : EventArgs
-    {
-        public ChatRecordStartedEventArgs(DateTime startedAt)
-        {
-            StartedAt = startedAt;
-        }
-
-        public DateTime StartedAt { get; }
-    }
-
+    /// <summary>
+    /// The press-and-hold gesture, and nothing else. What is being recorded, and how far along it
+    /// is, belongs to <see cref="ChatRecordSession"/>.
+    /// </summary>
     public partial class ChatRecordButton : AnimatedIconToggleButton
     {
         public ComposeViewModel ViewModel => DataContext as ComposeViewModel;
@@ -73,15 +35,26 @@ namespace Telegram.Controls.Chats
         private Visual _icon;
 
         private readonly DispatcherTimer _timer;
-        private readonly Recorder _recorder;
 
-        private DateTime _start;
-        private TimeSpan _duration;
+        // One session per button, and one button per chat. The engine underneath used to be a
+        // thread-static singleton, so a recording started in one chat drove the state of every
+        // other chat and story composer loaded on the same thread, and whichever loaded last owned
+        // the level meter.
+        private readonly ChatRecordSession _session = new();
 
-        public TimeSpan Elapsed => DateTime.Now - _start + _duration;
+        public ChatRecordSession Session => _session;
 
-        public bool IsRecording => _recordingAudioVideo;
-        public bool IsLocked => _recordingLocked;
+        public TimeSpan Elapsed => _session.Elapsed;
+
+        public bool IsRecording => _session.IsRecording;
+
+        public bool IsLocked => _session.IsLocked;
+
+        public bool IsViewOnce
+        {
+            get => _session.IsViewOnce;
+            set => _session.IsViewOnce = value;
+        }
 
         private bool _isRestricted;
         public bool IsRestricted
@@ -115,7 +88,7 @@ namespace Telegram.Controls.Chats
             }
         }
 
-        public byte[] GetWaveform() => _recorder.GetWaveform();
+        public byte[] GetWaveform() => _session.GetWaveform();
 
         public ChatRecordButton()
         {
@@ -128,18 +101,15 @@ namespace Telegram.Controls.Chats
 
             _timer = new DispatcherTimer();
             _timer.Interval = TimeSpan.FromMilliseconds(300);
-            _timer.Tick += (s, args) =>
-            {
-                Logger.Debug("Timer Tick, check for permissions");
+            _timer.Tick += OnTimerTick;
 
-                _timer.Stop();
-                RecordAudioVideoRunnable();
-            };
-
-            _recorder = Recorder.Current;
-
-            Loaded += OnLoaded;
-            Unloaded += OnUnloaded;
+            // Nothing to detach: the session is owned by this button and cannot outlive it.
+            _session.RecordingStarting += OnRecordingStarting;
+            _session.RecordingStarted += OnRecordingStarted;
+            _session.RecordingStopped += OnRecordingStopped;
+            _session.RecordingLocked += OnRecordingLocked;
+            _session.RecordingTooShort += OnRecordingTooShort;
+            _session.QuantumProcessed += OnQuantumProcessed;
         }
 
         protected override bool IsRuntimeCompatible()
@@ -160,24 +130,12 @@ namespace Telegram.Controls.Chats
             base.OnApplyTemplate();
         }
 
-        private void OnLoaded(object sender, RoutedEventArgs e)
+        private void OnTimerTick(object sender, object e)
         {
-            _recorder.RecordingStarting += OnRecordingStarting;
-            _recorder.RecordingStarted += OnRecordingStarted;
-            _recorder.RecordingStopped += OnRecordingStopped;
-            _recorder.RecordingFailed += OnRecordingStopped;
+            Logger.Debug("Timer Tick, check for permissions");
 
-            _recorder.QuantumProcessed = amplitude => QuantumProcessed?.Invoke(this, amplitude);
-        }
-
-        private void OnUnloaded(object sender, RoutedEventArgs e)
-        {
-            _recorder.RecordingStarting -= OnRecordingStarting;
-            _recorder.RecordingStarted -= OnRecordingStarted;
-            _recorder.RecordingStopped -= OnRecordingStopped;
-            _recorder.RecordingFailed -= OnRecordingStopped;
-
-            _recorder.QuantumProcessed = null;
+            _timer.Stop();
+            StartRecording();
         }
 
         protected override void OnPointerEntered(PointerRoutedEventArgs e)
@@ -255,55 +213,30 @@ namespace Telegram.Controls.Chats
             OnRelease();
         }
 
-        private async void RecordAudioVideoRunnable()
+        private async void StartRecording()
         {
             _calledRecordRunnable = true;
             _recordAudioVideoRunnableStarted = false;
 
-            var permissions = await CheckAccessAsync(Mode);
-            if (permissions == false)
+            // Inherited from the permission check this replaced, which found consent status
+            // always Unspecified on Xbox and gave up asking. Unverified against AppCapability,
+            // and cheaper to keep than to be wrong about.
+            if (!string.Equals(AnalyticsInfo.VersionInfo.DeviceFamily, "Windows.Xbox"))
             {
-                return;
-            }
+                var requested = Mode == ChatRecordMode.Video
+                    ? MediaDeviceAccess.AudioAndVideo
+                    : MediaDeviceAccess.Audio;
 
-            LifetimeService.Current.Playback.Pause();
+                var permissions = await MediaDevicePermissions.CheckAccessAsync(XamlRoot, requested, ElementTheme.Default, MediaDevicePurpose.Record);
+                if (permissions == false)
+                {
+                    return;
+                }
+            }
 
             Logger.Debug("Permissions granted, mode: " + Mode);
 
-            _recorder.Start(Mode, ViewModel.Chat);
-            UpdateRecordingInterface();
-        }
-
-        private void OnRecordingStarting(object sender, EventArgs e)
-        {
-            if (!_recordingAudioVideo)
-            {
-                _recordingAudioVideo = true;
-                UpdateRecordingInterface();
-
-                if (_enqueuedLocking)
-                {
-                    LockRecording();
-                }
-            }
-        }
-
-        private void OnRecordingStarted(object sender, EventArgs e)
-        {
-            if (_recordingAudioVideo)
-            {
-                this.BeginOnUIThread(() => RecordingStarted?.Invoke(_recorder.MediaSource, EventArgs.Empty));
-            }
-        }
-
-        private void OnRecordingStopped(object sender, EventArgs e)
-        {
-            if (_recordingAudioVideo)
-            {
-                // cancel typing
-                _recordingAudioVideo = false;
-                UpdateRecordingInterface();
-            }
+            _session.Start(Mode, ViewModel.Chat);
         }
 
         private void UpdateVisualState()
@@ -318,105 +251,75 @@ namespace Telegram.Controls.Chats
             }
         }
 
-        private int recordInterfaceState;
-
         private DisplayRequest _request;
 
-        private void UpdateRecordingInterface()
+        private void OnRecordingStarting(object sender, EventArgs e)
         {
-            Logger.Debug("Updating interface, state: " + recordInterfaceState);
+            UpdateVisualState();
 
-            if (_recordingLocked && _recordingAudioVideo)
+            // Release, so that letting go of the pointer raises Click and ends the recording.
+            ClickMode = ClickMode.Release;
+
+            Automation.SetToolTip(this, null);
+
+            try
             {
-                if (recordInterfaceState == 2)
+                if (_request == null)
                 {
-                    return;
+                    _request = new DisplayRequest();
+                    _request.TryRequestActive();
                 }
-                recordInterfaceState = 2;
-
-                this.BeginOnUIThread(() =>
-                {
-                    UpdateVisualState();
-
-                    ClickMode = ClickMode.Press;
-                    RecordingLocked?.Invoke(this, EventArgs.Empty);
-                });
             }
-            else if (_recordingLocked && _recordingStopped)
-            {
-                if (recordInterfaceState == 3)
-                {
-                    return;
-                }
-                recordInterfaceState = 3;
+            catch { }
 
-                this.BeginOnUIThread(() =>
-                {
-                    UpdateVisualState();
+            RecordingStarting?.Invoke(this, e);
+        }
 
-                    ClickMode = ClickMode.Press;
-                    RecordingStopped?.Invoke(this, EventArgs.Empty);
-                });
-            }
-            else if (_recordingAudioVideo)
-            {
-                if (recordInterfaceState == 1)
-                {
-                    return;
-                }
-                recordInterfaceState = 1;
+        private void OnRecordingLocked(object sender, EventArgs e)
+        {
+            UpdateVisualState();
 
-                _recordingLocked = false;
+            ClickMode = ClickMode.Press;
+            RecordingLocked?.Invoke(this, e);
+        }
 
-                _start = DateTime.Now;
-                _duration = TimeSpan.Zero;
+        private void OnRecordingStopped(object sender, EventArgs e)
+        {
+            UpdateVisualState();
 
-                this.BeginOnUIThread(() =>
-                {
-                    UpdateVisualState();
+            ClickMode = ClickMode.Press;
+            Automation.SetToolTip(this, Mode == ChatRecordMode.Video ? Strings.AccDescrVideoMessage : Strings.AccDescrVoiceMessage);
 
-                    ClickMode = ClickMode.Release;
-                    RecordingStarting?.Invoke(this, EventArgs.Empty);
+            _request?.TryRequestRelease();
+            _request = null;
 
-                    Automation.SetToolTip(this, null);
+            RecordingStopped?.Invoke(this, e);
+        }
 
-                    try
-                    {
-                        if (_request == null)
-                        {
-                            _request = new DisplayRequest();
-                            _request.TryRequestActive();
-                        }
-                    }
-                    catch { }
-                });
-            }
-            else
-            {
-                if (recordInterfaceState == 0)
-                {
-                    return;
-                }
-                recordInterfaceState = 0;
+        private void OnRecordingStarted(object sender, MediaCapture e)
+        {
+            RecordingStarted?.Invoke(this, e);
+        }
 
-                _recordingStopped = false;
-                _recordingLocked = false;
+        private void OnQuantumProcessed(object sender, float e)
+        {
+            QuantumProcessed?.Invoke(this, e);
+        }
 
-                this.BeginOnUIThread(() =>
-                {
-                    UpdateVisualState();
+        private void OnRecordingTooShort(object sender, EventArgs e)
+        {
+            // Same hint the mode-switch tap shows: releasing before there is anything to send is a
+            // tap that happened to last a little longer.
+            ShowHoldHint();
+        }
 
-                    ClickMode = ClickMode.Press;
-                    RecordingStopped?.Invoke(this, EventArgs.Empty);
+        private void ShowHoldHint()
+        {
+            var message = Mode == ChatRecordMode.Video
+                ? Strings.HoldToVideo
+                : Strings.HoldToAudio;
 
-                    Automation.SetToolTip(this, Mode == ChatRecordMode.Video ? Strings.AccDescrVideoMessage : Strings.AccDescrVoiceMessage);
-
-                    _request?.TryRequestRelease();
-                    _request = null;
-                });
-            }
-
-            Logger.Debug("Updated interface, state: " + recordInterfaceState);
+            ToastPopup.Show(this, message, TeachingTipPlacementMode.TopLeft, dismissAfter: TimeSpan.FromSeconds(3));
         }
 
         private async void OnClick(object sender, RoutedEventArgs e)
@@ -441,15 +344,9 @@ namespace Telegram.Controls.Chats
 
                 Logger.Debug("Click mode: Press");
 
-                if (_recordingLocked)
+                if (_session.IsLocked)
                 {
-                    if (!_hasRecordVideo || _calledRecordRunnable)
-                    {
-                        _recorder.Stop(ViewModel, false);
-                        _recordingAudioVideo = false;
-                        UpdateRecordingInterface();
-                    }
-
+                    Complete();
                     return;
                 }
 
@@ -473,7 +370,7 @@ namespace Telegram.Controls.Chats
                 }
                 else
                 {
-                    RecordAudioVideoRunnable();
+                    StartRecording();
                 }
             }
             else
@@ -483,26 +380,43 @@ namespace Telegram.Controls.Chats
             }
         }
 
-        public void Release()
+        /// <summary>
+        /// Stops a locked recording and sends it.
+        /// </summary>
+        public void Complete()
         {
-            if (_recordingLocked)
+            if (_session.IsLocked && (!_hasRecordVideo || _calledRecordRunnable))
             {
-                Logger.Debug("Click mode: Release - Programmatic");
-
-                if (!_hasRecordVideo || _calledRecordRunnable)
-                {
-                    _recorder.Stop(ViewModel, false);
-                    _recordingAudioVideo = false;
-                    UpdateRecordingInterface();
-                }
+                Logger.Debug("Completing a locked recording");
+                _session.Complete(ViewModel);
             }
+        }
+
+        /// <summary>
+        /// Stops a recording and throws it away.
+        /// </summary>
+        public void Cancel()
+        {
+            _session.Cancel();
+        }
+
+        public void Lock()
+        {
+            Logger.Debug("Locking recording");
+            _session.Lock();
+        }
+
+        public Task<ChatRecordResult> TogglePauseAsync()
+        {
+            Logger.Debug("Pause recording");
+            return _session.TogglePauseAsync();
         }
 
         private void OnRelease()
         {
             ClickMode = ClickMode.Press;
 
-            if (_recordingLocked)
+            if (_session.IsLocked)
             {
                 Logger.Debug("Recording is locked, abort");
                 return;
@@ -514,175 +428,22 @@ namespace Telegram.Controls.Chats
                 _timer.Stop();
                 Mode = Mode == ChatRecordMode.Video ? ChatRecordMode.Voice : ChatRecordMode.Video;
 
-                var message = Mode == ChatRecordMode.Video
-                    ? Strings.HoldToVideo
-                    : Strings.HoldToAudio;
-
-                ToastPopup.Show(this, message, TeachingTipPlacementMode.TopLeft, dismissAfter: TimeSpan.FromSeconds(3));
+                ShowHoldHint();
             }
             else if (!_hasRecordVideo || _calledRecordRunnable)
             {
                 Logger.Debug("Timer has tick, stopping recording");
-
-                _recorder.Stop(ViewModel, false);
-                _recordingAudioVideo = false;
-                UpdateRecordingInterface();
+                _session.Complete(ViewModel);
             }
 
             UpdateVisualState();
         }
 
-        private async Task<bool> CheckAccessAsync(ChatRecordMode mode)
-        {
-            try
-            {
-                var audioPermission = await CheckDeviceAccessAsync(true, mode);
-                if (audioPermission == false)
-                {
-                    return false;
-                }
-
-                if (mode == ChatRecordMode.Video)
-                {
-                    var videoPermission = await CheckDeviceAccessAsync(false, ChatRecordMode.Video);
-                    if (videoPermission == false)
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-            catch
-            {
-                // TODO: notify user
-                return false;
-            }
-        }
-
-        private async Task<bool> CheckDeviceAccessAsync(bool audio, ChatRecordMode mode)
-        {
-            // For some reason, as far as I understood, CurrentStatus is always Unspecified on Xbox
-            if (string.Equals(AnalyticsInfo.VersionInfo.DeviceFamily, "Windows.Xbox"))
-            {
-                return true;
-            }
-
-            var access = DeviceAccessInformation.CreateFromDeviceClass(audio ? DeviceClass.AudioCapture : DeviceClass.VideoCapture);
-            if (access.CurrentStatus == DeviceAccessStatus.Unspecified)
-            {
-                MediaCapture capture = null;
-                try
-                {
-                    capture = new MediaCapture();
-                    var settings = new MediaCaptureInitializationSettings();
-                    settings.StreamingCaptureMode = mode == ChatRecordMode.Video
-                        ? StreamingCaptureMode.AudioAndVideo
-                        : StreamingCaptureMode.Audio;
-                    await capture.InitializeAsync(settings);
-                }
-                catch { }
-                finally
-                {
-                    capture?.Dispose();
-                    capture = null;
-                }
-
-                return false;
-            }
-            else if (access.CurrentStatus != DeviceAccessStatus.Allowed)
-            {
-                var message = audio
-                    ? mode == ChatRecordMode.Voice
-                    ? Strings.PermissionNoAudio
-                    : Strings.PermissionNoAudioVideo
-                    : Strings.PermissionNoCamera;
-
-                this.BeginOnUIThread(async () =>
-                {
-                    var confirm = await MessagePopup.ShowAsync(XamlRoot, message, Strings.AppName, Strings.PermissionOpenSettings, Strings.OK);
-                    if (confirm == ContentDialogResult.Primary)
-                    {
-                        await Launcher.LaunchUriAsync(new Uri("ms-settings:appsfeatures-app"));
-                    }
-                });
-
-                return false;
-            }
-
-            return true;
-        }
-
-        private readonly bool _hasRecordVideo = true;
-
-        private bool _pointerEntered;
-        private bool _pointerReleased;
-
-        private bool _calledRecordRunnable;
-        private bool _recordAudioVideoRunnableStarted;
-
-        private bool _recordingAudioVideo;
-
-        private bool _recordingPaused;
-        private bool _recordingStopped;
-
-        private bool _recordingLocked;
-        private bool _enqueuedLocking;
-
-        public void StopRecording(bool cancel)
-        {
-            _recorder.Stop(null, cancel ? true : new bool?());
-            _recordingStopped = !cancel;
-            _recordingAudioVideo = false;
-            UpdateRecordingInterface();
-        }
-
-        public void LockRecording()
-        {
-            Logger.Debug("Locking recording");
-
-            _enqueuedLocking = false;
-            _recordingLocked = true;
-            UpdateRecordingInterface();
-        }
-
-        public async Task<ChatRecordResult> PauseRecording()
-        {
-            Logger.Debug("Pause recording");
-
-            if (_recordingPaused)
-            {
-                _start = DateTime.Now;
-                _recordingPaused = false;
-            }
-            else
-            {
-                _duration = Elapsed;
-                _recordingPaused = true;
-            }
-
-            UpdateRecordingInterface();
-
-            var result = await _recorder.PauseAsync();
-            if (result != null)
-            {
-                _start = DateTime.Now;
-                _duration = result.Duration;
-            }
-
-            return result;
-        }
-
         public async void ToggleRecording()
         {
-            if (_recordingLocked)
+            if (_session.IsLocked)
             {
-                if (!_hasRecordVideo || _calledRecordRunnable)
-                {
-                    _recorder.Stop(ViewModel, false);
-                    _recordingAudioVideo = false;
-                    UpdateRecordingInterface();
-                }
+                Complete();
             }
             else
             {
@@ -692,765 +453,26 @@ namespace Telegram.Controls.Chats
                     return;
                 }
 
-                _enqueuedLocking = true;
-                RecordAudioVideoRunnable();
+                // Nothing is holding a pointer down, so it locks the moment it begins.
+                _session.RequestLock();
+                StartRecording();
             }
         }
 
+        // Whether tapping switches between voice and video, which is what the 300ms timer is for.
+        private readonly bool _hasRecordVideo = true;
+
+        private bool _pointerEntered;
+        private bool _pointerReleased;
+
+        private bool _calledRecordRunnable;
+        private bool _recordAudioVideoRunnableStarted;
+
         public event EventHandler RecordingStarting;
-        public event EventHandler RecordingStarted;
+        public event EventHandler<MediaCapture> RecordingStarted;
         public event EventHandler RecordingStopped;
         public event EventHandler RecordingLocked;
 
         public event EventHandler<float> QuantumProcessed;
-
-        public bool IsViewOnce
-        {
-            get => _recorder.IsViewOnce;
-            set => _recorder.IsViewOnce = value;
-        }
-
-        public partial class Recorder
-        {
-            public event EventHandler RecordingFailed;
-            public event EventHandler RecordingStarting;
-            public event EventHandler RecordingStarted;
-            public event EventHandler RecordingStopped;
-            public event EventHandler RecordingTooShort;
-
-            public Action<float> QuantumProcessed;
-
-            [ThreadStatic]
-            private static Recorder _current;
-            public static Recorder Current => _current ??= new Recorder();
-
-            private readonly ConcurrentQueueWorker _recordQueue;
-            private readonly DispatcherQueue _dispatcherQueue;
-
-            private OpusRecorder _recorder;
-            private StorageFile _file;
-            private ChatRecordMode _mode;
-            private Chat _chat;
-
-            private MediaFrameReader _reader;
-
-            private readonly AudioWaveform _waveform = new();
-
-            // Set only when the capture format can be encoded as it arrives. Otherwise the
-            // recording goes through MediaCapture's own encoder and is transcoded when sent.
-            private VoiceSink _sink;
-
-            private float[] _samples;
-            private uint _channels;
-            private uint _bitsPerSample;
-
-            private bool _paused;
-
-            public Recorder()
-            {
-                _recordQueue = new ConcurrentQueueWorker(1);
-                _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
-            }
-
-            public static void Release()
-            {
-                _current = null;
-            }
-
-            public bool IsViewOnce { get; set; }
-
-            public async void Start(ChatRecordMode mode, Chat chat)
-            {
-                Logger.Debug("Start invoked, mode: " + mode);
-
-                await _recordQueue.Enqueue(async () =>
-                {
-                    Logger.Debug("Enqueued start invoked");
-
-                    if (_recorder != null)
-                    {
-                        Logger.Debug("_recorder != null, abort");
-
-                        RecordingFailed?.Invoke(this, EventArgs.Empty);
-                        return;
-                    }
-
-                    RecordingStarting?.Invoke(this, EventArgs.Empty);
-
-                    try
-                    {
-                        _mode = mode;
-                        _chat = chat;
-                        _paused = false;
-                        _channels = 0;
-                        _bitsPerSample = 0;
-                        _waveform.Reset();
-
-                        _recorder = new OpusRecorder(mode == ChatRecordMode.Video);
-
-                        _recorder.m_mediaCapture = new MediaCapture();
-                        _recorder.m_mediaCapture.Failed += OnFailed;
-
-                        if (mode == ChatRecordMode.Video)
-                        {
-                            var cameraDevice = await _recorder.FindCameraDeviceByPanelAsync(Windows.Devices.Enumeration.Panel.Front);
-                            if (cameraDevice != null)
-                            {
-                                // Figure out where the camera is located
-                                if (cameraDevice.EnclosureLocation == null || cameraDevice.EnclosureLocation.Panel == Windows.Devices.Enumeration.Panel.Unknown)
-                                {
-                                    // No information on the location of the camera, assume it's an external camera, not integrated on the device
-                                    _recorder._externalCamera = true;
-                                }
-                                else
-                                {
-                                    // Camera is fixed on the device
-                                    _recorder._externalCamera = false;
-
-                                    // Only mirror the preview if the camera is on the front panel
-                                    _recorder._mirroringPreview = cameraDevice.EnclosureLocation.Panel == Windows.Devices.Enumeration.Panel.Front;
-                                }
-
-                                _recorder.settings.VideoDeviceId = cameraDevice.Id;
-                            }
-                        }
-
-                        await _recorder.m_mediaCapture.InitializeAsync(_recorder.settings);
-                        RecordingStarted?.Invoke(this, EventArgs.Empty);
-
-                        Logger.Debug("Devices initialized, starting");
-
-                        // For a voice message the reader is the recording, so it always runs. A
-                        // video message animates the same blob and keeps the gate it had.
-                        var reader = mode == ChatRecordMode.Voice
-                            || (PowerSavingPolicy.AreMaterialsEnabled && ApiInfo.CanAnimatePaths);
-
-                        var streaming = reader && await PrepareReaderAsync(mode);
-
-                        _file = await CreateFileAsync(mode, streaming);
-
-                        if (streaming)
-                        {
-                            _sink = new VoiceSink(_file.Path);
-
-                            if (!_sink.IsValid)
-                            {
-                                throw new InvalidOperationException("Opus encoder couldn't open " + _file.Path);
-                            }
-                        }
-                        else
-                        {
-                            Logger.Info("Recording through MediaCapture, the file will be transcoded when sent");
-                            await _recorder.StartAsync(_file);
-                        }
-
-                        // Started last, so that no sample arrives before there is something to
-                        // write it to.
-                        await StartReaderAsync();
-
-                        Logger.Debug("Recording started at " + DateTime.Now);
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.Debug("Failed to initialize devices, abort: " + ex);
-
-                        if (_reader != null)
-                        {
-                            _reader.FrameArrived -= OnAudioFrameArrived;
-
-                            _reader.Dispose();
-                            _reader = null;
-                        }
-
-                        _sink?.Dispose();
-                        _sink = null;
-
-                        _recorder?.Dispose();
-                        _recorder = null;
-
-                        _file = null;
-
-                        RecordingFailed?.Invoke(this, EventArgs.Empty);
-                    }
-                });
-            }
-
-            private void OnFailed(MediaCapture sender, MediaCaptureFailedEventArgs errorEventArgs)
-            {
-                Logger.Debug(errorEventArgs.Message);
-            }
-
-            private static Task<StorageFile> CreateFileAsync(ChatRecordMode mode, bool streaming)
-            {
-                var fileName = string.Format(mode == ChatRecordMode.Video
-                    ? "video_{0:yyyy}-{0:MM}-{0:dd}_{0:HH}-{0:mm}-{0:ss}.mp4"
-                    : streaming
-                    ? "voice_{0:yyyy}-{0:MM}-{0:dd}_{0:HH}-{0:mm}-{0:ss}.oga"
-                    : "voice_{0:yyyy}-{0:MM}-{0:dd}_{0:HH}-{0:mm}-{0:ss}.wav", DateTime.Now);
-
-                // Unique rather than fail: the name is only second-accurate, and two recordings
-                // within the same second is a tap away.
-                return ApplicationData.Current.TemporaryFolder.CreateFileAsync(fileName, CreationCollisionOption.GenerateUniqueName).AsTask();
-            }
-
-            /// <summary>
-            /// Creates the audio frame reader, and reports whether its samples can be handed to
-            /// the encoder as they are.
-            /// </summary>
-            private async Task<bool> PrepareReaderAsync(ChatRecordMode mode)
-            {
-                try
-                {
-                    var frameSource = _recorder.m_mediaCapture.FrameSources.FirstOrDefault(x => x.Value.Info.MediaStreamType == MediaStreamType.Audio);
-                    if (frameSource.Value == null)
-                    {
-                        Logger.Info("No audio frame source was found.");
-                        return false;
-                    }
-
-                    var source = frameSource.Value;
-                    var format = source.CurrentFormat;
-
-                    // The encoder is 48kHz: at any other rate the samples would play back at the
-                    // wrong speed, so ask for one and give up on streaming if there isn't one.
-                    //
-                    // Only ever for a voice message. A video message records through MediaCapture,
-                    // and renegotiating the format of the source it is about to record from would
-                    // change what lands in the mp4 for the sake of a blob.
-                    if (mode == ChatRecordMode.Voice && format.AudioEncodingProperties?.SampleRate != VoiceSink.SampleRate)
-                    {
-                        var match = source.SupportedFormats.FirstOrDefault(x => x.AudioEncodingProperties?.SampleRate == VoiceSink.SampleRate && IsSupportedSubtype(x.Subtype));
-                        if (match != null)
-                        {
-                            await source.SetFormatAsync(match);
-                            format = source.CurrentFormat;
-                        }
-                    }
-
-                    var reader = await _recorder.m_mediaCapture.CreateFrameReaderAsync(source);
-
-                    // Buffered rather than Realtime: a dropped frame used to cost a blob update,
-                    // it now costs a gap in the recording.
-                    reader.AcquisitionMode = MediaFrameReaderAcquisitionMode.Buffered;
-                    reader.FrameArrived += OnAudioFrameArrived;
-
-                    _reader = reader;
-
-                    var properties = format.AudioEncodingProperties;
-                    if (properties == null)
-                    {
-                        return false;
-                    }
-
-                    _channels = properties.ChannelCount;
-                    _bitsPerSample = properties.BitsPerSample;
-
-                    return mode == ChatRecordMode.Voice
-                        && properties.SampleRate == VoiceSink.SampleRate
-                        && IsSupportedSubtype(format.Subtype)
-                        && (_bitsPerSample == 32 || _bitsPerSample == 16)
-                        && _channels > 0;
-                }
-                catch (Exception ex)
-                {
-                    Logger.Info("The audio frame reader couldn't be created: " + ex);
-                    return false;
-                }
-            }
-
-            private async Task StartReaderAsync()
-            {
-                if (_reader == null)
-                {
-                    return;
-                }
-
-                try
-                {
-                    var status = await _reader.StartAsync();
-                    if (status != MediaFrameReaderStartStatus.Success)
-                    {
-                        Logger.Info("The MediaFrameReader couldn't start.");
-                    }
-                }
-                catch
-                {
-                    // A task was canceled.
-                }
-            }
-
-            private static bool IsSupportedSubtype(string subtype)
-            {
-                // 32-bit float and 16-bit PCM are the two the sink knows how to read.
-                return string.Equals(subtype, MediaEncodingSubtypes.Float, StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(subtype, MediaEncodingSubtypes.Pcm, StringComparison.OrdinalIgnoreCase);
-            }
-
-            private unsafe void OnAudioFrameArrived(MediaFrameReader sender, MediaFrameArrivedEventArgs args)
-            {
-                using var reference = sender.TryAcquireLatestFrame();
-                if (reference?.SourceKind != MediaFrameSourceKind.Audio || _paused)
-                {
-                    return;
-                }
-
-                // The reader can be running with a format we never managed to read, in which case
-                // there is nothing to say about how to interpret its bytes.
-                if (_channels == 0 || _bitsPerSample == 0)
-                {
-                    return;
-                }
-
-                using var frame = reference.AudioMediaFrame.GetAudioFrame();
-
-                using var audioBuffer = frame.LockBuffer(AudioBufferAccessMode.Read);
-                using var bufferReference = audioBuffer.CreateReference();
-
-                // Get the buffer from the AudioFrame
-                bufferReference.Buffer(out byte* buffer, out uint capacity);
-
-                var samples = ReadSamples(buffer, Math.Min(audioBuffer.Length, capacity));
-
-                // Every frame is folded in, and only the notification is rate-limited: this
-                // callback is the recording now, so it can't afford to skip one.
-                if (_waveform.Add(samples))
-                {
-                    QuantumProcessed?.Invoke(_waveform.Level);
-                }
-
-                _sink?.Write(samples);
-            }
-
-            /// <summary>
-            /// Presents the captured buffer as mono 32-bit float, which is what both the waveform
-            /// and the encoder read.
-            /// </summary>
-            private unsafe ReadOnlySpan<float> ReadSamples(byte* buffer, uint length)
-            {
-                var channels = (int)_channels;
-                var count = (int)(length / (_bitsPerSample / 8 * _channels));
-
-                // Mono float is the common case and needs no conversion at all.
-                if (_bitsPerSample == 32 && channels == 1)
-                {
-                    return new ReadOnlySpan<float>(buffer, count);
-                }
-
-                if (_samples == null || _samples.Length < count)
-                {
-                    _samples = new float[count];
-                }
-
-                var target = _samples.AsSpan(0, count);
-
-                if (_bitsPerSample == 32)
-                {
-                    var source = (float*)buffer;
-
-                    for (int i = 0; i < count; i++)
-                    {
-                        var sum = 0f;
-                        for (int j = 0; j < channels; j++)
-                        {
-                            sum += source[i * channels + j];
-                        }
-
-                        target[i] = sum / channels;
-                    }
-                }
-                else
-                {
-                    var source = (short*)buffer;
-
-                    for (int i = 0; i < count; i++)
-                    {
-                        var sum = 0f;
-                        for (int j = 0; j < channels; j++)
-                        {
-                            sum += source[i * channels + j] / 32768f;
-                        }
-
-                        target[i] = sum / channels;
-                    }
-                }
-
-                return target;
-            }
-
-            public byte[] GetWaveform()
-            {
-                return _waveform.GetWaveform();
-            }
-
-            public async Task<ChatRecordResult> PauseAsync()
-            {
-                Logger.Debug("Pause invoked");
-
-                var tsc = new TaskCompletionSource<ChatRecordResult>();
-
-                _ = _recordQueue.Enqueue(async () =>
-                {
-                    Logger.Debug("Enqueued pause invoked");
-
-                    var recorder = _recorder;
-                    if (recorder == null)
-                    {
-                        Logger.Debug("recorder or file == null, abort");
-
-                        // Setting it is what releases the caller: it awaits this task.
-                        tsc.SetResult(null);
-                        return;
-                    }
-
-                    if (_sink != null)
-                    {
-                        // Nothing to pause: the frames keep arriving and are dropped, which keeps
-                        // the device warm and resuming instant.
-                        _paused = !_paused;
-
-                        tsc.SetResult(_paused
-                            ? new ChatRecordResult(_sink.Duration, GetWaveform())
-                            : null);
-                        return;
-                    }
-
-                    var paused = await recorder.PauseAsync();
-                    if (paused != null)
-                    {
-                        tsc.SetResult(new ChatRecordResult(paused.RecordDuration, GetWaveform()));
-
-                        if (_reader != null)
-                        {
-                            try
-                            {
-                                await _reader.StopAsync();
-                            }
-                            catch
-                            {
-                                // A task was canceled.
-                            }
-                        }
-                    }
-                    else
-                    {
-                        tsc.SetResult(null);
-
-                        if (_reader != null)
-                        {
-                            try
-                            {
-                                await _reader.StartAsync();
-                            }
-                            catch
-                            {
-                                // A task was canceled.
-                            }
-                        }
-                    }
-                });
-
-                return await tsc.Task;
-            }
-
-            public async void Stop(ComposeViewModel viewModel, bool? cancel)
-            {
-                Logger.Debug("Stop invoked, cancel: " + cancel);
-
-                await _recordQueue.Enqueue(async () =>
-                {
-                    Logger.Debug("Enqueued stop invoked");
-
-                    var recorder = _recorder;
-                    var file = _file;
-                    var mode = _mode;
-                    var chat = _chat;
-
-                    var reader = _reader;
-
-                    if (recorder == null || file == null || chat == null)
-                    {
-                        Logger.Debug("recorder or file == null, abort");
-                        return;
-                    }
-
-                    if (recorder.m_mediaCapture != null)
-                    {
-                        recorder.m_mediaCapture.Failed -= OnFailed;
-                    }
-
-                    RecordingStopped?.Invoke(this, EventArgs.Empty);
-
-                    Logger.Debug("stopping reader");
-
-                    if (reader != null)
-                    {
-                        try
-                        {
-                            await reader.StopAsync();
-                        }
-                        catch
-                        {
-                            // A task was canceled.
-                        }
-
-                        reader.FrameArrived -= OnAudioFrameArrived;
-                        reader.Dispose();
-
-                        QuantumProcessed?.Invoke(0);
-                    }
-
-                    var sink = _sink;
-                    var waveform = Array.Empty<byte>();
-
-                    TimeSpan duration;
-
-                    if (sink != null)
-                    {
-                        sink.Complete();
-
-                        // Counted from the samples that were actually encoded, so it matches the
-                        // file rather than the moment the user pressed the button.
-                        duration = sink.Duration;
-                        waveform = GetWaveform();
-
-                        sink.Dispose();
-
-                        await recorder.StopAsync();
-                    }
-                    else
-                    {
-                        var result = await recorder.StopAsync();
-                        duration = result?.RecordDuration ?? TimeSpan.Zero;
-
-                        if (mode == ChatRecordMode.Voice)
-                        {
-                            waveform = GetWaveform();
-                        }
-                    }
-
-                    Logger.Debug("recorder stopped, duration: " + duration);
-
-                    if (cancel == true || duration.TotalMilliseconds < 700)
-                    {
-                        try
-                        {
-                            await file.DeleteAsync();
-                        }
-                        catch { }
-
-                        Logger.Debug("recording canceled or too short, abort");
-
-                        if (duration.TotalMilliseconds < 700)
-                        {
-                            RecordingTooShort?.Invoke(this, EventArgs.Empty);
-                        }
-                    }
-                    else
-                    {
-                        Logger.Debug("sending recorded file");
-
-                        if (cancel == false)
-                        {
-                            Send(viewModel, mode, chat, file, recorder._mirroringPreview, duration, waveform, sink != null);
-                        }
-                    }
-
-                    _recorder = null;
-                    _file = null;
-
-                    _reader = null;
-                    _sink = null;
-                });
-            }
-
-            private async void Send(ComposeViewModel viewModel, ChatRecordMode mode, Chat chat, StorageFile file, bool mirroring, TimeSpan duration, byte[] waveform, bool encoded)
-            {
-                var selfDestructType = IsViewOnce
-                        ? new MessageSelfDestructTypeImmediately()
-                        : null;
-
-                IsViewOnce = false;
-
-                if (mode == ChatRecordMode.Video)
-                {
-                    var props = await file.Properties.GetVideoPropertiesAsync();
-                    var width = props.GetWidth();
-                    var height = props.GetHeight();
-                    var x = 0d;
-                    var y = 0d;
-
-                    if (width > height)
-                    {
-                        x = (width - height) / 2;
-                        width = height;
-                    }
-                    else if (height > width)
-                    {
-                        y = (height - width) / 2;
-                        height = width;
-                    }
-
-                    var length = viewModel.ClientService.Options.SuggestedVideoNoteLength;
-                    var videoBitrate = viewModel.ClientService.Options.SuggestedVideoNoteVideoBitrate;
-                    var audioBitrate = viewModel.ClientService.Options.SuggestedVideoNoteAudioBitrate;
-
-                    var video = await StorageMedia.CreateAsync(file);
-                    var generation = new VideoGeneration
-                    {
-                        Transcode = true,
-                        Transform = true,
-                        CropRectangle = new Rect(x, y, width, height),
-                        OutputSize = new Size(length, length),
-                        Flip = mirroring ? ImageFlip.Horizontal : ImageFlip.None,
-                        Width = (uint)length,
-                        Height = (uint)length,
-                        VideoBitrate = (uint)videoBitrate * 1000,
-                        AudioBitrate = (uint)audioBitrate * 1000
-                    };
-
-                    try
-                    {
-                        _dispatcherQueue.TryEnqueue(() => _ = viewModel.SendVideoNoteAsync(video as StorageVideo, generation, selfDestructType));
-                    }
-                    catch { }
-                }
-                else
-                {
-                    // Already Ogg/Opus when the sink wrote it, so there is nothing to convert.
-                    var conversion = encoded
-                        ? ConversionType.Copy
-                        : ConversionType.Opus;
-
-                    try
-                    {
-                        _dispatcherQueue.TryEnqueue(() => _ = viewModel.SendVoiceNoteAsync(file, conversion, duration, waveform, null, selfDestructType));
-                    }
-                    catch { }
-                }
-            }
-
-            public MediaCapture MediaSource => _recorder.m_mediaCapture;
-
-            internal sealed class OpusRecorder
-            {
-                private readonly bool m_isVideo;
-
-                private LowLagMediaRecording m_lowLag;
-                private bool m_paused;
-
-                public MediaCapture m_mediaCapture;
-                public MediaCaptureInitializationSettings settings;
-
-                // Information about the camera device
-                public bool _mirroringPreview;
-                public bool _externalCamera;
-
-                //// Rotation Helper to simplify handling rotation compensation for the camera streams
-                //public CameraRotationHelper _rotationHelper;
-
-                public OpusRecorder(bool video)
-                {
-                    m_isVideo = video;
-                    InitializeSettings();
-                }
-
-                private void InitializeSettings()
-                {
-                    // We're forcing CPU because "Auto" seems to be failing on some devices.
-                    settings = new MediaCaptureInitializationSettings();
-                    settings.MediaCategory = MediaCategory.Media;
-                    settings.AudioProcessing = m_isVideo ? AudioProcessing.Default : SettingsService.Current.Diagnostics.ForceRawAudio ? AudioProcessing.Raw : AudioProcessing.Default;
-                    settings.MemoryPreference = MediaCaptureMemoryPreference.Cpu;
-                    settings.SharingMode = MediaCaptureSharingMode.SharedReadOnly;
-                    settings.StreamingCaptureMode = m_isVideo ? StreamingCaptureMode.AudioAndVideo : StreamingCaptureMode.Audio;
-                }
-
-                public async Task<DeviceInformation> FindCameraDeviceByPanelAsync(Windows.Devices.Enumeration.Panel desiredPanel)
-                {
-                    // Get available devices for capturing pictures
-                    var allVideoDevices = await DeviceInformation.FindAllAsync(DeviceClass.VideoCapture);
-
-                    // Get the desired camera by panel
-                    DeviceInformation desiredDevice = allVideoDevices.FirstOrDefault(x => x.EnclosureLocation != null && x.EnclosureLocation.Panel == desiredPanel);
-
-                    // If there is no device mounted on the desired panel, return the first device found
-                    return desiredDevice ?? allVideoDevices.FirstOrDefault();
-                }
-
-                public async Task StartAsync(StorageFile file)
-                {
-                    MediaEncodingProfile profile;
-                    if (m_isVideo)
-                    {
-                        profile = MediaEncodingProfile.CreateMp4(VideoEncodingQuality.Auto);
-                    }
-                    else
-                    {
-                        profile = MediaEncodingProfile.CreateWav(AudioEncodingQuality.High);
-                        profile.Audio.BitsPerSample = 16;
-                        profile.Audio.SampleRate = 48000;
-                        profile.Audio.ChannelCount = 1;
-                    }
-
-                    m_lowLag = await m_mediaCapture.PrepareLowLagRecordToStorageFileAsync(profile, file);
-                    await m_lowLag.StartAsync();
-                }
-
-                public async Task<MediaCapturePauseResult> PauseAsync()
-                {
-                    try
-                    {
-                        if (m_paused)
-                        {
-                            m_paused = false;
-                            await m_lowLag.ResumeAsync();
-                            return null;
-                        }
-                        else
-                        {
-                            m_paused = true;
-                            return await m_lowLag.PauseWithResultAsync(MediaCapturePauseBehavior.RetainHardwareResources);
-                        }
-                    }
-                    catch
-                    {
-                        return null;
-                    }
-                }
-
-                public async Task<MediaCaptureStopResult> StopAsync()
-                {
-                    MediaCaptureStopResult result = null;
-                    try
-                    {
-                        // Null when the sink did the recording: there is only the device to close.
-                        if (m_lowLag != null)
-                        {
-                            result = await m_lowLag.StopWithResultAsync();
-                            await m_lowLag.FinishAsync();
-                        }
-                    }
-                    catch { }
-                    finally
-                    {
-                        m_mediaCapture?.Dispose();
-                        m_mediaCapture = null;
-                    }
-                    return result;
-                }
-
-                public void Dispose()
-                {
-                    try
-                    {
-                        m_lowLag = null;
-
-                        m_mediaCapture.Dispose();
-                        m_mediaCapture = null;
-                    }
-                    catch { }
-                }
-            }
-        }
     }
 }

--- a/Telegram/Navigation/WindowContext.cs
+++ b/Telegram/Navigation/WindowContext.cs
@@ -338,7 +338,6 @@ namespace Telegram.Navigation
             PlaceholderHelper.Release();
             AnimatedImageLoader.Release();
             ProfilePicture.Loader.Release();
-            ChatRecordButton.Recorder.Release();
 
             // TODO: needed? From some tests, this prevented the whole Window root from being garbage collected
             if (SynchronizationContext.Current is SecondaryViewSynchronizationContextDecorator decorator)

--- a/Telegram/Telegram.csproj
+++ b/Telegram/Telegram.csproj
@@ -213,6 +213,8 @@
     <Compile Include="Common\PageBlockHelper.cs" />
     <Compile Include="Common\Profiler.cs" />
     <Compile Include="Common\Recording\AudioWaveform.cs" />
+    <Compile Include="Common\Recording\ChatRecordEngine.cs" />
+    <Compile Include="Common\Recording\ChatRecordSession.cs" />
     <Compile Include="Common\Recording\VoiceSink.cs" />
     <Compile Include="Common\RichHtml.cs" />
     <Compile Include="Common\SliderHelper.cs" />

--- a/Telegram/Views/ChatView.xaml.cs
+++ b/Telegram/Views/ChatView.xaml.cs
@@ -1464,7 +1464,7 @@ namespace Telegram.Views
             }
             else if (args.Key == VirtualKey.D && /*args.RepeatCount == 1 &&*/ modifiers == VirtualKeyModifiers.Control)
             {
-                btnVoiceMessage.StopRecording(true);
+                btnVoiceMessage.Cancel();
                 args.Handled = true;
             }
             else if (args.Key == VirtualKey.P && /*args.RepeatCount == 1 &&*/ modifiers == VirtualKeyModifiers.Control)

--- a/chat-record-rewrite.md
+++ b/chat-record-rewrite.md
@@ -222,18 +222,42 @@ Two knock-on moves:
 
 ---
 
-## Task 1 — Extract the state machine, no behaviour change
+## Task 1 — Extract the state machine, no behaviour change — **done, unbuilt**
 
-- [ ] **1.1** Move the flag soup and `UpdateRecordingInterface` into `ChatRecordSession` with an
+- [x] **1.1** Move the flag soup and `UpdateRecordingInterface` into `ChatRecordSession` with an
   explicit enum state and one transition method. Keep the existing engine (`Recorder`) behind it
   verbatim so the diff is mechanical and testable against the current behaviour.
-- [ ] **1.2** One session per host, created by ChatView/StoriesWindow and passed to both the button
-  and the bar. Drop `[ThreadStatic] Recorder.Current` and `Recorder.Release()`
-  (`Navigation/WindowContext.cs:297`).
-- [ ] **1.3** Pair every `+=` in `SetControlledButton` with a `-=`, and replace the `_timer.Tick`
+- [x] **1.2** ~~One session per host, created by ChatView/StoriesWindow and passed to both the
+  button and the bar.~~ The button owns one and exposes it — a button is already one per host, and
+  this way no XAML or host code changes. Dropped `[ThreadStatic] Recorder.Current` and
+  `Recorder.Release()` (`Navigation/WindowContext.cs:297`).
+- [x] **1.3** Pair every `+=` in `SetControlledButton` with a `-=`, and replace the `_timer.Tick`
   lambda with a named method.
-- [ ] **1.4** Delete `StopRecording(bool)`'s null-`cancel` path: `Cancel()` and `Complete()` as two
+- [x] **1.4** Delete `StopRecording(bool)`'s null-`cancel` path: `Cancel()` and `Complete()` as two
   methods, no tri-state.
+
+**How it landed.** `Telegram/Common/Recording/` gains `ChatRecordEngine` (the old nested
+`Recorder`, moved out whole and no longer thread-static) and `ChatRecordSession`, which owns the
+state, the clock and the engine. `ChatRecordButton` is down from 1355 lines to ~440 and holds the
+gesture and its own visuals; `ChatRecordBar` is unchanged apart from the renamed calls and the
+detach.
+
+`ChatRecordState` has three values, not four. The old interface state 3 — locked, then stopped —
+was only reachable through `StopRecording(false)`, which no caller ever passed. It went out with
+the tri-state rather than being carried over.
+
+**What the extraction fixed, beyond shape.**
+
+- Two chats no longer share one recording. The engine was `[ThreadStatic]`, and every loaded button
+  on the thread subscribed to it: a recording in a chat drove the state of the story composer too,
+  `QuantumProcessed` was a single field so whichever loaded last owned the level meter, and the
+  first to unload set it to null for the other.
+- `Elapsed` is off `Environment.TickCount64` rather than `DateTime.Now`, so a clock change during a
+  recording no longer moves it, and it stops while paused. It restarts when the device is actually
+  open, so it no longer counts the few hundred ms of `InitializeAsync` — the residue between it and
+  the sent duration is now the gap between the device opening and the first frame.
+- The pause state is reset when a recording ends, so it can't leak into the next one.
+- `ChatRecordBar` detaches from the button on unload.
 
 ## Task 2 — Voice: encode straight to Opus, no WAV — **done, unbuilt**
 
@@ -287,16 +311,24 @@ read-and-reasoned only. The two things most worth watching on first run: whether
 acquisition really delivers every frame through `TryAcquireLatestFrame`, and which path the log
 says it took.
 
-## Task 3 — Permissions and start-up
+## Task 3 — Permissions and start-up — **3.2 still open**
 
-- [ ] **3.1** Replace `CheckAccessAsync`/`CheckDeviceAccessAsync` (:534–613) with
+- [x] **3.1** Replace `CheckAccessAsync`/`CheckDeviceAccessAsync` (:534–613) with
   `MediaDevicePermissions.CheckAccessAsync`, so the first press after granting actually records.
-  Keep the Xbox special case if it's still needed — verify.
+  Keep the Xbox special case if it's still needed — verify. *Kept, and still unverified: the note
+  it came from was about `DeviceAccessInformation`, not `AppCapability`, so it may well be dead
+  weight. Cheaper to keep than to be wrong about, and it is three lines with a comment saying so.*
+  `MediaDevicePermissions` grew a `MediaDevicePurpose`, so the denial keeps the recording wording
+  (`PermissionNoAudio`) instead of borrowing the call one.
 - [ ] **3.2** Start the engine on press and discard on an early release, instead of waiting 300 ms
   to learn whether it was a hold. The mode-switch tap then cancels a session that already began
   warming the device, and the felt latency drops by the whole timer plus init.
-- [ ] **3.3** `MediaCapture.Failed` must fail the session and reset the UI (:843), not just log.
-- [ ] **3.4** Give `RecordingTooShort` a consumer — a toast, matching the Android/desktop wording.
+- [x] **3.3** `MediaCapture.Failed` must fail the session and reset the UI (:843), not just log.
+  It now cancels the recording and raises `RecordingFailed`, so unplugging the microphone ends the
+  recording instead of leaving the bar up forever.
+- [x] **3.4** Give `RecordingTooShort` a consumer — a toast, matching the Android/desktop wording.
+  *No new string: it shows `HoldToAudio`/`HoldToVideo`, the same hint the mode-switch tap shows,
+  which is what Android says when a press is too short to be a recording.*
 
 ## Task 4 — Video
 
@@ -320,7 +352,8 @@ says it took.
 - [ ] **5.1** Decide the sharing mode. `MediaCaptureSharingMode.SharedReadOnly` (:1267) forbids
   both `SetFormatAsync` on the audio frame source (Task 2.1) and stream properties on the camera
   (Task 4.1). Exclusive mode buys both and costs failing when another app holds the device.
-- [ ] **5.2** Reset the pause state on stop (:401) and stop `Elapsed` advancing while paused.
+- [x] **5.2** Reset the pause state on stop (:401) and stop `Elapsed` advancing while paused.
+  Both belong to `ChatRecordSession` now.
 - [ ] **5.3** The lock/pause/view-once visuals are ~250 lines of hand-built keyframe pairs that
   duplicate each other forward and backward (`Pause_Click`, both branches). Fold into one
   parameterised helper.


### PR DESCRIPTION
Task 1 of `chat-record-rewrite.md`, plus the parts of Task 3 it unblocks.

**Stacked on #3363** — base is `voice-record-opus`, so this diff is only the new commit.
Merge that one first.

## What was happening

`ChatRecordButton` held four things: the press-and-hold gesture, the state of the recording,
the capture engine, and the decision of what to do with the result. The engine was
`[ThreadStatic]` and every loaded button subscribed to it, so:

- a recording started in one chat set `_recordingAudioVideo` on the story composer too;
- `QuantumProcessed` was a single `Action` field, so whichever button loaded last took the
  level meter over, and the first to unload set it to null for the other;
- `IsViewOnce` was shared global state.

## What changed

`ChatRecordSession` owns the state and the engine, one per button — which is one per chat.
`ChatRecordEngine` is the old nested `Recorder`, moved out whole. The button is down from
1355 lines to ~440 and keeps the gesture and its own visuals; `ChatRecordBar` only changes
where it calls and how it detaches.

Seven booleans and an integer interface state become three named states. The fourth —
locked, then stopped — was reachable only through `StopRecording(false)`, which nothing ever
called, so it went out with the tri-state stop that neither sent nor discarded (and would
have thrown on the null `viewModel` if it had). `Cancel()` and `Complete()` say which they
are.

Also fixed, all of them one-liners once the state had somewhere to live:

- `Elapsed` is off `Environment.TickCount64` instead of `DateTime.Now`, freezes while paused,
  and restarts when the device is actually open rather than when the button was pressed — so
  the label no longer counts the few hundred ms of `InitializeAsync`.
- The pause state is reset when a recording ends instead of leaking into the next one.
- `ChatRecordBar` detaches from the button on unload; the two timer lambdas became named
  methods.
- **Permissions** go through `MediaDevicePermissions`, which is what calls already use. The
  old check asked `DeviceAccessInformation` and then `return false` regardless, so the first
  press after granting access only ever primed the prompt. `MediaDevicePermissions` grew a
  `MediaDevicePurpose` so the denial keeps the recording wording rather than borrowing the
  call one.
- **`MediaCapture.Failed`** ends the recording instead of only logging, so unplugging the mic
  no longer leaves the bar up forever.
- **`RecordingTooShort`** finally has a consumer. No new string: it shows
  `HoldToAudio`/`HoldToVideo`, the same hint the mode-switch tap shows, which is what Android
  says when a press is too short to be a recording.

## Deviations from the plan, and what I left

- The plan said the hosts create the session and pass it to both controls. The button owns it
  and exposes `Session` instead — a button is already one per host, and this way no XAML and
  no host code changes. The full "button raises intents, bar renders state" split can come
  when the bar is reworked.
- Task 3.2 (start the engine on press instead of waiting out the 300 ms mode-switch timer) is
  **not** in here. It changes how the gesture feels and wants tuning on a real device.
- The Xbox bypass in the permission check is kept and still unverified — the note it came from
  was about `DeviceAccessInformation`, not `AppCapability`, so it may be dead weight. It is
  three lines with a comment saying exactly that.
- Session and engine each have their own `_paused`: one gates the clock, the other gates the
  frames. They agree because they toggle together, which is a thing to collapse rather than
  rely on.

## Verification

Read-and-reasoned plus a Roslyn parse check; I don't build this project. Every member the bar
and both hosts use on the button was enumerated and checked against the new surface, and
`FrameworkElement.IsLoaded` was confirmed against `Windows.winmd` rather than assumed.

Worth exercising: lock and send, lock and cancel, slide to cancel, tap to switch mode, Ctrl+R,
pause and resume, and a story composer open at the same time as a chat — that last one is what
the thread-static engine used to break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
