### PR TITLE
Expose TDLib object vectors as List<T>

### DIFF
--- a/Telegram.Generators/Emit/ApiEmitter.cs
+++ b/Telegram.Generators/Emit/ApiEmitter.cs
@@ -60,11 +60,11 @@ namespace Telegram.Generators.Emit
                 // from the wire without every consumer having to null-check.
                 if (prop.Type == "string" && !prop.IsVector)
                 {
-                    builder.AppendLine("    public " + Naming.PropertyType(prop) + " " + fieldName + " { get; set; } = string.Empty;");
+                    builder.AppendLine("    public " + Naming.PropertyType(prop, type.IsFunction) + " " + fieldName + " { get; set; } = string.Empty;");
                 }
                 else
                 {
-                    builder.AppendLine("    public " + Naming.PropertyType(prop) + " " + fieldName + " { get; set; }");
+                    builder.AppendLine("    public " + Naming.PropertyType(prop, type.IsFunction) + " " + fieldName + " { get; set; }");
                 }
             }
 
@@ -127,7 +127,7 @@ namespace Telegram.Generators.Emit
                 }
 
                 var property = type.Properties[i];
-                builder.Append(Naming.PropertyType(property) + " " + Naming.ParameterName(property));
+                builder.Append(Naming.ParameterType(property) + " " + Naming.ParameterName(property));
             }
 
             builder.AppendLine(")");
@@ -135,7 +135,16 @@ namespace Telegram.Generators.Emit
 
             foreach (var property in type.Properties)
             {
-                builder.AppendLine("        " + Naming.PropertyName(property, className) + " = " + Naming.ParameterName(property) + ";");
+                var value = Naming.ParameterName(property);
+
+                if (property.IsVector && !type.IsFunction)
+                {
+                    // Parameter is the interface, field is the List. Free for a parsed response,
+                    // which arrives as a List already; a copy only for the arrays app code passes.
+                    value = "TdCollection.AsList(" + value + ")";
+                }
+
+                builder.AppendLine("        " + Naming.PropertyName(property, className) + " = " + value + ";");
             }
 
             builder.AppendLine("    }");

--- a/Telegram.Generators/Emit/ApiEmitter.cs
+++ b/Telegram.Generators/Emit/ApiEmitter.cs
@@ -127,7 +127,7 @@ namespace Telegram.Generators.Emit
                 }
 
                 var property = type.Properties[i];
-                builder.Append(Naming.ParameterType(property) + " " + Naming.ParameterName(property));
+                builder.Append(Naming.ParameterType(property, type.IsFunction) + " " + Naming.ParameterName(property));
             }
 
             builder.AppendLine(")");
@@ -135,16 +135,7 @@ namespace Telegram.Generators.Emit
 
             foreach (var property in type.Properties)
             {
-                var value = Naming.ParameterName(property);
-
-                if (property.IsVector && !type.IsFunction)
-                {
-                    // Parameter is the interface, field is the List. Free for a parsed response,
-                    // which arrives as a List already; a copy only for the arrays app code passes.
-                    value = "TdCollection.AsList(" + value + ")";
-                }
-
-                builder.AppendLine("        " + Naming.PropertyName(property, className) + " = " + value + ";");
+                builder.AppendLine("        " + Naming.PropertyName(property, className) + " = " + Naming.ParameterName(property) + ";");
             }
 
             builder.AppendLine("    }");

--- a/Telegram.Generators/Schema/Naming.cs
+++ b/Telegram.Generators/Schema/Naming.cs
@@ -97,19 +97,10 @@ namespace Telegram.Generators.Schema
             return name;
         }
 
-        /// <summary>
-        /// The constructor parameter type. Always the interface, so that `new[] { x }` and
-        /// `[x]` both still bind - the property converts, and for a parsed response that is a cast
-        /// rather than a copy, both parsers building a List already.
-        /// </summary>
-        public static string ParameterType(SchemaProperty property)
+        /// <summary>The constructor parameter type, which matches the field.</summary>
+        public static string ParameterType(SchemaProperty property, bool function)
         {
-            if (property.IsVectorOfVectors)
-            {
-                return "IList<List<" + ScalarType(property.Type) + ">>";
-            }
-
-            return PropertyType(property, true);
+            return PropertyType(property, function);
         }
 
         public static string ScalarType(string name)

--- a/Telegram.Generators/Schema/Naming.cs
+++ b/Telegram.Generators/Schema/Naming.cs
@@ -65,18 +65,26 @@ namespace Telegram.Generators.Schema
         }
 
         /// <summary>The C# type for a field, including vector nesting and nullability.</summary>
-        public static string PropertyType(SchemaProperty property)
+        /// <remarks>
+        /// A vector is a List on an object and an IList on a function. Objects are read - bound to
+        /// ItemsSource, iterated per render - and List is what makes the concrete type visible to
+        /// the analyzer, keeps foreach from boxing an enumerator, and lets the indexer inline.
+        /// Functions are only ever written and serialised, so none of that applies and IList is the
+        /// friendlier parameter type.
+        /// </remarks>
+        public static string PropertyType(SchemaProperty property, bool function = true)
         {
             var name = ScalarType(property.Type);
+            var list = function ? "IList" : "List";
 
             if (property.IsVectorOfVectors)
             {
-                return "IList<IList<" + name + ">>";
+                return list + "<" + list + "<" + name + ">>";
             }
 
             if (property.IsVector)
             {
-                return "IList<" + name + ">";
+                return list + "<" + name + ">";
             }
 
             // The schema states nullability in prose rather than in the type, so this reads it back
@@ -87,6 +95,21 @@ namespace Telegram.Generators.Schema
             }
 
             return name;
+        }
+
+        /// <summary>
+        /// The constructor parameter type. Always the interface, so that `new[] { x }` and
+        /// `[x]` both still bind - the property converts, and for a parsed response that is a cast
+        /// rather than a copy, both parsers building a List already.
+        /// </summary>
+        public static string ParameterType(SchemaProperty property)
+        {
+            if (property.IsVectorOfVectors)
+            {
+                return "IList<List<" + ScalarType(property.Type) + ">>";
+            }
+
+            return PropertyType(property, true);
         }
 
         public static string ScalarType(string name)

--- a/Telegram.Generators/SchemaGenerator.cs
+++ b/Telegram.Generators/SchemaGenerator.cs
@@ -265,6 +265,17 @@ namespace Telegram.Generators
             builder.AppendLine("namespace Telegram.Td.Api");
             builder.AppendLine("{");
 
+            // Constructors take the interface so that arrays keep binding, fields hold the List.
+            // A response is already a List and only gets cast; an array gets copied once.
+            builder.AppendLine("internal static class TdCollection");
+            builder.AppendLine("{");
+            builder.AppendLine("    public static List<T> AsList<T>(IList<T> value)");
+            builder.AppendLine("    {");
+            builder.AppendLine("        return value == null ? null : value as List<T> ?? new List<T>(value);");
+            builder.AppendLine("    }");
+            builder.AppendLine("}");
+            builder.AppendLine();
+
             foreach (var type in classes)
             {
                 ApiEmitter.WriteClass(builder, type, serializable.Contains(type));

--- a/Telegram.Generators/SchemaGenerator.cs
+++ b/Telegram.Generators/SchemaGenerator.cs
@@ -265,16 +265,6 @@ namespace Telegram.Generators
             builder.AppendLine("namespace Telegram.Td.Api");
             builder.AppendLine("{");
 
-            // Constructors take the interface so that arrays keep binding, fields hold the List.
-            // A response is already a List and only gets cast; an array gets copied once.
-            builder.AppendLine("internal static class TdCollection");
-            builder.AppendLine("{");
-            builder.AppendLine("    public static List<T> AsList<T>(IList<T> value)");
-            builder.AppendLine("    {");
-            builder.AppendLine("        return value == null ? null : value as List<T> ?? new List<T>(value);");
-            builder.AppendLine("    }");
-            builder.AppendLine("}");
-            builder.AppendLine();
 
             foreach (var type in classes)
             {

--- a/Telegram.Generators/WinRTExposedTypeAnalyzer.cs
+++ b/Telegram.Generators/WinRTExposedTypeAnalyzer.cs
@@ -219,7 +219,7 @@ namespace Telegram.Generators
                 var operation = (IArgumentOperation)context.Operation;
                 var parameter = operation.Parameter;
 
-                if (parameter == null || !IsProjected(parameter.ContainingSymbol?.ContainingType))
+                if (parameter == null || !IsBoundary(parameter.ContainingSymbol))
                 {
                     return;
                 }
@@ -322,6 +322,28 @@ namespace Telegram.Generators
                     default:
                         return Enumerable.Empty<IOperation>();
                 }
+            }
+
+            /// <summary>
+            /// Whether crossing into this member means crossing into WinRT.
+            /// </summary>
+            /// <remarks>
+            /// x:Bind does not assign the property itself: it calls a Set_ on the XamlBindingSetters
+            /// the XAML compiler emits into the page, which takes the value as object and assigns it
+            /// one frame later. That class belongs to this assembly and is projected by nothing, so
+            /// following the call is the only way to see the concrete type - and the only reason the
+            /// concrete type is there to see is that the property is declared as a List.
+            /// </remarks>
+            private bool IsBoundary(ISymbol member)
+            {
+                var declaring = member?.ContainingType;
+                if (declaring == null)
+                {
+                    return false;
+                }
+
+                return IsProjected(declaring)
+                    || (declaring.Name == "XamlBindingSetters" && member.Name.StartsWith("Set_", System.StringComparison.Ordinal));
             }
 
             private bool IsReadOnly(ITypeSymbol type)

--- a/Telegram/Common/Extensions.cs
+++ b/Telegram/Common/Extensions.cs
@@ -171,15 +171,14 @@ namespace Telegram.Common
 
         public static FormattedText AsFormattedText(this string str, bool allocate = true)
         {
-            return new FormattedText(str, allocate ? Array.Empty<TextEntity>() : null);
+            return new FormattedText(str, allocate ? [] : null);
         }
 
         public static FormattedText AsFormattedText(this string str, TextEntityType type)
         {
-            return new FormattedText(str, new[]
-            {
+            return new FormattedText(str, [
                 new TextEntity(0, str.Length, type)
-            });
+            ]);
         }
 
         public static bool TryGetValue(this CoreWebView2HttpRequestHeaders headers, string key, out string value)

--- a/Telegram/Common/MarkdownToInstantView.cs
+++ b/Telegram/Common/MarkdownToInstantView.cs
@@ -473,7 +473,7 @@ namespace Telegram.Common
 
         private static void ConvertTable(Table table, List<PageBlock> output)
         {
-            var rows = new List<IList<PageBlockTableCell>>();
+            var rows = new List<List<PageBlockTableCell>>();
             var aligns = table.ColumnDefinitions;
 
             foreach (var child in table)

--- a/Telegram/Common/MessageHelper.cs
+++ b/Telegram/Common/MessageHelper.cs
@@ -330,7 +330,7 @@ namespace Telegram.Common
             if (package.AvailableFormats.Contains(StandardDataFormats.Text))
             {
                 string text = await package.GetTextAsync();
-                IList<TextEntity> entities = null;
+                List<TextEntity> entities = null;
 
                 if (package.AvailableFormats.Contains("application/x-tl-field-tags"))
                 {
@@ -416,7 +416,7 @@ namespace Telegram.Common
                     }
                 }
 
-                return new FormattedText(text, entities ?? Array.Empty<TextEntity>());
+                return new FormattedText(text, entities ?? []);
             }
 
             return null;
@@ -1256,7 +1256,7 @@ namespace Telegram.Common
             if (response is UpgradedGift gift)
             {
                 var text = gift.OriginalDetails?.Text ?? string.Empty.AsFormattedText();
-                var receivedGift = new ReceivedGift(string.Empty, null, text, 0, true, false, false, false, false, false, 0, new SentGiftUpgraded(gift), Array.Empty<int>(), 0, 0, false, 0, 0, 0, 0, 0, string.Empty, 0);
+                var receivedGift = new ReceivedGift(string.Empty, null, text, 0, true, false, false, false, false, false, 0, new SentGiftUpgraded(gift), [], 0, 0, false, 0, 0, 0, 0, 0, string.Empty, 0);
 
                 navigation.ShowPopup(new ReceivedGiftPopup(clientService, navigation, receivedGift, null, null));
             }
@@ -2065,7 +2065,7 @@ namespace Telegram.Common
                 var message = Strings.RequestToJoinSent + Environment.NewLine + (channel ? Strings.RequestToJoinChannelSentDescription : Strings.RequestToJoinGroupSentDescription);
                 var entity = new TextEntity(0, Strings.RequestToJoinSent.Length, new TextEntityTypeBold());
 
-                var text = new FormattedText(message, new[] { entity });
+                var text = new FormattedText(message, [entity]);
 
                 ToastPopup.Show(navigation.XamlRoot, text, ToastPopupIcon.JoinRequested);
             }

--- a/Telegram/Common/PageBlockHelper.cs
+++ b/Telegram/Common/PageBlockHelper.cs
@@ -2054,7 +2054,7 @@ namespace Telegram.Common
             return true;
         }
 
-        private static bool Compare(IList<IList<PageBlockTableCell>> a, IList<IList<PageBlockTableCell>> b)
+        private static bool Compare(List<List<PageBlockTableCell>> a, List<List<PageBlockTableCell>> b)
         {
             if (a.Count != b.Count)
             {

--- a/Telegram/Common/PageBlockHelper.cs
+++ b/Telegram/Common/PageBlockHelper.cs
@@ -102,7 +102,7 @@ namespace Telegram.Common
         /// first block whose kind is included in <paramref name="kind"/>, or null
         /// if none matches.
         /// </summary>
-        public static PageBlock FindFirstMedia(IList<PageBlock> blocks, PageBlockMediaKind kind)
+        public static PageBlock FindFirstMedia(List<PageBlock> blocks, PageBlockMediaKind kind)
         {
             if (blocks == null || kind == PageBlockMediaKind.None)
             {
@@ -172,7 +172,7 @@ namespace Telegram.Common
             }
         }
 
-        private static PageBlock FindFirstMediaInList(IList<PageBlock> blocks, PageBlockMediaKind kind)
+        private static PageBlock FindFirstMediaInList(List<PageBlock> blocks, PageBlockMediaKind kind)
         {
             if (blocks == null) return null;
             foreach (var b in blocks)
@@ -192,7 +192,7 @@ namespace Telegram.Common
         /// <see cref="FindFirstMedia"/>) and returns every block whose kind is
         /// included in <paramref name="kind"/>, in document order.
         /// </summary>
-        public static List<PageBlock> FindAllMedia(IList<PageBlock> blocks, PageBlockMediaKind kind)
+        public static List<PageBlock> FindAllMedia(List<PageBlock> blocks, PageBlockMediaKind kind)
         {
             var result = new List<PageBlock>();
             FindAllMedia(blocks, kind, result);
@@ -205,7 +205,7 @@ namespace Telegram.Common
         /// traversal is recursion over the call stack with no intermediate
         /// allocations (no LINQ/iterators/closures).
         /// </summary>
-        public static void FindAllMedia(IList<PageBlock> blocks, PageBlockMediaKind kind, List<PageBlock> result)
+        public static void FindAllMedia(List<PageBlock> blocks, PageBlockMediaKind kind, List<PageBlock> result)
         {
             if (blocks == null || kind == PageBlockMediaKind.None)
             {
@@ -260,7 +260,7 @@ namespace Telegram.Common
             }
         }
 
-        private static void CollectMediaInList(IList<PageBlock> blocks, PageBlockMediaKind kind, List<PageBlock> result)
+        private static void CollectMediaInList(List<PageBlock> blocks, PageBlockMediaKind kind, List<PageBlock> result)
         {
             if (blocks == null) return;
             foreach (var b in blocks)
@@ -295,7 +295,7 @@ namespace Telegram.Common
         /// Walks both the block tree and any nested rich-text content (paragraphs,
         /// captions, table cells, etc.). The returned list is owned by the caller.
         /// </summary>
-        public static IList<PageBlockLink> GetLinks(IList<PageBlock> blocks)
+        public static IList<PageBlockLink> GetLinks(List<PageBlock> blocks)
         {
             var result = new List<PageBlockLink>();
             if (blocks == null)
@@ -311,7 +311,7 @@ namespace Telegram.Common
             return result;
         }
 
-        private static void CollectLinksFromBlocks(IList<PageBlock> blocks, List<PageBlockLink> result)
+        private static void CollectLinksFromBlocks(List<PageBlock> blocks, List<PageBlockLink> result)
         {
             if (blocks == null) return;
             foreach (var b in blocks)
@@ -595,7 +595,7 @@ namespace Telegram.Common
         // GetRichText — flatten a block list into a single RichTexts (lines joined by '\n')
         // =====================================================================
 
-        public static string GetPlainText(IList<PageBlock> blocks)
+        public static string GetPlainText(List<PageBlock> blocks)
         {
             return GetRichText(blocks).ToPlainText();
         }
@@ -608,7 +608,7 @@ namespace Telegram.Common
         /// rendered as hardcoded placeholder strings; replace the
         /// <c>Placeholder*</c> constants at the top of this class to localize.
         /// </summary>
-        public static RichTexts GetRichText(IList<PageBlock> blocks)
+        public static RichTexts GetRichText(List<PageBlock> blocks)
         {
             var pieces = new List<RichText>();
             if (blocks != null)
@@ -626,7 +626,7 @@ namespace Telegram.Common
         {
             if (pieces.Count == 0)
             {
-                return new RichTexts(Array.Empty<RichText>());
+                return new RichTexts([]);
             }
 
             // Drop empty pieces (null/empty plain text / empty concatenations) so we
@@ -635,7 +635,7 @@ namespace Telegram.Common
 
             if (pieces.Count == 0)
             {
-                return new RichTexts(Array.Empty<RichText>());
+                return new RichTexts([]);
             }
 
             var joined = new List<RichText>(pieces.Count * 2 - 1);
@@ -647,7 +647,7 @@ namespace Telegram.Common
             return new RichTexts(joined);
         }
 
-        private static void CollectRichTextFromBlocks(IList<PageBlock> blocks, List<RichText> pieces)
+        private static void CollectRichTextFromBlocks(List<PageBlock> blocks, List<RichText> pieces)
         {
             if (blocks == null) return;
             foreach (var b in blocks) CollectRichTextFromBlock(b, pieces);
@@ -912,7 +912,7 @@ namespace Telegram.Common
         // needs scroll-to-anchor, add an Anchors side-channel on StyledText.
         private const char ObjectReplacementChar = '\uFFFC';
 
-        public static void Flatten(RichText richText, StringBuilder text, IList<TextEntity> entities)
+        public static void Flatten(RichText richText, StringBuilder text, List<TextEntity> entities)
         {
             switch (richText)
             {
@@ -1085,7 +1085,7 @@ namespace Telegram.Common
         // Lays the cached marker over the span an EmitSpan just wrote. Purely a style:
         // the link entity underneath keeps its type, so click handling is unaffected and
         // only the highlighter looks for this.
-        private static void EmitCached(bool isCached, int start, StringBuilder text, IList<TextEntity> entities)
+        private static void EmitCached(bool isCached, int start, StringBuilder text, List<TextEntity> entities)
         {
             int length = text.Length - start;
             if (isCached && length > 0)
@@ -1094,7 +1094,7 @@ namespace Telegram.Common
             }
         }
 
-        private static void EmitSpan(RichText inner, StringBuilder text, IList<TextEntity> entities, TextEntityType type)
+        private static void EmitSpan(RichText inner, StringBuilder text, List<TextEntity> entities, TextEntityType type)
         {
             int start = text.Length;
             Flatten(inner, text, entities);
@@ -1208,7 +1208,7 @@ namespace Telegram.Common
 
         // Top-level blocks are joined by a single '\n' (the inverse of ToPageBlocks, which splits
         // paragraphs on '\n'). Returns false the moment a block isn't losslessly representable.
-        private static bool TryAppendBlocks(IList<PageBlock> blocks, StringBuilder text, List<TextEntity> entities)
+        private static bool TryAppendBlocks(List<PageBlock> blocks, StringBuilder text, List<TextEntity> entities)
         {
             if (blocks == null)
             {
@@ -1330,7 +1330,7 @@ namespace Telegram.Common
             }
         }
 
-        private static bool TryAppendInputBlocks(IList<InputPageBlock> blocks, StringBuilder text, List<TextEntity> entities)
+        private static bool TryAppendInputBlocks(List<InputPageBlock> blocks, StringBuilder text, List<TextEntity> entities)
         {
             if (blocks == null)
             {
@@ -1450,7 +1450,7 @@ namespace Telegram.Common
         // Strict inline flatten: like Flatten, but returns false on any RichText that can't be
         // faithfully carried by a message entity (icon, anchor, reference / reference-link /
         // anchor-link, or any unknown type — all caught by the default arm).
-        private static bool TryAppendRichText(RichText richText, StringBuilder text, IList<TextEntity> entities)
+        private static bool TryAppendRichText(RichText richText, StringBuilder text, List<TextEntity> entities)
         {
             switch (richText)
             {
@@ -1522,7 +1522,7 @@ namespace Telegram.Common
             }
         }
 
-        private static bool TryEmitSpan(RichText inner, StringBuilder text, IList<TextEntity> entities, TextEntityType type)
+        private static bool TryEmitSpan(RichText inner, StringBuilder text, List<TextEntity> entities, TextEntityType type)
         {
             int start = text.Length;
             if (!TryAppendRichText(inner, text, entities))
@@ -1555,7 +1555,7 @@ namespace Telegram.Common
         /// mapped to their <c>richText*</c> equivalents, with nested/overlapping ranges
         /// resolved into a nested <see cref="RichText"/> tree.
         /// </summary>
-        public static IList<PageBlock> ToPageBlocks(FormattedText text)
+        public static List<PageBlock> ToPageBlocks(FormattedText text)
         {
             var blocks = new List<PageBlock>();
             var s = text?.Text ?? string.Empty;
@@ -1630,7 +1630,7 @@ namespace Telegram.Common
         }
 
         // Split [start,end) on '\n' and add one PageBlockParagraph per non-empty line.
-        private static void AppendParagraphs(IList<PageBlock> blocks, string s, int start, int end, List<TextEntity> inline)
+        private static void AppendParagraphs(List<PageBlock> blocks, string s, int start, int end, List<TextEntity> inline)
         {
             int lineStart = start;
             for (int i = start; i <= end; i++)
@@ -1982,7 +1982,7 @@ namespace Telegram.Common
             return Compare(a.Credit, b.Credit) && Compare(a.Text, b.Text);
         }
 
-        private static bool Compare(IList<PageBlock> a, IList<PageBlock> b)
+        private static bool Compare(List<PageBlock> a, List<PageBlock> b)
         {
             if (a == null || b == null)
             {
@@ -2012,7 +2012,7 @@ namespace Telegram.Common
                 && Compare(a.Blocks, b.Blocks);
         }
 
-        private static bool Compare(IList<PageBlockListItem> a, IList<PageBlockListItem> b)
+        private static bool Compare(List<PageBlockListItem> a, List<PageBlockListItem> b)
         {
             if (a.Count != b.Count)
             {
@@ -2135,7 +2135,7 @@ namespace Telegram.Common
         }
 
         /// <summary>Converts a list of display <see cref="PageBlock"/> into their <c>inputPageBlock*</c> equivalents (unsupported blocks dropped). The returned list is owned by the caller.</summary>
-        public static IList<InputPageBlock> ToInputBlocks(IList<PageBlock> blocks)
+        public static List<InputPageBlock> ToInputBlocks(List<PageBlock> blocks)
         {
             var result = new List<InputPageBlock>();
             if (blocks != null)
@@ -2217,7 +2217,7 @@ namespace Telegram.Common
             }
         }
 
-        private static IList<InputPageBlockListItem> ToInputListItems(IList<PageBlockListItem> items)
+        private static List<InputPageBlockListItem> ToInputListItems(List<PageBlockListItem> items)
         {
             var result = new List<InputPageBlockListItem>();
             if (items != null)
@@ -2272,7 +2272,7 @@ namespace Telegram.Common
                 ? new InputThumbnail(ToInputFile(thumb.Photo), thumb.Width, thumb.Height)
                 : null;
 
-            return new InputPhoto(ToInputFile(main.Photo), thumbnail, null, Array.Empty<int>(), main.Width, main.Height);
+            return new InputPhoto(ToInputFile(main.Photo), thumbnail, null, [], main.Width, main.Height);
         }
 
         private static InputVideo ToInputVideo(Video video)
@@ -2283,7 +2283,7 @@ namespace Telegram.Common
             }
 
             return new InputVideo(ToInputFile(video.VideoValue), ToInputThumbnail(video.Thumbnail), null, 0,
-                Array.Empty<int>(), video.Duration, video.Width, video.Height, video.SupportsStreaming);
+                [], video.Duration, video.Width, video.Height, video.SupportsStreaming);
         }
 
         private static InputAnimation ToInputAnimation(Animation animation)
@@ -2294,7 +2294,7 @@ namespace Telegram.Common
             }
 
             return new InputAnimation(ToInputFile(animation.AnimationValue), ToInputThumbnail(animation.Thumbnail),
-                Array.Empty<int>(), animation.Duration, animation.Width, animation.Height);
+                [], animation.Duration, animation.Width, animation.Height);
         }
 
         private static InputAudio ToInputAudio(Audio audio)

--- a/Telegram/Common/PageBlockRenderer.cs
+++ b/Telegram/Common/PageBlockRenderer.cs
@@ -837,7 +837,7 @@ namespace Telegram.Common
             }
             else
             {
-                var formatted = new FormattedText(plain.Text, new[] { new TextEntity(0, plain.Text.Length, new TextEntityTypePreCode(block.Language)) });
+                var formatted = new FormattedText(plain.Text, [new TextEntity(0, plain.Text.Length, new TextEntityTypePreCode(block.Language))]);
                 var textBlock = CreateTextBlock();
                 textBlock.SetText(clientService, formatted);
 
@@ -1243,7 +1243,7 @@ namespace Telegram.Common
             }
 
             // See ProcessPhoto: the gallery is built on tap, not collected here.
-            var message = CreateMessage(clientService, new MessageVideo(block.Video, Array.Empty<AlternativeVideo>(), Array.Empty<VideoStoryboard>(), null, 0, null, false, block.HasSpoiler, false));
+            var message = CreateMessage(clientService, new MessageVideo(block.Video, [], [], null, 0, null, false, block.HasSpoiler, false));
             var content = new VideoContent(message, album: parent is PageBlockCollage);
             content.HorizontalAlignment = parent is PageBlockCollage ? HorizontalAlignment.Stretch : HorizontalAlignment.Center;
             content.ClearValue(FrameworkElement.MaxWidthProperty);
@@ -1716,7 +1716,7 @@ namespace Telegram.Common
         //   - last block (unless full media): 6px bottom
         // LayoutRoot.Children is kept 1:1 with blocks by the diff (null elements are
         // inserted as Border placeholders), so indices line up.
-        public void UpdateSpacing(Panel panel, IList<PageBlock> blocks, bool root)
+        public void UpdateSpacing(Panel panel, List<PageBlock> blocks, bool root)
         {
             var count = Math.Min(blocks.Count, panel.Children.Count);
 

--- a/Telegram/Common/RichHtml.cs
+++ b/Telegram/Common/RichHtml.cs
@@ -417,7 +417,7 @@ namespace Telegram.Common
         private static void ParseTable(Node node, List<PageBlock> output)
         {
             var caption = EmptyText();
-            var rows = new List<IList<PageBlockTableCell>>();
+            var rows = new List<List<PageBlockTableCell>>();
             CollectRows(node, rows, ref caption);
 
             if (rows.Count == 0)
@@ -434,7 +434,7 @@ namespace Telegram.Common
             });
         }
 
-        private static void CollectRows(Node node, List<IList<PageBlockTableCell>> rows, ref RichText caption)
+        private static void CollectRows(Node node, List<List<PageBlockTableCell>> rows, ref RichText caption)
         {
             foreach (var child in node.Children)
             {
@@ -460,7 +460,7 @@ namespace Telegram.Common
             }
         }
 
-        private static IList<PageBlockTableCell> ParseRow(Node row)
+        private static List<PageBlockTableCell> ParseRow(Node row)
         {
             var cells = new List<PageBlockTableCell>();
 

--- a/Telegram/Common/RichHtml.cs
+++ b/Telegram/Common/RichHtml.cs
@@ -53,7 +53,7 @@ namespace Telegram.Common
         /// Parses an HTML fragment into page blocks. Returns an empty list when there is
         /// nothing to paste — the caller decides what an empty paste means.
         /// </summary>
-        public static IList<PageBlock> Parse(string html)
+        public static List<PageBlock> Parse(string html)
         {
             var blocks = new List<PageBlock>();
             if (string.IsNullOrEmpty(html))

--- a/Telegram/Common/TLNavigationService.cs
+++ b/Telegram/Common/TLNavigationService.cs
@@ -428,7 +428,7 @@ namespace Telegram.Common
                     var text = string.Format(Strings.ChannelAntiSpamInfo2, path);
                     var index = Strings.ChannelAntiSpamInfo2.IndexOf("{0}");
 
-                    var formatted = new FormattedText(text, new[] { new TextEntity(index, path.Length, new TextEntityTypeTextUrl("tg://")) });
+                    var formatted = new FormattedText(text, [new TextEntity(index, path.Length, new TextEntityTypeTextUrl("tg://"))]);
 
                     await ShowPopupAsync(formatted, Strings.AppName, Strings.OK);
                     return;

--- a/Telegram/Common/TextStyleRun.cs
+++ b/Telegram/Common/TextStyleRun.cs
@@ -81,7 +81,7 @@ namespace Telegram.Common
         // free; nothing on either side of the ABI writes to it.
         public static readonly IList<TextStylePart> NoParts = new List<TextStylePart>();
 
-        public static IList<TextStylePart> GetParts(IList<TextEntity> entities)
+        public static IList<TextStylePart> GetParts(List<TextEntity> entities)
         {
             if (entities == null)
             {
@@ -126,7 +126,7 @@ namespace Telegram.Common
             return GetRuns(formatted.Text, formatted.Entities);
         }
 
-        public static IList<TextStyleRun> GetRuns(string text, IList<TextEntity> entities)
+        public static IList<TextStyleRun> GetRuns(string text, List<TextEntity> entities)
         {
             if (entities == null || entities.Count == 0)
             {
@@ -273,11 +273,15 @@ namespace Telegram.Common
             return (starts && ends) || text.IndexOfAny(_lineBreakChars, offset, length) >= 0;
         }
 
-        public static IList<TextEntity> GetEntities(string text, IList<TextStyleRun> runs)
+        // Shared because it is only ever read. Array.Empty was free; a List allocated per message
+        // would not be, and these sit on the render path.
+        public static readonly List<TextEntity> NoEntities = new();
+
+        public static List<TextEntity> GetEntities(string text, IList<TextStyleRun> runs)
         {
             if (runs == null)
             {
-                return Array.Empty<TextEntity>();
+                return NoEntities;
             }
 
             var results = new List<TextEntity>();
@@ -342,12 +346,12 @@ namespace Telegram.Common
             return results;
         }
 
-        private static void Create(int offset, int length, IList<TextEntity> entities, TextEntityType type)
+        private static void Create(int offset, int length, List<TextEntity> entities, TextEntityType type)
         {
             entities.Add(new TextEntity(offset, length, type));
         }
 
-        private static void CreateOrMerge(string text, int offset, int length, IList<TextEntity> entities, TextEntityType type)
+        private static void CreateOrMerge(string text, int offset, int length, List<TextEntity> entities, TextEntityType type)
         {
             var last = entities.LastOrDefault(x => x.Length + x.Offset == offset && AreTheSame(x.Type, type));
             if (last != null)
@@ -404,14 +408,14 @@ namespace Telegram.Common
             return new StyledText(text.Text, text.Entities, GetParagraphs(text.Text, text.Entities));
         }
 
-        public static StyledText GetText(string text, IList<TextEntity> entities)
+        public static StyledText GetText(string text, List<TextEntity> entities)
         {
             if (string.IsNullOrEmpty(text))
             {
                 return StyledText.Empty;
             }
 
-            return new StyledText(text, entities, GetParagraphs(text, entities ?? Array.Empty<TextEntity>()));
+            return new StyledText(text, entities, GetParagraphs(text, entities ?? NoEntities));
         }
 
         #region RichText
@@ -466,7 +470,7 @@ namespace Telegram.Common
             }
         }
 
-        private static IList<StyledParagraph> GetParagraphs(string text, IList<TextEntity> entities)
+        private static IList<StyledParagraph> GetParagraphs(string text, List<TextEntity> entities)
         {
             List<Break> indexes = null;
             var previous = 0;
@@ -552,15 +556,15 @@ namespace Telegram.Common
             };
         }
 
-        private static StyledParagraph Split(string text, IList<TextEntity> entities, int startIndex, int length, TextDirectionality? direction, int padding)
+        private static StyledParagraph Split(string text, List<TextEntity> entities, int startIndex, int length, TextDirectionality? direction, int padding)
         {
             if (length <= 0)
             {
-                return new StyledParagraph(string.Empty, startIndex, length, Array.Empty<TextEntity>());
+                return new StyledParagraph(string.Empty, startIndex, length, NoEntities);
             }
 
             var message = text.Substring(startIndex, Math.Min(text.Length - startIndex, length));
-            IList<TextEntity> sub = null;
+            List<TextEntity> sub = null;
 
             foreach (var entity in entities)
             {
@@ -620,7 +624,7 @@ namespace Telegram.Common
 
     public partial class StyledText
     {
-        public StyledText(string text, IList<TextEntity> entities, IList<StyledParagraph> paragraphs)
+        public StyledText(string text, List<TextEntity> entities, IList<StyledParagraph> paragraphs)
         {
             Text = text;
             Parts = TextStyleRun.GetParts(entities);
@@ -698,7 +702,7 @@ namespace Telegram.Common
             return new FormattedText(Text.Substring(start, end - start), entities);
         }
 
-        public static StyledText Empty = new(string.Empty, Array.Empty<TextEntity>(), Array.Empty<StyledParagraph>());
+        public static StyledText Empty = new(string.Empty, TextStyleRun.NoEntities, Array.Empty<StyledParagraph>());
     }
 
     public partial class StyledParagraph
@@ -706,18 +710,18 @@ namespace Telegram.Common
         private readonly bool _hasDates;
         private readonly bool _hasRelativeDates;
 
-        public StyledParagraph(string text, IList<TextEntity> entities)
+        public StyledParagraph(string text, List<TextEntity> entities)
             : this(text, 0, text.Length, entities)
         {
 
         }
 
-        public StyledParagraph(string text, int offset, int length, IList<TextEntity> entities, TextDirectionality? direction = null, int padding = 0)
+        public StyledParagraph(string text, int offset, int length, List<TextEntity> entities, TextDirectionality? direction = null, int padding = 0)
         {
             Text = text;
             Offset = offset;
             Length = length;
-            Entities = entities ?? Array.Empty<TextEntity>();
+            Entities = entities ?? TextStyleRun.NoEntities;
             Parts = TextStyleRun.GetParts(entities);
             Runs = TextStyleRun.GetRuns(text, entities);
             Direction = direction ?? NativeUtils.GetDirectionality(text);
@@ -749,7 +753,7 @@ namespace Telegram.Common
 
         public int Length { get; }
 
-        public IList<TextEntity> Entities { get; }
+        public List<TextEntity> Entities { get; }
 
         public IList<TextStylePart> Parts { get; }
 

--- a/Telegram/Controls/Cells/ChatCell.xaml.cs
+++ b/Telegram/Controls/Cells/ChatCell.xaml.cs
@@ -1602,12 +1602,12 @@ namespace Telegram.Controls.Cells
             {
                 if (formatted?.Text.Length > 0)
                 {
-                    var entities = new TextEntity[formatted.Entities.Count];
+                    var entities = new List<TextEntity>(formatted.Entities.Count);
 
                     for (int i = 0; i < formatted.Entities.Count; i++)
                     {
                         TextEntity entity = formatted.Entities[i];
-                        entities[i] = new TextEntity(entity.Offset + text.Length, entity.Length, entity.Type);
+                        entities.Add(new TextEntity(entity.Offset + text.Length, entity.Length, entity.Type));
                     }
 
                     return new FormattedText(text + formatted.Text, entities);

--- a/Telegram/Controls/Cells/Premium/PremiumFeatureCell.xaml.cs
+++ b/Telegram/Controls/Cells/Premium/PremiumFeatureCell.xaml.cs
@@ -162,7 +162,7 @@ namespace Telegram.Controls.Cells.Premium
                 {
                     Width = 196,
                     Height = 292,
-                    Outline = Array.Empty<ClosedVectorPath>()
+                    Outline = AnimatedImageSource.NoOutline
                 };
             }
             else
@@ -255,7 +255,7 @@ namespace Telegram.Controls.Cells.Premium
                 {
                     Width = 196,
                     Height = 292,
-                    Outline = Array.Empty<ClosedVectorPath>()
+                    Outline = AnimatedImageSource.NoOutline
                 };
             }
             else

--- a/Telegram/Controls/Chats/ChatBackgroundControl.cs
+++ b/Telegram/Controls/Chats/ChatBackgroundControl.cs
@@ -6,6 +6,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using Telegram.Common;
 using Telegram.Native.Controls;
@@ -198,7 +199,7 @@ namespace Telegram.Controls.Chats
 
             if (background == null)
             {
-                var freeform = dark ? new[] { 0x6C7FA6, 0x2E344B, 0x7874A7, 0x333258 } : new[] { 0xDBDDBB, 0x6BA587, 0xD5D88D, 0x88B884 };
+                List<int> freeform = dark ? [0x6C7FA6, 0x2E344B, 0x7874A7, 0x333258] : [0xDBDDBB, 0x6BA587, 0xD5D88D, 0x88B884];
                 background = new Background(0, true, dark, string.Empty,
                     new Document(string.Empty, "application/x-tgwallpattern", null, null, TdExtensions.GetLocalFile("Assets\\Background.tgv", "Background")),
                     new BackgroundTypePattern(new BackgroundFillFreeformGradient(freeform), dark ? 100 : 50, dark, false));

--- a/Telegram/Controls/Chats/ChatTextBox.cs
+++ b/Telegram/Controls/Chats/ChatTextBox.cs
@@ -113,7 +113,7 @@ namespace Telegram.Controls.Chats
         /// </summary>
         private async Task<bool> TryPasteRichAsync(DataPackageView package)
         {
-            IList<PageBlock> blocks;
+            List<PageBlock> blocks;
             bool own;
 
             try

--- a/Telegram/Controls/FormattedTextBlock.cs
+++ b/Telegram/Controls/FormattedTextBlock.cs
@@ -615,7 +615,7 @@ namespace Telegram.Controls
             SetText(clientService, TextStyleRun.GetText(text), fontSize);
         }
 
-        public void SetText(IClientService clientService, string text, IList<TextEntity> entities, double fontSize = 0)
+        public void SetText(IClientService clientService, string text, List<TextEntity> entities, double fontSize = 0)
         {
             SetText(clientService, TextStyleRun.GetText(text, entities), fontSize);
         }

--- a/Telegram/Controls/FormattedTextBox.cs
+++ b/Telegram/Controls/FormattedTextBox.cs
@@ -1633,12 +1633,12 @@ namespace Telegram.Controls
             }
         }
 
-        public void SetText(string text, IList<TextEntity> entities)
+        public void SetText(string text, List<TextEntity> entities)
         {
             SetText(text, entities, false);
         }
 
-        public void SetText(string text, IList<TextEntity> entities, bool updateSelection = false)
+        public void SetText(string text, List<TextEntity> entities, bool updateSelection = false)
         {
             try
             {
@@ -1669,7 +1669,7 @@ namespace Telegram.Controls
             }
         }
 
-        private void SetTextImpl(string text, IList<TextEntity> entities, bool updateSelection)
+        private void SetTextImpl(string text, List<TextEntity> entities, bool updateSelection)
         {
             if (updateSelection is false)
             {

--- a/Telegram/Controls/Messages/Content/GameContent.xaml.cs
+++ b/Telegram/Controls/Messages/Content/GameContent.xaml.cs
@@ -210,7 +210,7 @@ namespace Telegram.Controls.Messages.Content
             ReplaceEntities(span, text.Text, text.Entities);
         }
 
-        private void ReplaceEntities(Span span, string text, IList<TextEntity> entities)
+        private void ReplaceEntities(Span span, string text, List<TextEntity> entities)
         {
             var previous = 0;
 

--- a/Telegram/Controls/Messages/Content/InstantContent.xaml.cs
+++ b/Telegram/Controls/Messages/Content/InstantContent.xaml.cs
@@ -212,9 +212,9 @@ namespace Telegram.Controls.Messages.Content
         }
 
         private IClientService _clientService;
-        private IList<PageBlock> _prevValue;
+        private List<PageBlock> _prevValue;
 
-        public void UpdateView(IClientService clientService, IList<PageBlock> blocks, bool part)
+        public void UpdateView(IClientService clientService, List<PageBlock> blocks, bool part)
         {
             // Kept for the whole lifetime, not just while the template is pending: the
             // renderer asks for a message back (IPageBlockContext.CreateMessage) outside
@@ -227,7 +227,7 @@ namespace Telegram.Controls.Messages.Content
                 return;
             }
 
-            var prev = _prevValue ?? Array.Empty<PageBlock>();
+            var prev = _prevValue ?? [];
             var diff = DiffUtil.CalculateDiff(prev, blocks, PageBlockHelper.Compare, Constants.DiffOptions);
 
             Logger.Info(string.Format("Steps: {0}, added: {1}, removed: {2}, moved: {3}", diff.Steps.Count, diff.AddedItems.Count, diff.RemovedItems.Count, diff.MovedItems.Count));

--- a/Telegram/Controls/Messages/MessageBubble.xaml.cs
+++ b/Telegram/Controls/Messages/MessageBubble.xaml.cs
@@ -2268,17 +2268,17 @@ namespace Telegram.Controls.Messages
                         var usupported = Strings.UnsupportedMessage;
                         var entity = new TextEntity(0, Strings.UnsupportedMessage.Length, new TextEntityTypeItalic());
 
-                        result = ReplaceEntities(message, new FormattedText(usupported, new[] { entity }));
+                        result = ReplaceEntities(message, new FormattedText(usupported, [entity]));
                         break;
                     }
 
                 case MessageVenue venue:
                     {
                         var venueText = $"{venue.Venue.Title}\n{venue.Venue.Address}";
-                        var venueEntities = new TextEntity[]
-                        {
-                    new(0, venue.Venue.Title.Length, new TextEntityTypeBold())
-                        };
+                        List<TextEntity> venueEntities =
+                        [
+                            new(0, venue.Venue.Title.Length, new TextEntityTypeBold())
+                        ];
 
                         result = ReplaceEntities(message, venueText, venueEntities);
                         break;
@@ -2325,7 +2325,7 @@ namespace Telegram.Controls.Messages
             return ReplaceEntities(message, text.Text, text.Entities, fontSize);
         }
 
-        private bool ReplaceEntities(MessageViewModel message, string text, IList<TextEntity> entities, double fontSize = 0)
+        private bool ReplaceEntities(MessageViewModel message, string text, List<TextEntity> entities, double fontSize = 0)
         {
             // TODO: this crashes due to an internal framework exception
             //Message.IsTextSelectionEnabled = !message.Chat.HasProtectedContent;
@@ -3201,7 +3201,7 @@ namespace Telegram.Controls.Messages
             Grid.SetRow(Message, 2);
             Panel.Placeholder = true;
 
-            Message.SetText(null, message, Array.Empty<TextEntity>());
+            Message.SetText(null, message, TextStyleRun.NoEntities);
 
             UpdateMockup(outgoing, first, last);
         }
@@ -3250,7 +3250,7 @@ namespace Telegram.Controls.Messages
             Grid.SetRow(Message, 2);
             Panel.Placeholder = true;
 
-            Message.SetText(null, message, Array.Empty<TextEntity>());
+            Message.SetText(null, message, TextStyleRun.NoEntities);
 
             UpdateMockup(outgoing, first, last);
         }
@@ -3324,7 +3324,7 @@ namespace Telegram.Controls.Messages
             Grid.SetRow(Message, 2);
             Panel.Placeholder = true;
 
-            Message.SetText(null, message, Array.Empty<TextEntity>());
+            Message.SetText(null, message, TextStyleRun.NoEntities);
 
             UpdateMockup(outgoing, first, last);
         }
@@ -3413,7 +3413,7 @@ namespace Telegram.Controls.Messages
             Grid.SetRow(Message, 2);
             Panel.Placeholder = false;
 
-            Message.SetText(null, message, Array.Empty<TextEntity>());
+            Message.SetText(null, message, TextStyleRun.NoEntities);
 
             LoadTemplateChild(ref HeaderPanel);
             LoadTemplateChild(ref HeaderLabel);
@@ -3550,7 +3550,7 @@ namespace Telegram.Controls.Messages
                 Media.Child = presenter;
             }
 
-            Message.SetText(null, caption, Array.Empty<TextEntity>());
+            Message.SetText(null, caption, TextStyleRun.NoEntities);
 
             UpdateMockup(outgoing, first, last);
         }
@@ -3605,7 +3605,7 @@ namespace Telegram.Controls.Messages
 
             if (sender != null)
             {
-                var message = new Message(chat.Id, sender, null, 0, null, null, false, false, false, false, false, false, false, false, false, false, 0, 0, null, null, null, Array.Empty<UnreadReaction>(), null, null, null, null, null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, null, null);
+                var message = new Message(chat.Id, sender, null, 0, null, null, false, false, false, false, false, false, false, false, false, false, 0, 0, null, null, null, [], null, null, null, null, null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, null, null);
                 var settings = clientService.Session.Resolve<ISettingsService>();
 
                 var delegato = new ChatMessageDelegate(clientService, settings, chat);

--- a/Telegram/Controls/Messages/MessageServiceText.cs
+++ b/Telegram/Controls/Messages/MessageServiceText.cs
@@ -2532,11 +2532,6 @@ namespace Telegram.Controls.Messages
         {
             source.Text = source.Text.Replace("**", string.Empty);
 
-            if (source.Entities.IsReadOnly)
-            {
-                source.Entities = new List<TextEntity>(source.Entities);
-            }
-
             for (int i = 0; i < args.Length; i++)
             {
                 var obj = args[i];
@@ -2670,11 +2665,6 @@ namespace Telegram.Controls.Messages
 
         private static FormattedText ReplaceWithLinks(FormattedText source, string param, IEnumerable<long> uids, IClientService clientService)
         {
-            if (source.Entities.IsReadOnly)
-            {
-                source.Entities = new List<TextEntity>(source.Entities);
-            }
-
             int index;
             int start = index = source.Text.IndexOf(param);
             if (start >= 0)

--- a/Telegram/Controls/Messages/MessageServiceText.cs
+++ b/Telegram/Controls/Messages/MessageServiceText.cs
@@ -184,7 +184,7 @@ namespace Telegram.Controls.Messages
 
             if (accentColorChanged.OldBackgroundCustomEmojiId != 0)
             {
-                oldEmoji = new FormattedText("{0}", new[] { new TextEntity(0, 3, new TextEntityTypeCustomEmoji(accentColorChanged.OldBackgroundCustomEmojiId)) });
+                oldEmoji = new FormattedText("{0}", [new TextEntity(0, 3, new TextEntityTypeCustomEmoji(accentColorChanged.OldBackgroundCustomEmojiId))]);
             }
             else
             {
@@ -193,7 +193,7 @@ namespace Telegram.Controls.Messages
 
             if (accentColorChanged.NewBackgroundCustomEmojiId != 0)
             {
-                newEmoji = new FormattedText("{1}", new[] { new TextEntity(0, 3, new TextEntityTypeCustomEmoji(accentColorChanged.NewBackgroundCustomEmojiId)) });
+                newEmoji = new FormattedText("{1}", [new TextEntity(0, 3, new TextEntityTypeCustomEmoji(accentColorChanged.NewBackgroundCustomEmojiId))]);
             }
             else
             {
@@ -210,7 +210,7 @@ namespace Telegram.Controls.Messages
 
             if (profileAccentColorChanged.OldProfileBackgroundCustomEmojiId != 0)
             {
-                oldEmoji = new FormattedText("{0}", new[] { new TextEntity(0, 3, new TextEntityTypeCustomEmoji(profileAccentColorChanged.OldProfileBackgroundCustomEmojiId)) });
+                oldEmoji = new FormattedText("{0}", [new TextEntity(0, 3, new TextEntityTypeCustomEmoji(profileAccentColorChanged.OldProfileBackgroundCustomEmojiId))]);
             }
             else
             {
@@ -219,7 +219,7 @@ namespace Telegram.Controls.Messages
 
             if (profileAccentColorChanged.NewProfileBackgroundCustomEmojiId != 0)
             {
-                newEmoji = new FormattedText("{1}", new[] { new TextEntity(0, 3, new TextEntityTypeCustomEmoji(profileAccentColorChanged.NewProfileBackgroundCustomEmojiId)) });
+                newEmoji = new FormattedText("{1}", [new TextEntity(0, 3, new TextEntityTypeCustomEmoji(profileAccentColorChanged.NewProfileBackgroundCustomEmojiId))]);
             }
             else
             {
@@ -1359,10 +1359,9 @@ namespace Telegram.Controls.Messages
 
         private static FormattedText UpdateForumTopicCreated(MessageWithOwner message, MessageForumTopicCreated forumTopicCreated, bool history)
         {
-            var topicName = new FormattedText($"\U0001F4C3 {forumTopicCreated.Name}", new[]
-            {
+            var topicName = new FormattedText($"\U0001F4C3 {forumTopicCreated.Name}", [
                 new TextEntity(0, 2, new TextEntityTypeCustomEmoji(forumTopicCreated.Icon.CustomEmojiId))
-            });
+            ]);
 
             return ClientEx.Format(Strings.TopicWasCreatedAction, topicName);
         }
@@ -1838,7 +1837,7 @@ namespace Telegram.Controls.Messages
                 {
                     if (animatedEmoji.AnimatedEmoji.Sticker?.FullType is StickerFullTypeCustomEmoji customEmoji)
                     {
-                        var emoji = new FormattedText(animatedEmoji.Emoji, new[] { new TextEntity(0, animatedEmoji.Emoji.Length, new TextEntityTypeCustomEmoji(customEmoji.CustomEmojiId)) });
+                        var emoji = new FormattedText(animatedEmoji.Emoji, [new TextEntity(0, animatedEmoji.Emoji.Length, new TextEntityTypeCustomEmoji(customEmoji.CustomEmojiId))]);
                         return ReplaceWithLink(ClientEx.Format(Strings.ActionPinnedText, emoji), message.GetSender());
                     }
 
@@ -1991,7 +1990,7 @@ namespace Telegram.Controls.Messages
 
             return index < 0
                 ? content.AsFormattedText()
-                : new FormattedText(content, new[] { new TextEntity(index, user.FirstName.Length, new TextEntityTypeBold()) });
+                : new FormattedText(content, [new TextEntity(index, user.FirstName.Length, new TextEntityTypeBold())]);
         }
 
         private static FormattedText UpdateSupergroupChatCreate(MessageWithOwner message, MessageSupergroupChatCreate supergroupChatCreate, bool history)
@@ -2504,7 +2503,7 @@ namespace Telegram.Controls.Messages
             return ClientEx.ParseMarkdown(content);
         }
 
-        private readonly static FormattedText _emptyString = new(string.Empty, Array.Empty<TextEntity>());
+        private readonly static FormattedText _emptyString = new(string.Empty, []);
 
         private static FormattedText UpdateStory(MessageWithOwner message, MessageStory story, bool history)
         {

--- a/Telegram/Controls/Messages/MessageTextBlock.cs
+++ b/Telegram/Controls/Messages/MessageTextBlock.cs
@@ -162,7 +162,7 @@ namespace Telegram.Controls.Messages
             SetText(clientService, TextStyleRun.GetText(text), fontSize);
         }
 
-        public void SetText(IClientService clientService, string text, IList<TextEntity> entities, double fontSize = 0)
+        public void SetText(IClientService clientService, string text, List<TextEntity> entities, double fontSize = 0)
         {
             SetText(clientService, TextStyleRun.GetText(text, entities), fontSize);
         }

--- a/Telegram/Controls/Messages/ReactionsMenuFlyout.xaml.cs
+++ b/Telegram/Controls/Messages/ReactionsMenuFlyout.xaml.cs
@@ -649,7 +649,7 @@ namespace Telegram.Controls.Messages
 
         public async void Initialize(IClientService clientService)
         {
-            var empty = Array.Empty<AvailableReaction>();
+            List<AvailableReaction> empty = [];
             var reactions = clientService.ActiveReactions
                 .Select(x => new AvailableReaction(new ReactionTypeEmoji(x), false))
                 .ToList();
@@ -1123,7 +1123,7 @@ namespace Telegram.Controls.Messages
             }
             else if (ItemClick != null)
             {
-                var empty = Array.Empty<AvailableReaction>();
+                List<AvailableReaction> empty = [];
                 var reactions = _viewModel.ClientService.ActiveReactions
                     .Select(x => new AvailableReaction(new ReactionTypeEmoji(x), false))
                     .ToList();

--- a/Telegram/Controls/ProfileHeader.xaml.cs
+++ b/Telegram/Controls/ProfileHeader.xaml.cs
@@ -402,7 +402,7 @@ namespace Telegram.Controls
                 ProfileColors colors;
                 if (chat.EmojiStatus?.Type is EmojiStatusTypeUpgradedGift upgradedGift)
                 {
-                    colors = new ProfileColors(new ProfileAccentColors(Array.Empty<int>(), new[] { upgradedGift.BackdropColors.EdgeColor, upgradedGift.BackdropColors.CenterColor }, Array.Empty<int>()));
+                    colors = new ProfileColors(new ProfileAccentColors([], [upgradedGift.BackdropColors.EdgeColor, upgradedGift.BackdropColors.CenterColor], []));
                 }
                 else if (ViewModel.ClientService.TryGetProfileColor(chat.ProfileAccentColorId, out ProfileColor color))
                 {
@@ -1705,7 +1705,7 @@ namespace Telegram.Controls
             ReplaceEntities(DescriptionSpan, text.Text, text.Entities);
         }
 
-        private void ReplaceEntities(Span span, string text, IList<TextEntity> entities)
+        private void ReplaceEntities(Span span, string text, List<TextEntity> entities)
         {
             var previous = 0;
 

--- a/Telegram/Controls/Stories/Popups/StoryReactPopup.xaml.cs
+++ b/Telegram/Controls/Stories/Popups/StoryReactPopup.xaml.cs
@@ -106,7 +106,7 @@ namespace Telegram.Controls.Stories.Popups
             var response = await _clientService.SendAsync(new GetLiveStoryTopDonors(_story.GroupCall.Id));
             if (response is LiveStoryDonors donors)
             {
-                _reactors = [.. donors.TopDonors ?? Array.Empty<PaidReactor>()];
+                _reactors = donors.TopDonors is { } topDonors ? [.. topDonors] : [];
 
                 if (_reactors.Count > 0)
                 {

--- a/Telegram/Controls/Stories/StoriesWindow.xaml.cs
+++ b/Telegram/Controls/Stories/StoriesWindow.xaml.cs
@@ -1093,7 +1093,7 @@ namespace Telegram.Controls.Stories
                 var text = Strings.StealthModeOn + Environment.NewLine + Strings.StealthModeOnHint;
                 var entity = new TextEntity(0, Strings.StealthModeOn.Length, new TextEntityTypeBold());
 
-                ToastPopup.Show(XamlRoot, new FormattedText(text, new[] { entity }));
+                ToastPopup.Show(XamlRoot, new FormattedText(text, [entity]));
             }
             else if (story.ClientService.IsPremium)
             {

--- a/Telegram/Services/Calls/VoipCoordinator.cs
+++ b/Telegram/Services/Calls/VoipCoordinator.cs
@@ -293,7 +293,7 @@ namespace Telegram.Services
 
             MessageSenders availableAliases;
             availableAliases = await clientService.SendAsync(new GetVideoChatAvailableParticipants(chatId)) as MessageSenders;
-            availableAliases ??= new MessageSenders(0, Array.Empty<MessageSender>());
+            availableAliases ??= new MessageSenders(0, []);
 
             var popup = new VideoChatAliasesPopup(clientService, chat, true, availableAliases.Senders);
 
@@ -355,7 +355,7 @@ namespace Telegram.Services
             {
                 MessageSenders availableAliases;
                 availableAliases = await clientService.SendAsync(new GetVideoChatAvailableParticipants(chat.Id)) as MessageSenders;
-                availableAliases ??= new MessageSenders(0, Array.Empty<MessageSender>());
+                availableAliases ??= new MessageSenders(0, []);
 
                 var popup = new VideoChatAliasesPopup(clientService, chat, false, availableAliases.Senders);
 

--- a/Telegram/Services/Calls/VoipGroupCall.cs
+++ b/Telegram/Services/Calls/VoipGroupCall.cs
@@ -1865,7 +1865,7 @@ namespace Telegram.Services.Calls
         /// <summary>
         /// At most 3 recently speaking users in the group call.
         /// </summary>
-        public IList<GroupCallRecentSpeaker> RecentSpeakers { get; private set; }
+        public List<GroupCallRecentSpeaker> RecentSpeakers { get; private set; }
 
         /// <summary>
         /// True, if all group call participants are loaded.

--- a/Telegram/Services/ClientService.ChatList.cs
+++ b/Telegram/Services/ClientService.ChatList.cs
@@ -69,7 +69,7 @@ namespace Telegram.Services
                 if (missing == 0)
                 {
                     // Have enough chats in the chat list to answer request
-                    var result = new long[Math.Max(0, Math.Min(limit, sorted.Count - offset))];
+                    var result = new List<long>(Math.Max(0, Math.Min(limit, sorted.Count - offset)));
                     var pos = 0;
 
                     using (var iter = sorted.GetEnumerator())
@@ -82,7 +82,7 @@ namespace Telegram.Services
 
                             if (i >= offset)
                             {
-                                result[pos++] = iter.Current.Id;
+                                result.Add(iter.Current.Id);
                             }
                         }
                     }
@@ -101,7 +101,7 @@ namespace Telegram.Services
                 }
                 else
                 {
-                    return new Chats(0, Array.Empty<long>());
+                    return new Chats(0, []);
                 }
             }
 

--- a/Telegram/Services/ClientService.ChatList.cs
+++ b/Telegram/Services/ClientService.ChatList.cs
@@ -17,7 +17,7 @@ namespace Telegram.Services
         private readonly NewDictionary<ChatList, SortedSet<OrderedItem>> _chatList = new(ChatListEqualityComparer.Instance);
         private readonly DefaultDictionary<ChatList, bool> _haveFullChatList = new(ChatListEqualityComparer.Instance);
 
-        private void SetChatPositions(Chat chat, IList<ChatPosition> positions)
+        private void SetChatPositions(Chat chat, List<ChatPosition> positions)
         {
             lock (_chatList)
             {

--- a/Telegram/Services/ClientService.StoryList.cs
+++ b/Telegram/Services/ClientService.StoryList.cs
@@ -102,7 +102,7 @@ namespace Telegram.Services
                 if (!load)
                 {
                     // Have enough chats in the chat list to answer request
-                    var result = new long[Math.Max(0, Math.Min(limit, sorted.Count - offset))];
+                    var result = new List<long>(Math.Max(0, Math.Min(limit, sorted.Count - offset)));
                     var pos = 0;
 
                     using (var iter = sorted.GetEnumerator())
@@ -115,7 +115,7 @@ namespace Telegram.Services
 
                             if (i >= offset)
                             {
-                                result[pos++] = iter.Current.Id;
+                                result.Add(iter.Current.Id);
                             }
                         }
                     }
@@ -134,7 +134,7 @@ namespace Telegram.Services
                 }
                 else
                 {
-                    return new Chats(0, Array.Empty<long>());
+                    return new Chats(0, []);
                 }
             }
 

--- a/Telegram/Services/ClientService.cs
+++ b/Telegram/Services/ClientService.cs
@@ -1694,9 +1694,9 @@ namespace Telegram.Services
 
         public AgeVerificationParameters AgeVerificationParameters { get; private set; }
 
-        public IList<CloseBirthdayUser> CloseBirthdayUsers => _contactCloseBirthdays?.CloseBirthdayUsers ?? Array.Empty<CloseBirthdayUser>();
+        public IList<CloseBirthdayUser> CloseBirthdayUsers => _contactCloseBirthdays?.CloseBirthdayUsers ?? (IList<CloseBirthdayUser>)Array.Empty<CloseBirthdayUser>();
 
-        public IList<string> AnimationSearchEmojis => _animationSearchParameters?.Emojis ?? Array.Empty<string>();
+        public IList<string> AnimationSearchEmojis => _animationSearchParameters?.Emojis ?? (IList<string>)Array.Empty<string>();
 
         public string AnimationSearchProvider => _animationSearchParameters?.Provider;
 
@@ -2962,7 +2962,7 @@ namespace Telegram.Services
             return value != null;
         }
 
-        public IList<EmojiChatTheme> ChatThemes => _chatThemes?.ChatThemes ?? Array.Empty<EmojiChatTheme>();
+        public IList<EmojiChatTheme> ChatThemes => _chatThemes?.ChatThemes ?? (IList<EmojiChatTheme>)Array.Empty<EmojiChatTheme>();
 
         public bool TryGetGroupCallMessageLevel(long paidMessageStarCount, out GroupCallMessageLevel value)
         {

--- a/Telegram/Services/ClientService.cs
+++ b/Telegram/Services/ClientService.cs
@@ -100,7 +100,7 @@ namespace Telegram.Services
 
         ReactionType DefaultReaction { get; }
 
-        IList<ChatFolderInfo> ChatFolders { get; }
+        List<ChatFolderInfo> ChatFolders { get; }
         int MainChatListPosition { get; }
         bool AreTagsEnabled { get; }
 
@@ -141,7 +141,7 @@ namespace Telegram.Services
         string GetTitle(MessageOrigin origin, MessageImportInfo import);
         string GetTitle(MessageSender sender, bool firstName = false);
 
-        IList<ChatFolderInfo> GetChatFolders(Chat chat);
+        List<ChatFolderInfo> GetChatFolders(Chat chat);
 
         bool TryGetCachedReaction(string emoji, out EmojiReaction value);
         Task<IDictionary<string, EmojiReaction>> GetAllReactionsAsync();
@@ -156,12 +156,12 @@ namespace Telegram.Services
 
         QuickReplyShortcut GetQuickReplyShortcut(int id);
         QuickReplyShortcut GetQuickReplyShortcut(string name);
-        IList<QuickReplyMessage> GetQuickReplyMessages(int id);
+        List<QuickReplyMessage> GetQuickReplyMessages(int id);
         IList<QuickReplyShortcut> GetQuickReplyShortcuts();
         void LoadQuickReplyShortcuts();
         bool CheckQuickReplyShortcutName(string name);
 
-        IList<WelcomeMessage> GetWelcomeMessages(long chatId);
+        List<WelcomeMessage> GetWelcomeMessages(long chatId);
 
         Task<IList<MessageEffect>> GetMessageEffectsAsync(IEnumerable<long> effectIds);
         MessageEffect LoadMessageEffect(long effectId, bool preload);
@@ -339,7 +339,7 @@ namespace Telegram.Services
 
         private readonly ReaderWriterDictionary<int, GroupCall> _groupCalls = new();
 
-        private readonly ReaderWriterDictionary<long, IList<WelcomeMessage>> _welcomeMessages = new();
+        private readonly ReaderWriterDictionary<long, List<WelcomeMessage>> _welcomeMessages = new();
 
         private readonly ConcurrentDictionary<int, ChatListUnreadCount> _unreadCounts = new();
 
@@ -378,7 +378,7 @@ namespace Telegram.Services
 
         private ReactionType _defaultReaction;
 
-        private IList<ChatFolderInfo> _chatFolders = Array.Empty<ChatFolderInfo>();
+        private List<ChatFolderInfo> _chatFolders = [];
         private Dictionary<int, ChatFolderInfo> _chatFolders2 = new();
         private readonly object _chatFoldersLock = new();
         private int _mainChatListPosition = 0;
@@ -1016,7 +1016,7 @@ namespace Telegram.Services
 
             lock (_chatFoldersLock)
             {
-                _chatFolders = Array.Empty<ChatFolderInfo>();
+                _chatFolders = [];
                 _chatFolders2.Clear();
             }
 
@@ -1606,7 +1606,7 @@ namespace Telegram.Services
 
         public ReactionType DefaultReaction => _defaultReaction;
 
-        public IList<ChatFolderInfo> ChatFolders => _chatFolders;
+        public List<ChatFolderInfo> ChatFolders => _chatFolders;
 
         public int MainChatListPosition => _mainChatListPosition;
 
@@ -1839,7 +1839,7 @@ namespace Telegram.Services
             return _chatFolders.IndexOf(x) - _chatFolders.IndexOf(y);
         }
 
-        public IList<ChatFolderInfo> GetChatFolders(Chat chat)
+        public List<ChatFolderInfo> GetChatFolders(Chat chat)
         {
             List<ChatFolderInfo> result = null;
 
@@ -1874,7 +1874,7 @@ namespace Telegram.Services
                 }
             }
 
-            return Array.Empty<ChatFolderInfo>();
+            return [];
         }
 
         public bool TryGetCachedReaction(string emoji, out EmojiReaction value)
@@ -2008,14 +2008,14 @@ namespace Telegram.Services
                 .FirstOrDefault(x => x.Name == name);
         }
 
-        public IList<QuickReplyMessage> GetQuickReplyMessages(int id)
+        public List<QuickReplyMessage> GetQuickReplyMessages(int id)
         {
             if (_quickReplyShortcuts.TryGetValue(id, out var value))
             {
                 return value.Messages;
             }
 
-            return Array.Empty<QuickReplyMessage>();
+            return [];
         }
 
         public IList<QuickReplyShortcut> GetQuickReplyShortcuts()
@@ -2062,14 +2062,14 @@ namespace Telegram.Services
             return ClientEx.CheckQuickReplyShortcutName(name);
         }
 
-        public IList<WelcomeMessage> GetWelcomeMessages(long chatId)
+        public List<WelcomeMessage> GetWelcomeMessages(long chatId)
         {
             if (_welcomeMessages.TryGetValue(chatId, out var value))
             {
                 return value;
             }
 
-            return Array.Empty<WelcomeMessage>();
+            return [];
         }
 
         public bool IsSavedMessages(MessageSender sender)
@@ -4432,7 +4432,7 @@ namespace Telegram.Services
     {
         public QuickReplyShortcut Shortcut { get; set; }
 
-        public IList<QuickReplyMessage> Messages { get; set; }
+        public List<QuickReplyMessage> Messages { get; set; }
     }
 
     public partial class ChatListUnreadCount

--- a/Telegram/Services/ForumTopicService.cs
+++ b/Telegram/Services/ForumTopicService.cs
@@ -734,7 +734,7 @@ namespace Telegram.Services
 
         private Message MessageForumTopicCreated(ForumTopic topic)
         {
-            return new Message(topic.Info.ForumTopicId, topic.Info.CreatorId, null, _chatId, null, null, topic.Info.IsOutgoing, false, false, false, false, false, false, false, false, false, topic.Info.CreationDate, 0, null, null, null, Array.Empty<UnreadReaction>(), null, null, null, new MessageTopicForum(topic.Info.ForumTopicId), null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, new MessageForumTopicCreated(topic.Info.Name, false, topic.Info.Icon), null);
+            return new Message(topic.Info.ForumTopicId, topic.Info.CreatorId, null, _chatId, null, null, topic.Info.IsOutgoing, false, false, false, false, false, false, false, false, false, topic.Info.CreationDate, 0, null, null, null, [], null, null, null, new MessageTopicForum(topic.Info.ForumTopicId), null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, new MessageForumTopicCreated(topic.Info.Name, false, topic.Info.Icon), null);
         }
 
         public void UpdateMessageSendSucceeded(Message message, long oldMessageId)
@@ -889,7 +889,7 @@ namespace Telegram.Services
             }
         }
 
-        public void UpdateMessageUnreadReactions(long messageId, IList<UnreadReaction> unreadReactions, int unreadReactionCount)
+        public void UpdateMessageUnreadReactions(long messageId, List<UnreadReaction> unreadReactions, int unreadReactionCount)
         {
             // Important
             // Update UnreadMentionReactions

--- a/Telegram/Services/MessageAlbumLastMessageService.cs
+++ b/Telegram/Services/MessageAlbumLastMessageService.cs
@@ -22,7 +22,7 @@ namespace Telegram.Services
 
         private readonly object _lock = new();
 
-        private readonly static FormattedText _emptyText = new(string.Empty, Array.Empty<TextEntity>());
+        private readonly static FormattedText _emptyText = new(string.Empty, []);
 
         private Queue<long> _queue = new();
         private bool _loading = true;

--- a/Telegram/Services/PlaybackService.cs
+++ b/Telegram/Services/PlaybackService.cs
@@ -72,7 +72,7 @@ namespace Telegram.Services
         /// Album cover variants to use if the downloaded audio file contains no album cover.
         /// Provided thumbnail dimensions are approximate.
         /// </summary>
-        public IList<Thumbnail> ExternalAlbumCovers { get; set; }
+        public List<Thumbnail> ExternalAlbumCovers { get; set; }
 
         /// <summary>
         /// The thumbnail of the album cover in JPEG format; as defined by the sender. The

--- a/Telegram/Streams/AnimatedImageSource.cs
+++ b/Telegram/Streams/AnimatedImageSource.cs
@@ -21,7 +21,11 @@ namespace Telegram.Streams
 
         public bool NeedsRepainting { get; set; }
 
-        public IList<ClosedVectorPath> Outline { get; set; }
+        // AnimatedImage draws no shimmer at all when Outline is null, so having no outline has to
+        // be an empty list. Shared because it is only ever read - nothing may add to it.
+        public static readonly List<ClosedVectorPath> NoOutline = new();
+
+        public List<ClosedVectorPath> Outline { get; set; }
 
         // Needed for Outline
         public int Width { get; set; }

--- a/Telegram/Streams/DelayedFileSource.cs
+++ b/Telegram/Streams/DelayedFileSource.cs
@@ -73,7 +73,7 @@ namespace Telegram.Streams
                         Width = 512,
                         Height = 512,
                         NeedsRepainting = stickerSet.NeedsRepainting,
-                        Outline = stickerSet.ThumbnailOutline?.Paths ?? Array.Empty<ClosedVectorPath>(),
+                        Outline = stickerSet.ThumbnailOutline?.Paths ?? NoOutline,
                     };
                 }
 
@@ -83,7 +83,7 @@ namespace Telegram.Streams
                     Width = stickerSet.Thumbnail.Width,
                     Height = stickerSet.Thumbnail.Height,
                     NeedsRepainting = stickerSet.NeedsRepainting,
-                    Outline = stickerSet.ThumbnailOutline?.Paths ?? Array.Empty<ClosedVectorPath>(),
+                    Outline = stickerSet.ThumbnailOutline?.Paths ?? NoOutline,
                 };
             }
 
@@ -119,7 +119,7 @@ namespace Telegram.Streams
                         Width = 512,
                         Height = 512,
                         NeedsRepainting = stickerSet.NeedsRepainting,
-                        Outline = stickerSet.ThumbnailOutline?.Paths ?? Array.Empty<ClosedVectorPath>(),
+                        Outline = stickerSet.ThumbnailOutline?.Paths ?? NoOutline,
                     };
                 }
 
@@ -129,7 +129,7 @@ namespace Telegram.Streams
                     Width = stickerSet.Thumbnail.Width,
                     Height = stickerSet.Thumbnail.Height,
                     NeedsRepainting = stickerSet.NeedsRepainting,
-                    Outline = stickerSet.ThumbnailOutline?.Paths ?? Array.Empty<ClosedVectorPath>(),
+                    Outline = stickerSet.ThumbnailOutline?.Paths ?? NoOutline,
                 };
             }
 

--- a/Telegram/Td/Api/FormattedText.cs
+++ b/Telegram/Td/Api/FormattedText.cs
@@ -99,7 +99,7 @@ namespace Telegram.Td.Api
 
             if (args == null || args.Length == 0)
             {
-                return new FormattedText(format, Array.Empty<TextEntity>());
+                return new FormattedText(format, []);
             }
 
             // Parse the format string to find placeholders

--- a/Telegram/Td/Api/TdExtensions.cs
+++ b/Telegram/Td/Api/TdExtensions.cs
@@ -493,7 +493,7 @@ namespace Telegram.Td.Api
         {
             if (suggestedPostInfo is SuggestedPostInfo { State: SuggestedPostStatePending } && !outgoing)
             {
-                return new ReplyMarkupInlineKeyboard(new List<IList<InlineKeyboardButton>>
+                return new ReplyMarkupInlineKeyboard(new List<List<InlineKeyboardButton>>
                 {
                     new List<InlineKeyboardButton>
                     {

--- a/Telegram/Td/Api/TdExtensions.cs
+++ b/Telegram/Td/Api/TdExtensions.cs
@@ -250,7 +250,7 @@ namespace Telegram.Td.Api
 
         public static CallProtocol ToTd(this VoipCallProtocol protocol)
         {
-            return new CallProtocol(protocol.UdpP2p, protocol.UdpReflector, protocol.MinLayer, protocol.MaxLayer, protocol.LibraryVersions);
+            return new CallProtocol(protocol.UdpP2p, protocol.UdpReflector, protocol.MinLayer, protocol.MaxLayer, [.. protocol.LibraryVersions]);
         }
 
         public static long ToId(this MessageSender sender)
@@ -1490,7 +1490,7 @@ namespace Telegram.Td.Api
             }
 
             var message = text.Text.Substring(startIndex, Math.Min(text.Text.Length - startIndex, length));
-            IList<TextEntity> sub = null;
+            List<TextEntity> sub = null;
 
             foreach (var entity in text.Entities)
             {
@@ -1506,10 +1506,10 @@ namespace Telegram.Td.Api
                 }
             }
 
-            return new FormattedText(message, sub ?? Array.Empty<TextEntity>());
+            return new FormattedText(message, sub ?? []);
         }
 
-        public static (string Text, IList<TextEntity> Entities) Substring(this string text, IList<TextEntity> entities, int startIndex, int length)
+        public static (string Text, List<TextEntity> Entities) Substring(this string text, List<TextEntity> entities, int startIndex, int length)
         {
             if (text.Length < length)
             {
@@ -1517,7 +1517,7 @@ namespace Telegram.Td.Api
             }
 
             var message = text.Substring(startIndex, Math.Min(text.Length - startIndex, length));
-            IList<TextEntity> sub = null;
+            List<TextEntity> sub = null;
 
             foreach (var entity in entities)
             {
@@ -1533,7 +1533,7 @@ namespace Telegram.Td.Api
                 }
             }
 
-            return (message, sub ?? Array.Empty<TextEntity>());
+            return (message, sub ?? TextStyleRun.NoEntities);
         }
 
         public static bool Intersect(this TextEntity x, TextEntity y)
@@ -2668,7 +2668,7 @@ namespace Telegram.Td.Api
 
         public static Photo ToPhoto(this ChatPhotoInfo chatPhoto)
         {
-            return new Photo(false, null, new PhotoSize[] { new("t", chatPhoto.Small, 160, 160, Array.Empty<int>()), new("i", chatPhoto.Big, 640, 640, Array.Empty<int>()) });
+            return new Photo(false, null, [ new("t", chatPhoto.Small, 160, 160, []), new("i", chatPhoto.Big, 640, 640, []) ]);
         }
 
         public static Photo ToPhoto(this ChatPhoto chatPhoto)
@@ -3758,7 +3758,7 @@ namespace Telegram.Td.Api
         /// reactions, and the list is usually empty, so the enumerator would be the only
         /// allocation on the common path.
         /// </summary>
-        public static void Discern(this IList<UnreadReaction> reactions, out bool paid, out HashSet<string> emoji, out HashSet<long> customEmoji)
+        public static void Discern(this List<UnreadReaction> reactions, out bool paid, out HashSet<string> emoji, out HashSet<long> customEmoji)
         {
             paid = false;
             emoji = null;
@@ -4692,9 +4692,9 @@ namespace Telegram.Td.Api
             var split = slug.Split('?');
             var query = slug.ParseQueryString();
 
-            if (TryGetColors(split[0], '-', 1, 2, out int[] linear))
+            if (TryGetColors(split[0], '-', 1, 2, out List<int> linear))
             {
-                if (linear.Length > 1)
+                if (linear.Count > 1)
                 {
                     query.TryGetValue("rotation", out string rotationKey);
                     int.TryParse(rotationKey ?? string.Empty, out int rotation);
@@ -4704,7 +4704,7 @@ namespace Telegram.Td.Api
 
                 return new BackgroundFillSolid(linear[0]);
             }
-            else if (TryGetColors(split[0], '~', 3, 4, out int[] freeform))
+            else if (TryGetColors(split[0], '~', 3, 4, out List<int> freeform))
             {
                 return new BackgroundFillFreeformGradient(freeform);
             }
@@ -4735,9 +4735,9 @@ namespace Telegram.Td.Api
             var slug = uri.Segments.Last();
             var query = uri.Query.ParseQueryString();
 
-            if (TryGetColors(slug, '-', 1, 2, out int[] linear))
+            if (TryGetColors(slug, '-', 1, 2, out List<int> linear))
             {
-                if (linear.Length > 1)
+                if (linear.Count > 1)
                 {
                     query.TryGetValue("rotation", out string rotationKey);
                     int.TryParse(rotationKey ?? string.Empty, out int rotation);
@@ -4747,7 +4747,7 @@ namespace Telegram.Td.Api
 
                 return new BackgroundTypeFill(new BackgroundFillSolid(linear[0]));
             }
-            else if (TryGetColors(slug, '~', 3, 4, out int[] freeform))
+            else if (TryGetColors(slug, '~', 3, 4, out List<int> freeform))
             {
                 return new BackgroundTypeFill(new BackgroundFillFreeformGradient(freeform));
             }
@@ -4759,9 +4759,9 @@ namespace Telegram.Td.Api
                 var modeSplit = modeKey?.ToLower().Split('+') ?? Array.Empty<string>();
 
                 BackgroundFill fill = null;
-                if (bg_colorKey != null && TryGetColors(bg_colorKey, '-', 1, 2, out int[] patternLinear))
+                if (bg_colorKey != null && TryGetColors(bg_colorKey, '-', 1, 2, out List<int> patternLinear))
                 {
-                    if (patternLinear.Length > 1)
+                    if (patternLinear.Count > 1)
                     {
                         query.TryGetValue("rotation", out string rotationKey);
                         int.TryParse(rotationKey ?? string.Empty, out int rotation);
@@ -4773,7 +4773,7 @@ namespace Telegram.Td.Api
                         fill = new BackgroundFillSolid(patternLinear[0]);
                     }
                 }
-                else if (bg_colorKey != null && TryGetColors(bg_colorKey, '~', 3, 4, out int[] patternFreeform))
+                else if (bg_colorKey != null && TryGetColors(bg_colorKey, '~', 3, 4, out List<int> patternFreeform))
                 {
                     fill = new BackgroundFillFreeformGradient(patternFreeform);
                 }
@@ -4792,18 +4792,18 @@ namespace Telegram.Td.Api
             }
         }
 
-        private static bool TryGetColors(string slug, char separator, int minimum, int maximum, out int[] colors)
+        private static bool TryGetColors(string slug, char separator, int minimum, int maximum, out List<int> colors)
         {
             var split = slug?.Split(separator);
             if (split != null && split.Length >= minimum && split.Length <= maximum)
             {
-                colors = new int[split.Length];
+                colors = new List<int>(split.Length);
 
                 for (int i = 0; i < split.Length; i++)
                 {
                     if (int.TryParse(split[i], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int color))
                     {
-                        colors[i] = color;
+                        colors.Add(color);
                     }
                     else
                     {

--- a/Telegram/Td/ClientEx.cs
+++ b/Telegram/Td/ClientEx.cs
@@ -33,7 +33,7 @@ namespace Telegram.Td
             return ParseMarkdown(new FormattedText(text, null));
         }
 
-        public static FormattedText ParseMarkdown(string text, IList<TextEntity> entities)
+        public static FormattedText ParseMarkdown(string text, List<TextEntity> entities)
         {
             return ParseMarkdown(new FormattedText(text, entities));
         }
@@ -54,7 +54,7 @@ namespace Telegram.Td
             return GetMarkdownText(new FormattedText(text, null));
         }
 
-        public static FormattedText GetMarkdownText(string text, IList<TextEntity> entities)
+        public static FormattedText GetMarkdownText(string text, List<TextEntity> entities)
         {
             return GetMarkdownText(new FormattedText(text, entities));
         }
@@ -70,7 +70,7 @@ namespace Telegram.Td
             return text;
         }
 
-        public static IList<TextEntity> GetTextEntities(string text)
+        public static List<TextEntity> GetTextEntities(string text)
         {
             var result = Client.Execute(new GetTextEntities(text));
             if (result is TextEntities entities)
@@ -81,7 +81,7 @@ namespace Telegram.Td
             return [];
         }
 
-        public static FormattedText MergeEntities(FormattedText text, IList<TextEntity> entities)
+        public static FormattedText MergeEntities(FormattedText text, List<TextEntity> entities)
         {
             if (entities.Count > 0 && text.Entities.Count > 0)
             {
@@ -115,17 +115,17 @@ namespace Telegram.Td
 
         public static FormattedText CustomEmoji(string emoji, long customEmojiId)
         {
-            return new FormattedText(emoji, new[] { new TextEntity(0, emoji.Length, new TextEntityTypeCustomEmoji(customEmojiId)) });
+            return new FormattedText(emoji, [new TextEntity(0, emoji.Length, new TextEntityTypeCustomEmoji(customEmojiId))]);
         }
 
         public static FormattedText CustomEmoji(long customEmojiId)
         {
-            return new FormattedText("\U0001F642", new[] { new TextEntity(0, 2, new TextEntityTypeCustomEmoji(customEmojiId)) });
+            return new FormattedText("\U0001F642", [new TextEntity(0, 2, new TextEntityTypeCustomEmoji(customEmojiId))]);
         }
 
         public static FormattedText CustomEmoji(string glyph)
         {
-            return new FormattedText(glyph, new[] { new TextEntity(0, 1, new TextEntityTypeCustomEmoji(-1)) });
+            return new FormattedText(glyph, [new TextEntity(0, 1, new TextEntityTypeCustomEmoji(-1))]);
         }
 
         public static FormattedText Format(string format, params object[] args)

--- a/Telegram/Td/ClientJson.cs
+++ b/Telegram/Td/ClientJson.cs
@@ -549,7 +549,7 @@ namespace Telegram.Td.Api
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteArray<T>(this Utf8JsonWriter writer, ReadOnlySpan<byte> utf8PropertyName, IList<IList<T>>? obj) where T : Object
+        public static void WriteArray<T>(this Utf8JsonWriter writer, ReadOnlySpan<byte> utf8PropertyName, IList<List<T>>? obj) where T : Object
         {
             if (obj == null)
             {
@@ -717,9 +717,9 @@ namespace Telegram.Td.Api
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static List<IList<T>> GetObjectArrayArray<T>(this ref Utf8JsonReader reader, ClientResultHandler client, GetObjectArrayHandler<T> handler) where T : Object
+        public static List<List<T>> GetObjectArrayArray<T>(this ref Utf8JsonReader reader, ClientResultHandler client, GetObjectArrayHandler<T> handler) where T : Object
         {
-            var obj = new List<IList<T>>();
+            var obj = new List<List<T>>();
 
             reader.Read();
             while (reader.TokenType == JsonTokenType.StartArray)

--- a/Telegram/Td/PtrClientJson.cs
+++ b/Telegram/Td/PtrClientJson.cs
@@ -99,9 +99,9 @@ namespace Telegram.Td.Api
             return items;
         }
 
-        public static List<IList<T>> GetObjectArrayArrayPtr<T>(ref TdJsonReader reader, ClientResultHandler handler, PtrParser<T> parser) where T : Object
+        public static List<List<T>> GetObjectArrayArrayPtr<T>(ref TdJsonReader reader, ClientResultHandler handler, PtrParser<T> parser) where T : Object
         {
-            var items = new List<IList<T>>();
+            var items = new List<List<T>>();
 
             reader.Read();
 

--- a/Telegram/ViewModels/Authorization/AuthorizationViewModel.cs
+++ b/Telegram/ViewModels/Authorization/AuthorizationViewModel.cs
@@ -265,7 +265,7 @@ namespace Telegram.ViewModels.Authorization
 
             IsLoading = true;
 
-            var function = new SetAuthenticationPhoneNumber(phoneNumber, new PhoneNumberAuthenticationSettings(false, false, false, false, false, null, Array.Empty<string>()));
+            var function = new SetAuthenticationPhoneNumber(phoneNumber, new PhoneNumberAuthenticationSettings(false, false, false, false, false, null, []));
             Task<Object> request;
             if (ClientService.AuthorizationState is AuthorizationStateWaitOtherDeviceConfirmation)
             {

--- a/Telegram/ViewModels/BackgroundViewModel.cs
+++ b/Telegram/ViewModels/BackgroundViewModel.cs
@@ -290,11 +290,11 @@ namespace Telegram.ViewModels
             {
                 if (!_color3.IsEmpty && !_color4.IsEmpty)
                 {
-                    return new BackgroundFillFreeformGradient(new[] { _color1.Value, _color2.Value, _color3.Value, _color4.Value });
+                    return new BackgroundFillFreeformGradient([_color1.Value, _color2.Value, _color3.Value, _color4.Value]);
                 }
                 else if (!_color3.IsEmpty)
                 {
-                    return new BackgroundFillFreeformGradient(new[] { _color1.Value, _color2.Value, _color3.Value });
+                    return new BackgroundFillFreeformGradient([_color1.Value, _color2.Value, _color3.Value]);
                 }
 
                 return new BackgroundFillGradient(_color1.Value, _color2.Value, _rotation);

--- a/Telegram/ViewModels/Chats/ChatGalleryViewModel.cs
+++ b/Telegram/ViewModels/Chats/ChatGalleryViewModel.cs
@@ -253,7 +253,7 @@ namespace Telegram.ViewModels.Chats
 
             if (message.Advertisements == null)
             {
-                message.Advertisements = new VideoMessageAdvertisements(Array.Empty<VideoMessageAdvertisement>(), -1, -1);
+                message.Advertisements = new VideoMessageAdvertisements([], -1, -1);
 
                 var response = await ClientService.SendAsync(new GetVideoMessageAdvertisements(message.ChatId, message.Id));
                 if (response is VideoMessageAdvertisements advertisements)

--- a/Telegram/ViewModels/Chats/ChatStoriesViewModel.cs
+++ b/Telegram/ViewModels/Chats/ChatStoriesViewModel.cs
@@ -485,7 +485,7 @@ namespace Telegram.ViewModels.Chats
                         CanBeDeleted = canBeEdited
                     })
                     .ToList();
-                response = new Td.Api.Stories(0, items, Array.Empty<int>());
+                response = new Td.Api.Stories(0, items, []);
             }
 
             if (response is Td.Api.Stories stories)

--- a/Telegram/ViewModels/ChooseChatsViewModel.cs
+++ b/Telegram/ViewModels/ChooseChatsViewModel.cs
@@ -965,7 +965,7 @@ namespace Telegram.ViewModels
                         return await ClientService.SendAsync(new AddChatMembers(chat.Id, users.ToArray()));
                     }
 
-                    IList<FailedToAddMember> members = null;
+                    List<FailedToAddMember> members = null;
 
                     foreach (var userId in users)
                     {
@@ -982,7 +982,7 @@ namespace Telegram.ViewModels
                         }
                     }
 
-                    return new FailedToAddMembers(members ?? Array.Empty<FailedToAddMember>());
+                    return new FailedToAddMembers(members ?? []);
                 }
 
                 var selected = chats.Select(x => ClientService.GetUser(x)).Where(x => x != null).ToList();

--- a/Telegram/ViewModels/ComposeViewModel.cs
+++ b/Telegram/ViewModels/ComposeViewModel.cs
@@ -131,7 +131,7 @@ namespace Telegram.ViewModels
             }
 
             var reply = GetReply(true);
-            var input = new InputMessageAnimation(new InputAnimation(new InputFileId(animation.AnimationValue.Id), animation.Thumbnail?.ToInput(), Array.Empty<int>(), animation.Duration, animation.Width, animation.Height), null, false, false);
+            var input = new InputMessageAnimation(new InputAnimation(new InputFileId(animation.AnimationValue.Id), animation.Thumbnail?.ToInput(), [], animation.Duration, animation.Width, animation.Height), null, false, false);
 
             await SendMessageAsync(reply, input, options);
         }
@@ -686,7 +686,7 @@ namespace Telegram.ViewModels
             var factory = await MessageFactory.CreatePhotoAsync(file, caption, highQuality, captionAboveMedia, hasSpoiler, ttl, starCount);
             if (factory is InputPaidMedia inputPaidMedia)
             {
-                await SendMessageAsync(reply, new InputMessagePaidMedia(starCount, new[] { inputPaidMedia }, caption, captionAboveMedia, string.Empty), options);
+                await SendMessageAsync(reply, new InputMessagePaidMedia(starCount, [inputPaidMedia], caption, captionAboveMedia, string.Empty), options);
             }
             else if (factory is InputMessageContent input)
             {
@@ -699,7 +699,7 @@ namespace Telegram.ViewModels
             var factory = await MessageFactory.CreateVideoAsync(video, caption, animated, captionAboveMedia, hasSpoiler, ttl, starCount);
             if (factory is InputPaidMedia inputPaidMedia)
             {
-                await SendMessageAsync(reply, new InputMessagePaidMedia(starCount, new[] { inputPaidMedia }, caption, captionAboveMedia, string.Empty), options);
+                await SendMessageAsync(reply, new InputMessagePaidMedia(starCount, [inputPaidMedia], caption, captionAboveMedia, string.Empty), options);
             }
             else if (factory is InputMessageContent input)
             {
@@ -1087,7 +1087,7 @@ namespace Telegram.ViewModels
             return SendMessageAsync(formattedText?.Text, formattedText?.Entities, linkPreview, options, reply);
         }
 
-        public async Task<Object> SendMessageAsync(string text, IList<TextEntity> entities = null, LinkPreviewOptions linkPreview = null, MessageSendOptions options = null, InputMessageReplyTo reply = null)
+        public async Task<Object> SendMessageAsync(string text, List<TextEntity> entities = null, LinkPreviewOptions linkPreview = null, MessageSendOptions options = null, InputMessageReplyTo reply = null)
         {
             text ??= string.Empty;
             text = text.Replace('\v', '\n').Replace('\r', '\n');
@@ -1214,7 +1214,7 @@ namespace Telegram.ViewModels
             await SendMessageAsync(reply, new InputMessageRichMessage(richMessage, true), options);
         }
 
-        private bool TextStillContainsEmojis(IList<TextEntity> entities)
+        private bool TextStillContainsEmojis(List<TextEntity> entities)
         {
             if (entities.Count == 0 || !Settings.Stickers.DynamicPackOrder)
             {

--- a/Telegram/ViewModels/CreateChatPhotoViewModel.cs
+++ b/Telegram/ViewModels/CreateChatPhotoViewModel.cs
@@ -23,14 +23,14 @@ namespace Telegram.ViewModels
         {
             Items = new ObservableCollection<BackgroundFill>
             {
-                new BackgroundFillFreeformGradient(new[] { 0x5A7FFF, 0x2CA0F2, 0x4DFF89, 0x6BFCEB }),
-                new BackgroundFillFreeformGradient(new[] { 0xFF011D, 0xFF530D, 0xFE64DC, 0xFFDC61 }),
-                new BackgroundFillFreeformGradient(new[] { 0xFE64DC, 0xFF6847, 0xFFDD02, 0xFFAE10 }),
-                new BackgroundFillFreeformGradient(new[] { 0x84EC00, 0x00B7C2, 0x00C217, 0xFFE600 }),
-                new BackgroundFillFreeformGradient(new[] { 0x86B0FF, 0x35FFCF, 0x69FFFF, 0x76DEFF }),
-                new BackgroundFillFreeformGradient(new[] { 0xFAE100, 0xFF54EE, 0xFC2B78, 0xFF52D9 }),
-                new BackgroundFillFreeformGradient(new[] { 0x73A4FF, 0x5F55FF, 0xFF49F8, 0xEC76FF }),
-                new BackgroundFillFreeformGradient(new[] { 0x73A4FF, 0x5F55FF, 0xFF49F8, 0xEC76FF }),
+                new BackgroundFillFreeformGradient([0x5A7FFF, 0x2CA0F2, 0x4DFF89, 0x6BFCEB]),
+                new BackgroundFillFreeformGradient([0xFF011D, 0xFF530D, 0xFE64DC, 0xFFDC61]),
+                new BackgroundFillFreeformGradient([0xFE64DC, 0xFF6847, 0xFFDD02, 0xFFAE10]),
+                new BackgroundFillFreeformGradient([0x84EC00, 0x00B7C2, 0x00C217, 0xFFE600]),
+                new BackgroundFillFreeformGradient([0x86B0FF, 0x35FFCF, 0x69FFFF, 0x76DEFF]),
+                new BackgroundFillFreeformGradient([0xFAE100, 0xFF54EE, 0xFC2B78, 0xFF52D9]),
+                new BackgroundFillFreeformGradient([0x73A4FF, 0x5F55FF, 0xFF49F8, 0xEC76FF]),
+                new BackgroundFillFreeformGradient([0x73A4FF, 0x5F55FF, 0xFF49F8, 0xEC76FF]),
             };
 
             SelectedBackground = Items[0];

--- a/Telegram/ViewModels/Delegates/ISupergroupEditDelegate.cs
+++ b/Telegram/ViewModels/Delegates/ISupergroupEditDelegate.cs
@@ -12,6 +12,6 @@ namespace Telegram.ViewModels.Delegates
 {
     public interface ISupergroupEditDelegate : ISupergroupDelegate, IBasicGroupDelegate
     {
-        void UpdateChatWelcomeMessages(Chat chat, IList<WelcomeMessage> messages);
+        void UpdateChatWelcomeMessages(Chat chat, List<WelcomeMessage> messages);
     }
 }

--- a/Telegram/ViewModels/DialogEventLogViewModel.cs
+++ b/Telegram/ViewModels/DialogEventLogViewModel.cs
@@ -259,7 +259,7 @@ namespace Telegram.ViewModels
                 {
                     case ChatEventMemberInvited memberInvited:
                         message = GetMessage(_chat.Id, channel, item);
-                        message.Content = new MessageChatAddMembers(new[] { memberInvited.UserId });
+                        message.Content = new MessageChatAddMembers([memberInvited.UserId]);
                         break;
                     case ChatEventPermissionsChanged:
                     case ChatEventMemberRestricted:
@@ -339,7 +339,7 @@ namespace Telegram.ViewModels
                         if (item.MemberId is MessageSenderUser joinedUser)
                         {
                             message = GetMessage(_chat.Id, channel, item);
-                            message.Content = new MessageChatAddMembers(new long[] { joinedUser.UserId });
+                            message.Content = new MessageChatAddMembers([joinedUser.UserId]);
                         }
                         break;
                     case ChatEventTitleChanged titleChanged:
@@ -381,7 +381,7 @@ namespace Telegram.ViewModels
             {
                 var link = string.IsNullOrEmpty(usernameChanged.NewUsername) ? string.Empty : MeUrlPrefixConverter.Convert(ClientService, usernameChanged.NewUsername);
 
-                var text = new FormattedText(link, new[] { new TextEntity(0, link.Length, new TextEntityTypeUrl()) });
+                var text = new FormattedText(link, [new TextEntity(0, link.Length, new TextEntityTypeUrl())]);
                 var linkPreview = string.IsNullOrEmpty(usernameChanged.OldUsername) ? null : new LinkPreview { SiteName = Strings.EventLogPreviousLink, Description = MeUrlPrefixConverter.Convert(ClientService, usernameChanged.OldUsername).AsFormattedText() };
 
                 return new MessageText(text, linkPreview, null);

--- a/Telegram/ViewModels/DialogViewModel.Handle.cs
+++ b/Telegram/ViewModels/DialogViewModel.Handle.cs
@@ -1174,7 +1174,7 @@ namespace Telegram.ViewModels
                     }
                     else
                     {
-                        Handle(new UpdateDeleteMessages(update.ChatId, new[] { update.MessageId }, true, false));
+                        Handle(new UpdateDeleteMessages(update.ChatId, [update.MessageId], true, false));
                     }
                 }
                 else
@@ -1228,7 +1228,7 @@ namespace Telegram.ViewModels
         {
             if (update.Message.ChatId == _chat?.Id && Type == DialogType.History && update.Message.SchedulingState is MessageSchedulingStateSendWhenVideoProcessed)
             {
-                Handle(new UpdateDeleteMessages(update.Message.ChatId, new[] { update.OldMessageId }, true, false));
+                Handle(new UpdateDeleteMessages(update.Message.ChatId, [update.OldMessageId], true, false));
                 BeginOnUIThread(() =>
                 {
                     NavigationService.NavigateToChat(_chat, update.Message.Id, scheduled: true);

--- a/Telegram/ViewModels/DialogViewModel.Messages.cs
+++ b/Telegram/ViewModels/DialogViewModel.Messages.cs
@@ -2105,7 +2105,7 @@ namespace Telegram.ViewModels
             var title = Strings.SoundAdded + Environment.NewLine + Strings.SoundAddedSubtitle;
             var entity = new TextEntity(0, Strings.SoundAdded.Length, new TextEntityTypeBold());
 
-            var temp = new FormattedText(title, new[] { entity });
+            var temp = new FormattedText(title, [entity]);
             var markdown = ClientEx.ParseMarkdown(temp);
 
             ToastPopup.Show(XamlRoot, markdown, ToastPopupIcon.SoundDownload);
@@ -2376,7 +2376,7 @@ namespace Telegram.ViewModels
                     receivedGift = await ClientService.SendAsync(new GetReceivedGift(gift.ReceivedGiftId)) as ReceivedGift;
                 }
 
-                receivedGift ??= new ReceivedGift(gift.ReceivedGiftId, gift.SenderId, gift.Text, gift.UniqueGiftNumber, gift.IsPrivate, gift.IsSaved, false, gift.CanBeUpgraded && !gift.WasUpgraded, false, gift.WasRefunded, message.Date, new SentGiftRegular(gift.Gift), Array.Empty<int>(), gift.SellStarCount, gift.PrepaidUpgradeStarCount, gift.IsUpgradeSeparate, 0, 0, 0, 0, 0, gift.PrepaidUpgradeHash, 0);
+                receivedGift ??= new ReceivedGift(gift.ReceivedGiftId, gift.SenderId, gift.Text, gift.UniqueGiftNumber, gift.IsPrivate, gift.IsSaved, false, gift.CanBeUpgraded && !gift.WasUpgraded, false, gift.WasRefunded, message.Date, new SentGiftRegular(gift.Gift), [], gift.SellStarCount, gift.PrepaidUpgradeStarCount, gift.IsUpgradeSeparate, 0, 0, 0, 0, 0, gift.PrepaidUpgradeHash, 0);
 
                 ShowPopup(new ReceivedGiftPopup(ClientService, NavigationService, receivedGift, gift.ReceiverId, null));
             }
@@ -2388,7 +2388,7 @@ namespace Telegram.ViewModels
                     receivedGift = await ClientService.SendAsync(new GetReceivedGift(upgradedGift.ReceivedGiftId)) as ReceivedGift;
                 }
 
-                receivedGift ??= new ReceivedGift(upgradedGift.ReceivedGiftId, upgradedGift.SenderId, upgradedGift.Gift.OriginalDetails?.Text ?? string.Empty.AsFormattedText(), 0, true, upgradedGift.IsSaved, false, false, upgradedGift.CanBeTransferred, false, message.Date, new SentGiftUpgraded(upgradedGift.Gift), Array.Empty<int>(), 0, 0, false, upgradedGift.TransferStarCount, upgradedGift.DropOriginalDetailsStarCount, upgradedGift.NextTransferDate, upgradedGift.NextResaleDate, upgradedGift.ExportDate, string.Empty, upgradedGift.CraftDate);
+                receivedGift ??= new ReceivedGift(upgradedGift.ReceivedGiftId, upgradedGift.SenderId, upgradedGift.Gift.OriginalDetails?.Text ?? string.Empty.AsFormattedText(), 0, true, upgradedGift.IsSaved, false, false, upgradedGift.CanBeTransferred, false, message.Date, new SentGiftUpgraded(upgradedGift.Gift), [], 0, 0, false, upgradedGift.TransferStarCount, upgradedGift.DropOriginalDetailsStarCount, upgradedGift.NextTransferDate, upgradedGift.NextResaleDate, upgradedGift.ExportDate, string.Empty, upgradedGift.CraftDate);
 
                 ShowPopup(new ReceivedGiftPopup(ClientService, NavigationService, receivedGift, upgradedGift.ReceiverId, null));
             }

--- a/Telegram/ViewModels/DialogViewModel.cs
+++ b/Telegram/ViewModels/DialogViewModel.cs
@@ -632,7 +632,7 @@ namespace Telegram.ViewModels
             }
         }
 
-        public void SetText(string text, IList<TextEntity> entities = null, bool focus = false)
+        public void SetText(string text, List<TextEntity> entities = null, bool focus = false)
         {
             var field = TextField;
             if (field == null)
@@ -1982,7 +1982,7 @@ namespace Telegram.ViewModels
                 else if (message.Content is MessageContact contact && contact.Contact.PhoneNumber == "999888777666")
                 {
                     message.SenderId = new MessageSenderUser(contact.Contact.UserId);
-                    message.Content = new MessageChatAddMembers(new[] { contact.Contact.UserId });
+                    message.Content = new MessageChatAddMembers([contact.Contact.UserId]);
                 }
 
                 if (message.EffectId != 0)
@@ -2226,7 +2226,7 @@ namespace Telegram.ViewModels
                         }
                         else if (story.Content is StoryContentVideo video)
                         {
-                            message.GeneratedContent = new MessageVideo(new Video((int)video.Video.Duration, video.Video.Width, video.Video.Height, "video.mp4", "video/mp4", video.Video.HasStickers, true, video.Video.Minithumbnail, video.Video.Thumbnail, video.Video.Video), Array.Empty<AlternativeVideo>(), Array.Empty<VideoStoryboard>(), null, 0, null, false, false, false);
+                            message.GeneratedContent = new MessageVideo(new Video((int)video.Video.Duration, video.Video.Width, video.Video.Height, "video.mp4", "video/mp4", video.Video.HasStickers, true, video.Video.Minithumbnail, video.Video.Thumbnail, video.Video.Video), [], [], null, 0, null, false, false, false);
                         }
                     }
                     else
@@ -3662,7 +3662,7 @@ namespace Telegram.ViewModels
         /// spliced in — where a paste ends up when the pasted content says more than a
         /// message's text and entities can.
         /// </summary>
-        public void PasteRichMessage(FormattedText before, IList<PageBlock> blocks, FormattedText after)
+        public void PasteRichMessage(FormattedText before, List<PageBlock> blocks, FormattedText after)
         {
             var composed = new List<PageBlock>();
 

--- a/Telegram/ViewModels/Dialogs/DialogPendingTextMessage.cs
+++ b/Telegram/ViewModels/Dialogs/DialogPendingTextMessage.cs
@@ -504,7 +504,7 @@ namespace Telegram.ViewModels
             return total;
         }
 
-        private static int LengthTableCells(IList<IList<PageBlockTableCell>> rows)
+        private static int LengthTableCells(List<List<PageBlockTableCell>> rows)
         {
             int total = 0;
             if (rows != null)
@@ -887,9 +887,9 @@ namespace Telegram.ViewModels
             return result;
         }
 
-        private static IList<IList<PageBlockTableCell>> SubstringTableCells(IList<IList<PageBlockTableCell>> rows, ref int remaining)
+        private static List<List<PageBlockTableCell>> SubstringTableCells(List<List<PageBlockTableCell>> rows, ref int remaining)
         {
-            var result = new List<IList<PageBlockTableCell>>();
+            var result = new List<List<PageBlockTableCell>>();
             if (rows == null) return result;
             foreach (var row in rows)
             {

--- a/Telegram/ViewModels/Dialogs/DialogPendingTextMessage.cs
+++ b/Telegram/ViewModels/Dialogs/DialogPendingTextMessage.cs
@@ -286,13 +286,13 @@ namespace Telegram.ViewModels
 
     public class DialogPendingRichMessage : DialogPendingMessage
     {
-        private IList<PageBlock> _text;
-        private IList<PageBlock> _pending;
+        private List<PageBlock> _text;
+        private List<PageBlock> _pending;
 
         public DialogPendingRichMessage(UpdatePendingMessage update, MessageViewModel message)
             : base(update, message)
         {
-            _text = Array.Empty<PageBlock>();
+            _text = [];
             _textLength = 0;
 
             if (update.Content is MessageRichMessage messageRich)
@@ -320,7 +320,7 @@ namespace Telegram.ViewModels
             }
         }
 
-        private void Update(IList<PageBlock> blocks)
+        private void Update(List<PageBlock> blocks)
         {
             //if (text == null)
             //{
@@ -371,7 +371,7 @@ namespace Telegram.ViewModels
 
     public static class PageBlockStreaming
     {
-        public static int Length(IList<PageBlock> blocks)
+        public static int Length(List<PageBlock> blocks)
         {
             int total = 0;
             if (blocks != null)
@@ -491,7 +491,7 @@ namespace Telegram.ViewModels
             return 0;
         }
 
-        private static int LengthListItems(IList<PageBlockListItem> items)
+        private static int LengthListItems(List<PageBlockListItem> items)
         {
             int total = 0;
             if (items != null)
@@ -521,7 +521,7 @@ namespace Telegram.ViewModels
             return total;
         }
 
-        private static int LengthRelatedArticles(IList<PageBlockRelatedArticle> articles)
+        private static int LengthRelatedArticles(List<PageBlockRelatedArticle> articles)
         {
             int total = 0;
             if (articles != null)
@@ -541,13 +541,13 @@ namespace Telegram.ViewModels
         // Substring
         // ============================================================
 
-        public static IList<PageBlock> Substring(IList<PageBlock> blocks, int length)
+        public static List<PageBlock> Substring(List<PageBlock> blocks, int length)
         {
             int remaining = length;
             return SubstringList(blocks, ref remaining);
         }
 
-        private static IList<PageBlock> SubstringList(IList<PageBlock> blocks, ref int remaining)
+        private static List<PageBlock> SubstringList(List<PageBlock> blocks, ref int remaining)
         {
             var result = new List<PageBlock>();
             if (blocks == null) return result;
@@ -859,7 +859,7 @@ namespace Telegram.ViewModels
             return new PageBlockCaption(text, credit);
         }
 
-        private static IList<PageBlockListItem> SubstringListItems(IList<PageBlockListItem> items, ref int remaining)
+        private static List<PageBlockListItem> SubstringListItems(List<PageBlockListItem> items, ref int remaining)
         {
             var result = new List<PageBlockListItem>();
             if (items == null) return result;
@@ -917,7 +917,7 @@ namespace Telegram.ViewModels
             return result;
         }
 
-        private static IList<PageBlockRelatedArticle> SubstringRelatedArticles(IList<PageBlockRelatedArticle> articles, ref int remaining)
+        private static List<PageBlockRelatedArticle> SubstringRelatedArticles(List<PageBlockRelatedArticle> articles, ref int remaining)
         {
             var result = new List<PageBlockRelatedArticle>();
             if (articles == null) return result;

--- a/Telegram/ViewModels/Dialogs/DialogUnreadMessagesViewModel.cs
+++ b/Telegram/ViewModels/Dialogs/DialogUnreadMessagesViewModel.cs
@@ -86,10 +86,10 @@ namespace Telegram.ViewModels
 
                     if (_oldToNew)
                     {
-                        foreach (var message in messages.Messages.Reverse())
+                        for (int i = messages.Messages.Count - 1; i >= 0; i--)
                         {
                             stack ??= new List<long>();
-                            stack.Add(message.Id);
+                            stack.Add(messages.Messages[i].Id);
                         }
                     }
                     else

--- a/Telegram/ViewModels/Drawers/EmojiDrawerViewModel.cs
+++ b/Telegram/ViewModels/Drawers/EmojiDrawerViewModel.cs
@@ -546,8 +546,8 @@ namespace Telegram.ViewModels.Drawers
             var select = available.AllowCustomEmoji || sum > 7;
             var count = select ? 6 : 7;
 
-            IList<AvailableReaction> source = available.TopReactions.Take(count).ToList();
-            IList<AvailableReaction> additional = available.RecentReactions.Count > 0
+            List<AvailableReaction> source = available.TopReactions.Take(count).ToList();
+            List<AvailableReaction> additional = available.RecentReactions.Count > 0
                 ? available.RecentReactions
                 : available.PopularReactions;
 
@@ -605,7 +605,7 @@ namespace Telegram.ViewModels.Drawers
 
             var visible = new List<(AvailableReaction, Sticker)>();
 
-            void Populate(IList<AvailableReaction> source, List<(AvailableReaction, Sticker)> target)
+            void Populate(List<AvailableReaction> source, List<(AvailableReaction, Sticker)> target)
             {
                 foreach (var item in source)
                 {
@@ -632,7 +632,7 @@ namespace Telegram.ViewModels.Drawers
             return visible;
         }
 
-        private async void ContinueReactions(AvailableReactions available, IList<AvailableReaction> source, IList<AvailableReaction> sourceRecent)
+        private async void ContinueReactions(AvailableReactions available, List<AvailableReaction> source, List<AvailableReaction> sourceRecent)
         {
             if (available == null)
             {
@@ -664,7 +664,7 @@ namespace Telegram.ViewModels.Drawers
             var top = new List<StickerViewModel>();
             var recent = new List<StickerViewModel>();
 
-            void Populate(IList<AvailableReaction> source, List<StickerViewModel> target)
+            void Populate(List<AvailableReaction> source, List<StickerViewModel> target)
             {
                 foreach (var item in source)
                 {

--- a/Telegram/ViewModels/Drawers/EmojiDrawerViewModel.cs
+++ b/Telegram/ViewModels/Drawers/EmojiDrawerViewModel.cs
@@ -400,9 +400,9 @@ namespace Telegram.ViewModels.Drawers
             var recentResponse = await ClientService.SendAsync(new GetRecentEmojiStatuses()) as EmojiStatusCustomEmojis;
             var defaulResponse = await ClientService.SendAsync(new GetDefaultEmojiStatuses()) as EmojiStatusCustomEmojis;
 
-            var themed = themedResponse?.CustomEmojiIds ?? Array.Empty<long>();
-            var recent = recentResponse?.CustomEmojiIds ?? Array.Empty<long>();
-            var defaul = defaulResponse?.CustomEmojiIds ?? Array.Empty<long>();
+            var themed = themedResponse?.CustomEmojiIds ?? Enumerable.Empty<long>();
+            var recent = recentResponse?.CustomEmojiIds ?? Enumerable.Empty<long>();
+            var defaul = defaulResponse?.CustomEmojiIds ?? Enumerable.Empty<long>();
 
             var emoji = new List<long>();
             var delay = new List<long>();
@@ -436,10 +436,10 @@ namespace Telegram.ViewModels.Drawers
 
             var disallowedResponse = await ClientService.SendAsync(new GetDisallowedChatEmojiStatuses()) as EmojiStatusCustomEmojis;
 
-            var themed = themedResponse?.CustomEmojiIds ?? Array.Empty<long>();
-            var recent = recentResponse?.CustomEmojiIds ?? Array.Empty<long>();
-            var defaul = defaulResponse?.CustomEmojiIds ?? Array.Empty<long>();
-            var disall = disallowedResponse?.CustomEmojiIds ?? Array.Empty<long>();
+            var themed = themedResponse?.CustomEmojiIds ?? Enumerable.Empty<long>();
+            var recent = recentResponse?.CustomEmojiIds ?? Enumerable.Empty<long>();
+            var defaul = defaulResponse?.CustomEmojiIds ?? Enumerable.Empty<long>();
+            var disall = disallowedResponse?.CustomEmojiIds ?? Enumerable.Empty<long>();
 
             var emoji = new List<long>();
             var delay = new List<long>();

--- a/Telegram/ViewModels/Drawers/StickerDrawerViewModel.cs
+++ b/Telegram/ViewModels/Drawers/StickerDrawerViewModel.cs
@@ -240,7 +240,7 @@ namespace Telegram.ViewModels.Drawers
                 {
                     items.Add(new StickerSetViewModel(ClientService,
                         new StickerSetInfo(0, string.Empty, "emoji", null, null, false, false, false, false, new StickerTypeRegular(), false, false, false, stickers.StickersValue.Count, stickers.StickersValue),
-                        new StickerSet(0, string.Empty, "emoji", null, null, false, false, false, false, new StickerTypeRegular(), false, false, false, stickers.StickersValue, Array.Empty<Emojis>())));
+                        new StickerSet(0, string.Empty, "emoji", null, null, false, false, false, false, new StickerTypeRegular(), false, false, false, stickers.StickersValue, [])));
                 }
             }
         }
@@ -755,7 +755,7 @@ namespace Telegram.ViewModels.Drawers
                     {
                         Add(new StickerSetViewModel(_clientService,
                             new StickerSetInfo(0, string.Empty, "emoji", null, null, false, false, false, false, _type, false, false, false, stickers.StickersValue.Count, stickers.StickersValue),
-                            new StickerSet(0, string.Empty, "emoji", null, null, false, false, false, false, _type, false, false, false, stickers.StickersValue, Array.Empty<Emojis>())));
+                            new StickerSet(0, string.Empty, "emoji", null, null, false, false, false, false, _type, false, false, false, stickers.StickersValue, [])));
                     }
                 }
                 else if (phase == 1 && _query.Length > 1 && !_emojiOnly)
@@ -767,7 +767,7 @@ namespace Telegram.ViewModels.Drawers
                         {
                             Add(new StickerSetViewModel(_clientService,
                                 new StickerSetInfo(0, _query, "emoji", null, null, false, false, false, false, _type, false, false, false, stickers.StickersValue.Count, stickers.StickersValue),
-                                new StickerSet(0, _query, "emoji", null, null, false, false, false, false, _type, false, false, false, stickers.StickersValue, Array.Empty<Emojis>())));
+                                new StickerSet(0, _query, "emoji", null, null, false, false, false, false, _type, false, false, false, stickers.StickersValue, [])));
                         }
                     }
                     else
@@ -807,7 +807,7 @@ namespace Telegram.ViewModels.Drawers
 
                             Add(new StickerSetViewModel(_clientService,
                                 new StickerSetInfo(0, string.Empty, "emoji", null, null, false, false, false, false, _type, false, false, false, items.Count, items),
-                                new StickerSet(0, string.Empty, "emoji", null, null, false, false, false, false, _type, false, false, false, items, Array.Empty<Emojis>())));
+                                new StickerSet(0, string.Empty, "emoji", null, null, false, false, false, false, _type, false, false, false, items, [])));
                         }
                     }
                 }

--- a/Telegram/ViewModels/Folders/ShareFolderViewModel.cs
+++ b/Telegram/ViewModels/Folders/ShareFolderViewModel.cs
@@ -43,7 +43,7 @@ namespace Telegram.ViewModels.Folders
                 {
                     Name = folder.Name;
 
-                    var ids = new List<long>(data.Item2?.ChatIds ?? Array.Empty<long>());
+                    var ids = data.Item2?.ChatIds is { } chatIds ? new List<long>(chatIds) : new List<long>();
 
                     foreach (var id in folder.IncludedChatIds)
                     {

--- a/Telegram/ViewModels/Gallery/GalleryAnimation.cs
+++ b/Telegram/ViewModels/Gallery/GalleryAnimation.cs
@@ -47,7 +47,7 @@ namespace Telegram.ViewModels.Gallery
 
         public override InputMessageContent ToInput()
         {
-            return new InputMessageAnimation(new InputAnimation(new InputFileId(_animation.AnimationValue.Id), _animation.Thumbnail?.ToInput(), Array.Empty<int>(), _animation.Duration, _animation.Width, _animation.Height), null, false, false);
+            return new InputMessageAnimation(new InputAnimation(new InputFileId(_animation.AnimationValue.Id), _animation.Thumbnail?.ToInput(), [], _animation.Duration, _animation.Width, _animation.Height), null, false, false);
         }
     }
 }

--- a/Telegram/ViewModels/Gallery/GalleryChatPhoto.cs
+++ b/Telegram/ViewModels/Gallery/GalleryChatPhoto.cs
@@ -74,7 +74,7 @@ namespace Telegram.ViewModels.Gallery
                 //return new InputMessageAnimation(new InputFileId(_photo.Animation.File.Id), small?.ToInputThumbnail(), Array.Empty<int>(), ?, _photo.Animation.Length, _photo.Animation.Length, null);
             }
 
-            return new InputMessagePhoto(new InputPhoto(new InputFileId(big.Photo.Id), small?.ToInputThumbnail(), null, Array.Empty<int>(), big.Width, big.Height), null, false, null, false);
+            return new InputMessagePhoto(new InputPhoto(new InputFileId(big.Photo.Id), small?.ToInputThumbnail(), null, [], big.Width, big.Height), null, false, null, false);
         }
     }
 }

--- a/Telegram/ViewModels/Gallery/GalleryPhoto.cs
+++ b/Telegram/ViewModels/Gallery/GalleryPhoto.cs
@@ -46,7 +46,7 @@ namespace Telegram.ViewModels.Gallery
             var big = _photo.GetBig();
             var small = _photo.GetSmall();
 
-            return new InputMessagePhoto(new InputPhoto(new InputFileId(big.Photo.Id), small?.ToInputThumbnail(), null, Array.Empty<int>(), big.Width, big.Height), null, false, null, false);
+            return new InputMessagePhoto(new InputPhoto(new InputFileId(big.Photo.Id), small?.ToInputThumbnail(), null, [], big.Width, big.Height), null, false, null, false);
         }
     }
 }

--- a/Telegram/ViewModels/Gallery/GalleryVideo.cs
+++ b/Telegram/ViewModels/Gallery/GalleryVideo.cs
@@ -50,7 +50,7 @@ namespace Telegram.ViewModels.Gallery
 
         public override InputMessageContent ToInput()
         {
-            return new InputMessageVideo(new InputVideo(new InputFileId(_video.VideoValue.Id), _video.Thumbnail?.ToInput(), null, 0, Array.Empty<int>(), _video.Duration, _video.Width, _video.Height, _video.SupportsStreaming), null, false, null, false);
+            return new InputMessageVideo(new InputVideo(new InputFileId(_video.VideoValue.Id), _video.Thumbnail?.ToInput(), null, 0, [], _video.Duration, _video.Width, _video.Height, _video.SupportsStreaming), null, false, null, false);
         }
     }
 }

--- a/Telegram/ViewModels/InstantViewModel.cs
+++ b/Telegram/ViewModels/InstantViewModel.cs
@@ -67,7 +67,7 @@ namespace Telegram.ViewModels
         /// built from these on demand (see MessageDelegate.OpenPageBlockMedia) rather than
         /// collected while rendering, so nothing has to be kept in sync.
         /// </summary>
-        public IList<PageBlock> Blocks { get; set; }
+        public List<PageBlock> Blocks { get; set; }
 
         public MessageViewModel CreateMessage(Message message)
         {

--- a/Telegram/ViewModels/MainViewModel.cs
+++ b/Telegram/ViewModels/MainViewModel.cs
@@ -226,7 +226,7 @@ namespace Telegram.ViewModels
             BeginOnUIThread(() => UpdateChatFolders(update.ChatFolders, update.MainChatListPosition));
         }
 
-        private void UpdateChatFolders(IList<ChatFolderInfo> chatFolders, int mainChatListPosition)
+        private void UpdateChatFolders(List<ChatFolderInfo> chatFolders, int mainChatListPosition)
         {
             if (chatFolders.Count > 0)
             {
@@ -277,7 +277,7 @@ namespace Telegram.ViewModels
             Chats.Delegate?.UpdateChatFoldersLayout();
         }
 
-        private void Merge(IList<ChatFolderViewModel> destination, IList<ChatFolderInfo> origin, int selectedFolderId, out bool updateSelection)
+        private void Merge(IList<ChatFolderViewModel> destination, List<ChatFolderInfo> origin, int selectedFolderId, out bool updateSelection)
         {
             updateSelection = false;
 
@@ -455,7 +455,7 @@ namespace Telegram.ViewModels
             var message = Strings.UnconfirmedAuthConfirmed + Environment.NewLine + Strings.UnconfirmedAuthConfirmedMessage;
             var entity = new TextEntity(0, Strings.RequestToJoinSent.Length, new TextEntityTypeBold());
 
-            var markdown = new FormattedText(message, new[] { entity });
+            var markdown = new FormattedText(message, [entity]);
             var text = ClientEx.ParseMarkdown(markdown);
 
             ToastPopup.Show(NavigationService.XamlRoot, text, ToastPopupIcon.Success);

--- a/Telegram/ViewModels/MessageDelegate.cs
+++ b/Telegram/ViewModels/MessageDelegate.cs
@@ -540,7 +540,7 @@ namespace Telegram.ViewModels
         /// the tapped element finds its own block by walking up the Tag chain. That's what
         /// lets one renderer serve both hosts.
         /// </summary>
-        protected void OpenPageBlockMedia(IList<PageBlock> blocks, PageBlockMediaKind kind, FrameworkElement target)
+        protected void OpenPageBlockMedia(List<PageBlock> blocks, PageBlockMediaKind kind, FrameworkElement target)
         {
             var gallery = new InstantGalleryViewModel(ClientService,
                 ClientService.Session.Resolve<IStorageService>(),

--- a/Telegram/ViewModels/MessageViewModel.cs
+++ b/Telegram/ViewModels/MessageViewModel.cs
@@ -567,7 +567,7 @@ namespace Telegram.ViewModels
         public FactCheck FactCheck { get; set; }
         public MessageForwardInfo ForwardInfo { get; protected set; }
         public MessageImportInfo ImportInfo { get; protected set; }
-        public IList<UnreadReaction> UnreadReactions { get; set; }
+        public List<UnreadReaction> UnreadReactions { get; set; }
         public int EditDate { get; set; }
         public int Date { get; protected set; }
         public bool ContainsUnreadMention { get; set; }

--- a/Telegram/ViewModels/ProfileViewModel.cs
+++ b/Telegram/ViewModels/ProfileViewModel.cs
@@ -1077,7 +1077,7 @@ namespace Telegram.ViewModels
                 var confirm = await ShowPopupAsync(popup);
                 if (confirm == ContentDialogResult.Primary)
                 {
-                    ClientService.Send(new SetUserPrivacySettingRules(new UserPrivacySettingShowStatus(), new UserPrivacySettingRules(new UserPrivacySettingRule[] { new UserPrivacySettingRuleAllowAll() })));
+                    ClientService.Send(new SetUserPrivacySettingRules(new UserPrivacySettingShowStatus(), new UserPrivacySettingRules([new UserPrivacySettingRuleAllowAll()])));
                     ShowToast(Strings.PremiumLastSeenSet, ToastPopupIcon.Info);
                 }
                 else if (confirm == ContentDialogResult.Secondary && IsPremiumAvailable && !IsPremium)

--- a/Telegram/ViewModels/Settings/Privacy/SettingsPrivacyViewModelBase.cs
+++ b/Telegram/ViewModels/Settings/Privacy/SettingsPrivacyViewModelBase.cs
@@ -225,13 +225,13 @@ namespace Telegram.ViewModels.Settings
 
             _cached = rules;
 
-            _restrictedUsers = restrictedUsers ?? new UserPrivacySettingRuleRestrictUsers(Array.Empty<long>());
-            _restrictedChatMembers = restrictedChatMembers ?? new UserPrivacySettingRuleRestrictChatMembers(Array.Empty<long>());
+            _restrictedUsers = restrictedUsers ?? new UserPrivacySettingRuleRestrictUsers([]);
+            _restrictedChatMembers = restrictedChatMembers ?? new UserPrivacySettingRuleRestrictChatMembers([]);
 
             _restrictedBots = restrictedBots;
 
-            _allowedUsers = allowedUsers ?? new UserPrivacySettingRuleAllowUsers(Array.Empty<long>());
-            _allowedChatMembers = allowedChatMembers ?? new UserPrivacySettingRuleAllowChatMembers(Array.Empty<long>());
+            _allowedUsers = allowedUsers ?? new UserPrivacySettingRuleAllowUsers([]);
+            _allowedChatMembers = allowedChatMembers ?? new UserPrivacySettingRuleAllowChatMembers([]);
 
             _allowedPremium = allowedPremium;
             _allowedBots = allowedBots;

--- a/Telegram/ViewModels/Settings/SettingsAppearanceViewModel.cs
+++ b/Telegram/ViewModels/Settings/SettingsAppearanceViewModel.cs
@@ -58,7 +58,7 @@ namespace Telegram.ViewModels.Settings
         {
             static Background GetDefaultBackground(bool dark)
             {
-                var freeform = dark ? new[] { 0x6C7FA6, 0x2E344B, 0x7874A7, 0x333258 } : new[] { 0xDBDDBB, 0x6BA587, 0xD5D88D, 0x88B884 };
+                List<int> freeform = dark ? [0x6C7FA6, 0x2E344B, 0x7874A7, 0x333258] : [0xDBDDBB, 0x6BA587, 0xD5D88D, 0x88B884];
                 return new Background(0, true, dark, string.Empty,
                     new Document(string.Empty, "application/x-tgwallpattern", null, null, TdExtensions.GetLocalFile("Assets\\Background.tgv", "Background")),
                     new BackgroundTypePattern(new BackgroundFillFreeformGradient(freeform), dark ? 100 : 50, dark, false));

--- a/Telegram/ViewModels/Settings/SettingsBackgroundsViewModel.cs
+++ b/Telegram/ViewModels/Settings/SettingsBackgroundsViewModel.cs
@@ -46,7 +46,7 @@ namespace Telegram.ViewModels.Settings
             }
 
             var dark = Settings.Appearance.IsDarkTheme();
-            var freeform = dark ? new[] { 0x6C7FA6, 0x2E344B, 0x7874A7, 0x333258 } : new[] { 0xDBDDBB, 0x6BA587, 0xD5D88D, 0x88B884 };
+            List<int> freeform = dark ? [0x6C7FA6, 0x2E344B, 0x7874A7, 0x333258] : [0xDBDDBB, 0x6BA587, 0xD5D88D, 0x88B884];
 
             var background = ClientService.DefaultBackground;
             var predefined = new Background(Constants.WallpaperColorId, true, dark, string.Empty,

--- a/Telegram/ViewModels/Settings/SettingsPrivacyAndSecurityViewModel.cs
+++ b/Telegram/ViewModels/Settings/SettingsPrivacyAndSecurityViewModel.cs
@@ -262,10 +262,9 @@ namespace Telegram.ViewModels.Settings
 
             if (first != -1 && last != -1)
             {
-                var formatted = new FormattedText(pattern, new[]
-                {
+                var formatted = new FormattedText(pattern, [
                     new TextEntity(first, last - first + 1, new TextEntityTypeSpoiler())
-                });
+                ]);
 
                 return formatted;
             }

--- a/Telegram/ViewModels/Settings/SettingsUsernameViewModel.cs
+++ b/Telegram/ViewModels/Settings/SettingsUsernameViewModel.cs
@@ -72,7 +72,7 @@ namespace Telegram.ViewModels.Settings
         {
             if (editable != null)
             {
-                static IList<string> ReplaceEditable(IList<string> usernames, string original, string editable)
+                static string[] ReplaceEditable(IList<string> usernames, string original, string editable)
                 {
                     if (usernames == null)
                     {
@@ -99,8 +99,8 @@ namespace Telegram.ViewModels.Settings
 
                 usernames = new Usernames
                 {
-                    ActiveUsernames = ReplaceEditable(usernames?.ActiveUsernames, usernames?.EditableUsername, editable),
-                    DisabledUsernames = ReplaceEditable(usernames?.DisabledUsernames, usernames?.EditableUsername, editable),
+                    ActiveUsernames = [.. ReplaceEditable(usernames?.ActiveUsernames, usernames?.EditableUsername, editable)],
+                    DisabledUsernames = [.. ReplaceEditable(usernames?.DisabledUsernames, usernames?.EditableUsername, editable)],
                     EditableUsername = editable
                 };
             }

--- a/Telegram/ViewModels/Stories/ActiveStoriesViewModel.cs
+++ b/Telegram/ViewModels/Stories/ActiveStoriesViewModel.cs
@@ -192,7 +192,7 @@ namespace Telegram.ViewModels.Stories
 
         public override FormattedText GetFormattedText(bool clear, bool parseMarkdown)
         {
-            return new FormattedText(string.Empty, Array.Empty<TextEntity>());
+            return new FormattedText(string.Empty, []);
         }
 
         protected override void SetFormattedText(FormattedText text)

--- a/Telegram/ViewModels/Supergroups/SupergroupEditViewModelBase.cs
+++ b/Telegram/ViewModels/Supergroups/SupergroupEditViewModelBase.cs
@@ -201,7 +201,7 @@ namespace Telegram.ViewModels.Supergroups
 
             if (editable != null)
             {
-                static IList<string> ReplaceEditable(IList<string> usernames, string original, string editable)
+                static string[] ReplaceEditable(IList<string> usernames, string original, string editable)
                 {
                     if (usernames == null)
                     {
@@ -228,8 +228,8 @@ namespace Telegram.ViewModels.Supergroups
 
                 usernames = new Usernames
                 {
-                    ActiveUsernames = ReplaceEditable(usernames?.ActiveUsernames, usernames?.EditableUsername, editable),
-                    DisabledUsernames = ReplaceEditable(usernames?.DisabledUsernames, usernames?.EditableUsername, editable),
+                    ActiveUsernames = [.. ReplaceEditable(usernames?.ActiveUsernames, usernames?.EditableUsername, editable)],
+                    DisabledUsernames = [.. ReplaceEditable(usernames?.DisabledUsernames, usernames?.EditableUsername, editable)],
                     EditableUsername = editable
                 };
             }

--- a/Telegram/ViewModels/Supergroups/SupergroupReactionsViewModel.cs
+++ b/Telegram/ViewModels/Supergroups/SupergroupReactionsViewModel.cs
@@ -214,7 +214,7 @@ namespace Telegram.ViewModels.Supergroups
             ChatAvailableReactions value = _available switch
             {
                 SupergroupAvailableReactions.All => new ChatAvailableReactionsAll(),
-                SupergroupAvailableReactions.None => new ChatAvailableReactionsSome(Array.Empty<ReactionType>(), maxReactionCount),
+                SupergroupAvailableReactions.None => new ChatAvailableReactionsSome([], maxReactionCount),
                 SupergroupAvailableReactions.Some => new ChatAvailableReactionsSome(items, maxReactionCount),
                 _ => null
             };

--- a/Telegram/ViewModels/Users/UserPhotosViewModel.cs
+++ b/Telegram/ViewModels/Users/UserPhotosViewModel.cs
@@ -45,11 +45,11 @@ namespace Telegram.ViewModels.Users
                     Id = userFull.Photo.Id,
                     AddedDate = userFull.Photo.AddedDate,
                     Minithumbnail = userFull.Photo.Minithumbnail,
-                    Sizes = new[]
-                    {
+                    Sizes =
+                    [
                         new PhotoSize("x", user.ProfilePhoto.Small, 160, 160, Array.Empty<int>()),
                         new PhotoSize("y", user.ProfilePhoto.Big, 640, 640, Array.Empty<int>())
-                    },
+                    ],
                     Animation = userFull.Photo.Animation,
                     SmallAnimation = userFull.Photo.SmallAnimation,
                     Sticker = userFull.Photo.Sticker

--- a/Telegram/ViewModels/Users/UserPhotosViewModel.cs
+++ b/Telegram/ViewModels/Users/UserPhotosViewModel.cs
@@ -47,8 +47,8 @@ namespace Telegram.ViewModels.Users
                     Minithumbnail = userFull.Photo.Minithumbnail,
                     Sizes =
                     [
-                        new PhotoSize("x", user.ProfilePhoto.Small, 160, 160, Array.Empty<int>()),
-                        new PhotoSize("y", user.ProfilePhoto.Big, 640, 640, Array.Empty<int>())
+                        new PhotoSize("x", user.ProfilePhoto.Small, 160, 160, []),
+                        new PhotoSize("y", user.ProfilePhoto.Big, 640, 640, [])
                     ],
                     Animation = userFull.Photo.Animation,
                     SmallAnimation = userFull.Photo.SmallAnimation,

--- a/Telegram/Views/Calls/VoipPage.xaml.cs
+++ b/Telegram/Views/Calls/VoipPage.xaml.cs
@@ -8,6 +8,7 @@
 using Microsoft.Graphics.Canvas.Geometry;
 using Microsoft.UI.Xaml.Controls;
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using Telegram.Common;
 using Telegram.Composition;
@@ -44,9 +45,9 @@ namespace Telegram.Views.Calls
 
     public sealed partial class VoipPage : WindowEx, IPopupHost
     {
-        private static readonly int[] _pendingGradient = new[] { 0x568FD6, 0x626ED5, 0xA667D5, 0x7664DA };
-        private static readonly int[] _readyGradient = new[] { 0xACBD65, 0x459F8D, 0x53A4D1, 0x3E917A };
-        private static readonly int[] _errorGradient = new[] { 0xC0508D, 0xF09536, 0xCE5081, 0xFC7C4C };
+        private static readonly List<int> _pendingGradient = [0x568FD6, 0x626ED5, 0xA667D5, 0x7664DA];
+        private static readonly List<int> _readyGradient = [0xACBD65, 0x459F8D, 0x53A4D1, 0x3E917A];
+        private static readonly List<int> _errorGradient = [0xC0508D, 0xF09536, 0xCE5081, 0xFC7C4C];
 
         private readonly VoipCall _call;
 

--- a/Telegram/Views/ChatView.xaml.cs
+++ b/Telegram/Views/ChatView.xaml.cs
@@ -3812,7 +3812,7 @@ namespace Telegram.Views
 
         private async void LoadMessageViewers(MessageViewModel message, MessageProperties properties, MenuFlyout flyout)
         {
-            static async Task<IList<MessageViewer>> GetMessageViewersAsync(MessageViewModel message, MessageProperties properties)
+            static async Task<List<MessageViewer>> GetMessageViewersAsync(MessageViewModel message, MessageProperties properties)
             {
                 if (CanGetMessageViewers(message, properties, false))
                 {
@@ -3823,7 +3823,7 @@ namespace Telegram.Views
                     }
                 }
 
-                return Array.Empty<MessageViewer>();
+                return [];
             }
 
             var played = message.Content is MessageVoiceNote or MessageVideoNote;

--- a/Telegram/Views/Gifts/Popups/GiftCraftChoosePopup.xaml.cs
+++ b/Telegram/Views/Gifts/Popups/GiftCraftChoosePopup.xaml.cs
@@ -243,7 +243,7 @@ namespace Telegram.Views.Gifts.Popups
                     if (response is GiftResaleResultOk ok)
                     {
                         //_aggregator.Publish(new UpdateGiftIsSold(_gift.ReceivedGiftId));
-                        SelectedGift = new ReceivedGift(ok.ReceivedGiftId, null, null, 0, false, false, false, false, false, false, 0, new SentGiftUpgraded(giftForResale.Gift), Array.Empty<int>(), 0, 0, false, 0, 0, 0, 0, 0, string.Empty, 0); ;
+                        SelectedGift = new ReceivedGift(ok.ReceivedGiftId, null, null, 0, false, false, false, false, false, false, 0, new SentGiftUpgraded(giftForResale.Gift), [], 0, 0, false, 0, 0, 0, 0, 0, string.Empty, 0); ;
                         Hide(ContentDialogResult.Primary);
 
                         //if (chat != null)

--- a/Telegram/Views/Popups/ChatInviteFallbackPopup.xaml.cs
+++ b/Telegram/Views/Popups/ChatInviteFallbackPopup.xaml.cs
@@ -21,7 +21,7 @@ namespace Telegram.Views.Popups
         private readonly IClientService _clientService;
         private readonly ChatInviteLink _inviteLink;
 
-        public ChatInviteFallbackPopup(IClientService clientService, long chatId, IList<FailedToAddMember> members)
+        public ChatInviteFallbackPopup(IClientService clientService, long chatId, List<FailedToAddMember> members)
         {
             InitializeComponent();
 

--- a/Telegram/Views/Popups/ChooseProfileColorView.xaml.cs
+++ b/Telegram/Views/Popups/ChooseProfileColorView.xaml.cs
@@ -290,7 +290,7 @@ namespace Telegram.Views.Popups
                 ProfileColors colors;
                 if (upgradedGift != null)
                 {
-                    colors = new ProfileColors(new ProfileAccentColors(Array.Empty<int>(), new[] { upgradedGift.BackdropColors.EdgeColor, upgradedGift.BackdropColors.CenterColor }, Array.Empty<int>()));
+                    colors = new ProfileColors(new ProfileAccentColors([], [upgradedGift.BackdropColors.EdgeColor, upgradedGift.BackdropColors.CenterColor], []));
                 }
                 else if (_clientService.TryGetProfileColor(colorId, out ProfileColor color))
                 {

--- a/Telegram/Views/Popups/CreateChecklistPopup.xaml.cs
+++ b/Telegram/Views/Popups/CreateChecklistPopup.xaml.cs
@@ -140,11 +140,11 @@ namespace Telegram.Views.Popups
             }
         }
 
-        public IList<InputChecklistTask> Tasks => GetTasks(false);
+        public List<InputChecklistTask> Tasks => GetTasks(false);
 
-        public IList<InputChecklistTask> AddedTasks => GetTasks(true);
+        public List<InputChecklistTask> AddedTasks => GetTasks(true);
 
-        private IList<InputChecklistTask> GetTasks(bool addedTasksOnly)
+        private List<InputChecklistTask> GetTasks(bool addedTasksOnly)
         {
             var tasks = new List<InputChecklistTask>();
             var nextTaskId = Math.Max(0, Items.Max(x => x.Id));

--- a/Telegram/Views/Popups/QrCodePopup.xaml.cs
+++ b/Telegram/Views/Popups/QrCodePopup.xaml.cs
@@ -43,28 +43,28 @@ namespace Telegram.Views.Popups
 
         private readonly Dictionary<string, BackgroundFillFreeformGradient> _lightBackgrounds = new()
         {
-            { "\uD83C\uDFE0", new BackgroundFillFreeformGradient( new int[]{ 0x71B654, 0x2C9077, 0x9ABB3E, 0x68B55E }) },
-            { "\uD83D\uDC25", new BackgroundFillFreeformGradient( new int[]{ 0x43A371, 0x8ABD4C, 0x9DB139, 0x85B950 }) },
-            { "\u26C4", new BackgroundFillFreeformGradient( new int[]{ 0x66A1FF, 0x59B5EE, 0x41BAD2, 0x8A97FF }) },
-            { "\uD83D\uDC8E", new BackgroundFillFreeformGradient( new int[]{ 0x5198F5, 0x4BB7D2, 0xAD79FB, 0xDF86C7 }) },
-            { "\uD83D\uDC68\u200D\uD83C\uDFEB", new BackgroundFillFreeformGradient( new int[]{ 0x9AB955, 0x48A896, 0x369ADD, 0x5DC67B }) },
-            { "\uD83C\uDF37", new BackgroundFillFreeformGradient( new int[]{ 0xEE8044, 0xE19B23, 0xE55D93, 0xCB75D7 }) },
-            { "\uD83D\uDC9C", new BackgroundFillFreeformGradient( new int[]{ 0xEE597E, 0xE35FB2, 0xAD69F2, 0xFF9257 }) },
-            { "\uD83C\uDF84", new BackgroundFillFreeformGradient( new int[]{ 0xEC7046, 0xF79626, 0xE3761C, 0xF4AA2A }) },
-            { "\uD83C\uDFAE", new BackgroundFillFreeformGradient( new int[]{ 0x19B3D2, 0xDC62F4, 0xE64C73, 0xECA222 }) },
+            { "\uD83C\uDFE0", new BackgroundFillFreeformGradient( [0x71B654, 0x2C9077, 0x9ABB3E, 0x68B55E]) },
+            { "\uD83D\uDC25", new BackgroundFillFreeformGradient( [0x43A371, 0x8ABD4C, 0x9DB139, 0x85B950]) },
+            { "\u26C4", new BackgroundFillFreeformGradient( [0x66A1FF, 0x59B5EE, 0x41BAD2, 0x8A97FF]) },
+            { "\uD83D\uDC8E", new BackgroundFillFreeformGradient( [0x5198F5, 0x4BB7D2, 0xAD79FB, 0xDF86C7]) },
+            { "\uD83D\uDC68\u200D\uD83C\uDFEB", new BackgroundFillFreeformGradient( [0x9AB955, 0x48A896, 0x369ADD, 0x5DC67B]) },
+            { "\uD83C\uDF37", new BackgroundFillFreeformGradient( [0xEE8044, 0xE19B23, 0xE55D93, 0xCB75D7]) },
+            { "\uD83D\uDC9C", new BackgroundFillFreeformGradient( [0xEE597E, 0xE35FB2, 0xAD69F2, 0xFF9257]) },
+            { "\uD83C\uDF84", new BackgroundFillFreeformGradient( [0xEC7046, 0xF79626, 0xE3761C, 0xF4AA2A]) },
+            { "\uD83C\uDFAE", new BackgroundFillFreeformGradient( [0x19B3D2, 0xDC62F4, 0xE64C73, 0xECA222]) },
         };
 
         private readonly Dictionary<string, BackgroundFillFreeformGradient> _darkBackgrounds = new()
         {
-            { "\uD83C\uDFE0", new BackgroundFillFreeformGradient( new int[]{ 0x157FD1, 0x4A6CF2, 0x1876CD, 0x2CA6CE }) },
-            { "\uD83D\uDC25", new BackgroundFillFreeformGradient( new int[]{ 0x57A518, 0x1E7650, 0x6D9B17, 0x3FAB55 }) },
-            { "\u26C4", new BackgroundFillFreeformGradient( new int[]{ 0x2B6EDA, 0x2F7CB6, 0x1DA6C9, 0x6B7CFF }) },
-            { "\uD83D\uDC8E", new BackgroundFillFreeformGradient( new int[]{ 0xB256B8, 0x6F52FF, 0x249AC2, 0x347AD5 }) },
-            { "\uD83D\uDC68\u200D\uD83C\uDFEB", new BackgroundFillFreeformGradient( new int[]{ 0x238B68, 0x73A163, 0x15AC7F, 0x0E8C95 }) },
-            { "\uD83C\uDF37", new BackgroundFillFreeformGradient( new int[]{ 0xD95454, 0xD2770F, 0xCE4661, 0xAC5FC8 }) },
-            { "\uD83D\uDC9C", new BackgroundFillFreeformGradient( new int[]{ 0xD058AA, 0xE0743E, 0xD85568, 0xA369D3 }) },
-            { "\uD83C\uDF84", new BackgroundFillFreeformGradient( new int[]{ 0xD6681F, 0xCE8625, 0xCE6D30, 0xC98A1D }) },
-            { "\uD83C\uDFAE", new BackgroundFillFreeformGradient( new int[]{ 0xC74343, 0xEC7F36, 0x06B0F9, 0xA347FF }) },
+            { "\uD83C\uDFE0", new BackgroundFillFreeformGradient( [0x157FD1, 0x4A6CF2, 0x1876CD, 0x2CA6CE]) },
+            { "\uD83D\uDC25", new BackgroundFillFreeformGradient( [0x57A518, 0x1E7650, 0x6D9B17, 0x3FAB55]) },
+            { "\u26C4", new BackgroundFillFreeformGradient( [0x2B6EDA, 0x2F7CB6, 0x1DA6C9, 0x6B7CFF]) },
+            { "\uD83D\uDC8E", new BackgroundFillFreeformGradient( [0xB256B8, 0x6F52FF, 0x249AC2, 0x347AD5]) },
+            { "\uD83D\uDC68\u200D\uD83C\uDFEB", new BackgroundFillFreeformGradient( [0x238B68, 0x73A163, 0x15AC7F, 0x0E8C95]) },
+            { "\uD83C\uDF37", new BackgroundFillFreeformGradient( [0xD95454, 0xD2770F, 0xCE4661, 0xAC5FC8]) },
+            { "\uD83D\uDC9C", new BackgroundFillFreeformGradient( [0xD058AA, 0xE0743E, 0xD85568, 0xA369D3]) },
+            { "\uD83C\uDF84", new BackgroundFillFreeformGradient( [0xD6681F, 0xCE8625, 0xCE6D30, 0xC98A1D]) },
+            { "\uD83C\uDFAE", new BackgroundFillFreeformGradient( [0xC74343, 0xEC7F36, 0x06B0F9, 0xA347FF]) },
         };
 
         public QrCodePopup(IClientService clientService, INavigationService navigationService, ISettingsService settingsService, User user)
@@ -121,7 +121,7 @@ namespace Telegram.Views.Popups
 
             static Background GetDefaultBackground(bool dark)
             {
-                var freeform = dark ? new[] { 0x6C7FA6, 0x2E344B, 0x7874A7, 0x333258 } : new[] { 0xDBDDBB, 0x6BA587, 0xD5D88D, 0x88B884 };
+                List<int> freeform = dark ? [0x6C7FA6, 0x2E344B, 0x7874A7, 0x333258] : [0xDBDDBB, 0x6BA587, 0xD5D88D, 0x88B884];
                 return new Background(0, true, dark, string.Empty,
                     new Document(string.Empty, "application/x-tgwallpattern", null, null, TdExtensions.GetLocalFile("Assets\\Background.tgv", "Background")),
                     new BackgroundTypePattern(new BackgroundFillFreeformGradient(freeform), dark ? 100 : 50, dark, false));

--- a/Telegram/Views/Popups/ThemePreviewPopup.xaml.cs
+++ b/Telegram/Views/Popups/ThemePreviewPopup.xaml.cs
@@ -51,7 +51,7 @@ namespace Telegram.Views.Popups
             Title.Text = Strings.ThemePreviewTitle;
             Subtitle.Text = string.Format("{0} {1} {2}", Strings.LastSeen, Strings.TodayAt, Formatter.Time(DateTime.Now.AddHours(-1)));
 
-            Message1.Mockup(new MessagePhoto(new Photo(false, null, new[] { new PhotoSize("i", TdExtensions.GetLocalFile("Assets\\Mockup\\theme_preview_image.jpg"), 500, 302, Array.Empty<int>()) }), null, new FormattedText(), false, false, false), Strings.ThemePreviewLine4, false, DateTime.Now.AddSeconds(-25), true, true);
+            Message1.Mockup(new MessagePhoto(new Photo(false, null, [ new PhotoSize("i", TdExtensions.GetLocalFile("Assets\\Mockup\\theme_preview_image.jpg"), 500, 302, []) ]), null, new FormattedText(), false, false, false), Strings.ThemePreviewLine4, false, DateTime.Now.AddSeconds(-25), true, true);
             Message2.Mockup(Strings.ThemePreviewLine1, true, DateTime.Now, true, false);
             //Message3.Mockup(Strings.FontSizePreviewLine1, Strings.FontSizePreviewName, Strings.FontSizePreviewReply, false, DateTime.Now.AddSeconds(-25));
             Message3.Mockup(new MessageVoiceNote(new VoiceNote(3, new byte[]

--- a/Telegram/Views/Settings/Privacy/SettingsPrivacyShowForwardedPage.xaml.cs
+++ b/Telegram/Views/Settings/Privacy/SettingsPrivacyShowForwardedPage.xaml.cs
@@ -73,7 +73,7 @@ namespace Telegram.Views.Settings.Privacy
                 var forwardInfo = new MessageForwardInfo(origin, 0, null, string.Empty);
                 var content = new MessageText(Strings.PrivacyForwardsMessageLine.AsFormattedText(), null, null);
 
-                var message = new Message(0, new MessageSenderUser(user.Id), null, 0, null, null, false, false, false, false, false, false, false, false, false, false, DateTime.Now.ToTimestamp(), 0, forwardInfo, null, null, Array.Empty<UnreadReaction>(), null, null, null, null, null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, content, null);
+                var message = new Message(0, new MessageSenderUser(user.Id), null, 0, null, null, false, false, false, false, false, false, false, false, false, false, DateTime.Now.ToTimestamp(), 0, forwardInfo, null, null, [], null, null, null, null, null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, content, null);
 
                 var delegato = new ChatMessageDelegate(ViewModel.ClientService, ViewModel.Settings, chat);
                 var viewModel = new MessageViewModel(ViewModel.ClientService, delegato, chat, null, null, message, true);

--- a/Telegram/Views/Settings/SettingsAppearancePage.xaml.cs
+++ b/Telegram/Views/Settings/SettingsAppearancePage.xaml.cs
@@ -6,6 +6,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Telegram.Common;
 using Telegram.Controls.Cells;
@@ -213,14 +214,14 @@ namespace Telegram.Views.Settings
             var clientService = ViewModel.ClientService;
             var senderId = new MessageSenderUser(clientService.Options.MyId);
 
-            var message = new Message(0, senderId, null, 0, null, null, false, false, false, false, false, false, false, false, false, false, 0, 0, null, null, null, Array.Empty<UnreadReaction>(), null, null, null, null, null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, null, null);
+            var message = new Message(0, senderId, null, 0, null, null, false, false, false, false, false, false, false, false, false, false, 0, 0, null, null, null, [], null, null, null, null, null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, null, null);
 
             var settings = clientService.Session.Resolve<ISettingsService>();
 
             var delegato = new ChatMessageDelegate(clientService, settings, null);
             var viewModel = new MessageViewModel(clientService, delegato, null, null, null, message, true);
 
-            Reaction.SetReaction(viewModel, new MessageReaction(reaction, 1, false, senderId, new MessageSender[] { }));
+            Reaction.SetReaction(viewModel, new MessageReaction(reaction, 1, false, senderId, [ ]));
 
             if (Reaction.IsLoaded)
             {
@@ -230,7 +231,7 @@ namespace Telegram.Views.Settings
 
         private void Reaction_Click(object sender, RoutedEventArgs e)
         {
-            var empty = Array.Empty<AvailableReaction>();
+            List<AvailableReaction> empty = [];
             var reactions = ViewModel.ClientService.ActiveReactions
                 .Select(x => new AvailableReaction(new ReactionTypeEmoji(x), false))
                 .ToList();

--- a/Telegram/Views/Stars/Popups/ReactPopup.xaml.cs
+++ b/Telegram/Views/Stars/Popups/ReactPopup.xaml.cs
@@ -57,7 +57,9 @@ namespace Telegram.Views.Stars.Popups
 
                 StarCountSlider.Initialize(_starCount = 50, 1, clientService.Options.PaidReactionStarCountMax);
 
-                _reactors = new List<PaidReactor>(message.InteractionInfo?.Reactions?.PaidReactors ?? Array.Empty<PaidReactor>());
+                _reactors = message.InteractionInfo?.Reactions?.PaidReactors is { } paidReactors
+                    ? new List<PaidReactor>(paidReactors)
+                    : new List<PaidReactor>();
 
                 if (_reactors.Count > 0)
                 {

--- a/Telegram/Views/Stars/Popups/ReceivedGiftPopup.xaml.cs
+++ b/Telegram/Views/Stars/Popups/ReceivedGiftPopup.xaml.cs
@@ -787,14 +787,14 @@ namespace Telegram.Views.Stars.Popups
             var response = await _clientService.SendAsync(new GetGiftUpgradePreview(gift.Gift.Id));
             if (response is GiftUpgradePreview preview)
             {
-                foreach (var item in preview.Models.Reverse())
+                for (int i = preview.Models.Count - 1; i >= 0; i--)
                 {
-                    _clientService.DownloadFile(item.Sticker.StickerValue.Id, 32);
+                    _clientService.DownloadFile(preview.Models[i].Sticker.StickerValue.Id, 32);
                 }
 
-                foreach (var item in preview.Symbols.Reverse())
+                for (int i = preview.Symbols.Count - 1; i >= 0; i--)
                 {
-                    _clientService.DownloadFile(item.Sticker.StickerValue.Id, 31);
+                    _clientService.DownloadFile(preview.Symbols[i].Sticker.StickerValue.Id, 31);
                 }
 
                 _preview = preview;

--- a/Telegram/Views/Stars/Popups/ReceivedGiftPopup.xaml.cs
+++ b/Telegram/Views/Stars/Popups/ReceivedGiftPopup.xaml.cs
@@ -363,12 +363,12 @@ namespace Telegram.Views.Stars.Popups
 
                 var senderName = clientService.GetTitle(gift.OriginalDetails.SenderId);
                 var senderText = senderName != null
-                    ? new FormattedText(senderName, new[] { new TextEntity(0, senderName.Length, gift.OriginalDetails.SenderId.ToTextEntityType()) })
+                    ? new FormattedText(senderName, [new TextEntity(0, senderName.Length, gift.OriginalDetails.SenderId.ToTextEntityType())])
                     : null;
 
                 var receiverName = clientService.GetTitle(gift.OriginalDetails.ReceiverId);
                 var receiverText = receiverName != null
-                    ? new FormattedText(receiverName, new[] { new TextEntity(0, receiverName.Length, gift.OriginalDetails.ReceiverId.ToTextEntityType()) })
+                    ? new FormattedText(receiverName, [new TextEntity(0, receiverName.Length, gift.OriginalDetails.ReceiverId.ToTextEntityType())])
                     : null;
 
                 var date = Formatter.Date(gift.OriginalDetails.Date);

--- a/Telegram/Views/Stars/Popups/ResoldGiftsPopup.xaml.cs
+++ b/Telegram/Views/Stars/Popups/ResoldGiftsPopup.xaml.cs
@@ -584,7 +584,7 @@ namespace Telegram.Views.Stars.Popups
             {
                 Hide(ContentDialogResult.Primary);
 
-                var receivedGift = new ReceivedGift(gift.ReceivedGiftId, null, null, 0, false, false, false, false, false, false, 0, new SentGiftUpgraded(gift.Gift), Array.Empty<int>(), 0, 0, false, 0, 0, 0, 0, 0, string.Empty, 0);
+                var receivedGift = new ReceivedGift(gift.ReceivedGiftId, null, null, 0, false, false, false, false, false, false, 0, new SentGiftUpgraded(gift.Gift), [], 0, 0, false, 0, 0, 0, 0, 0, string.Empty, 0);
 
                 var confirm = await _navigationService.ShowPopupAsync(new ReceivedGiftPopup(_clientService, _navigationService, receivedGift, gift.Gift.OwnerId, _receiverId));
                 if (confirm == ContentDialogResult.Primary && _receiverId == null)

--- a/Telegram/Views/Stars/Popups/SendGiftPopup.xaml.cs
+++ b/Telegram/Views/Stars/Popups/SendGiftPopup.xaml.cs
@@ -54,7 +54,7 @@ namespace Telegram.Views.Stars.Popups
             clientService.TryGetChatFromUser(clientService.Options.MyId, out Chat chat);
 
             var content = new MessageGift(gift, clientService.MyId, _receiverId, string.Empty, string.Empty.AsFormattedText(), 0, gift.DefaultSellStarCount, 0, false, false, false, false, false, false, false, false, false, string.Empty, string.Empty);
-            var message = new Message(0, new MessageSenderUser(clientService.Options.MyId), null, 0, null, null, false, false, false, false, false, false, false, false, false, false, 0, 0, null, null, null, Array.Empty<UnreadReaction>(), null, null, null, null, null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, content, null);
+            var message = new Message(0, new MessageSenderUser(clientService.Options.MyId), null, 0, null, null, false, false, false, false, false, false, false, false, false, false, 0, 0, null, null, null, [], null, null, null, null, null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, content, null);
 
             var settings = clientService.Session.Resolve<ISettingsService>();
 
@@ -161,7 +161,7 @@ namespace Telegram.Views.Stars.Popups
             clientService.TryGetChatFromUser(clientService.Options.MyId, out Chat chat);
 
             var content = new MessageGiftedPremium(_clientService.Options.MyId, userId, string.Empty.AsFormattedText(), _option.Currency, _option.Amount, string.Empty, 0, _option.MonthCount, 0, _option.Sticker);
-            var message = new Message(0, new MessageSenderUser(clientService.Options.MyId), null, 0, null, null, false, false, false, false, false, false, false, false, false, false, 0, 0, null, null, null, Array.Empty<UnreadReaction>(), null, null, null, null, null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, content, null);
+            var message = new Message(0, new MessageSenderUser(clientService.Options.MyId), null, 0, null, null, false, false, false, false, false, false, false, false, false, false, 0, 0, null, null, null, [], null, null, null, null, null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, content, null);
 
             var settings = clientService.Session.Resolve<ISettingsService>();
 
@@ -218,7 +218,7 @@ namespace Telegram.Views.Stars.Popups
             }
 
             _clientService.TryGetChatFromUser(_clientService.Options.MyId, out Chat chat);
-            var message = new Message(0, new MessageSenderUser(_clientService.Options.MyId), null, 0, null, null, false, false, false, false, false, false, false, false, false, false, 0, 0, null, null, null, Array.Empty<UnreadReaction>(), null, null, null, null, null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, content, null);
+            var message = new Message(0, new MessageSenderUser(_clientService.Options.MyId), null, 0, null, null, false, false, false, false, false, false, false, false, false, false, 0, 0, null, null, null, [], null, null, null, null, null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, content, null);
 
             var settings = _clientService.Session.Resolve<ISettingsService>();
 

--- a/Telegram/Views/Supergroups/Popups/SupergroupReactionsPopup.xaml.cs
+++ b/Telegram/Views/Supergroups/Popups/SupergroupReactionsPopup.xaml.cs
@@ -192,7 +192,7 @@ namespace Telegram.Views.Supergroups.Popups
 
         private void Emoji_Click(object sender, RoutedEventArgs e)
         {
-            var empty = Array.Empty<AvailableReaction>();
+            List<AvailableReaction> empty = [];
             var reactions = ViewModel.ClientService.ActiveReactions
                 .Select(x => new AvailableReaction(new ReactionTypeEmoji(x), false))
                 .ToList();

--- a/Telegram/Views/Supergroups/SupergroupEditPage.xaml.cs
+++ b/Telegram/Views/Supergroups/SupergroupEditPage.xaml.cs
@@ -92,7 +92,7 @@ namespace Telegram.Views.Supergroups
             }
         }
 
-        public void UpdateChatWelcomeMessages(Chat chat, IList<WelcomeMessage> messages)
+        public void UpdateChatWelcomeMessages(Chat chat, List<WelcomeMessage> messages)
         {
             if (messages.Count > 0)
             {

--- a/Telegram/Views/Supergroups/SupergroupEditTypePage.xaml.cs
+++ b/Telegram/Views/Supergroups/SupergroupEditTypePage.xaml.cs
@@ -240,7 +240,7 @@ namespace Telegram.Views.Supergroups
 
         public void UpdateChatTitle(Chat chat) { }
         public void UpdateChatPhoto(Chat chat) { }
-        public void UpdateChatWelcomeMessages(Chat chat, IList<WelcomeMessage> messages) { }
+        public void UpdateChatWelcomeMessages(Chat chat, List<WelcomeMessage> messages) { }
 
         #endregion
 

--- a/notes/net10-port-todo.md
+++ b/notes/net10-port-todo.md
@@ -404,10 +404,16 @@ carries the exception type, message and a stack. The Application event log only 
       `new PlaceholderImageHelper(Window.Current)` per view, whose native constructor takes
       `window.Compositor()` — the first thing to check is whether that construction is what
       throws on the secondary view.
-- [ ] `{Binding}` is where the runtime differences will show. 180 occurrences across 32 of 481
-      XAML files, against 1927 `x:Bind` which are compiled and free. Each managed binding source
-      type needs `[GeneratedBindableCustomProperty]` and to be `partial`. Bindings whose source is
-      a XAML/WinRT type need nothing.
+- [x] `{Binding}` **audited — see `binding-audit.md`.** 108 occurrences across 26 of 475 files,
+      against 2038 `x:Bind`. Two mechanisms satisfy a classic binding and they are disjoint here:
+      `XamlTypeInfo.g.cs` emits real accessors for any managed member reached from markup (no
+      attribute, no registration, both projects), and `[GeneratedBindableCustomProperty]` covers the
+      types the compiler cannot see because they are only ever a runtime `DataContext`. So the risk
+      surface is just the second set. Three live defects fell out — `StickerSetViewModel.Title` and
+      `.IsInstalled` in the emoji drawer's group header, `RevenueTabItem.Text` behind
+      `DisplayMemberPath`, and `InstantViewModel.Title` behind the tab header's `SetBinding` — plus
+      eight occurrences that need a glance to confirm. The three bindings built in code-behind are
+      the worst of the surface: no markup, so nothing static sees them at all.
 
 ## Phase 5 — AOT (compiles, links, runs; three features still under repair)
 
@@ -500,6 +506,48 @@ reads these attributes in its own generator, and a generator cannot see what ano
 wrote. `TDAPI003` compares the schema against the attributes actually present and reports what a
 TDLib update has added. Classic `{Binding}` is a second blind spot, having no
 C# anywhere; `x:Bind` is covered, which is why the analyzer opts into analysing generated code.
+
+### IList<T> to List<T> on the generated API — ON A BRANCH
+
+Why: a binding assigns through the **declared** type, so with `IList<T>` no analyzer can ever see
+the concrete type, and `SettingsStoragePage` threw `E_INVALIDARG` with nothing to warn on. `List<T>`
+makes it visible, stops `foreach` boxing an enumerator (23 sites on `.Entities` alone, per render)
+and lets the indexer inline. Functions keep `IList<T>`: they are only written and serialised, never
+bound or iterated, and 93 of the 313 call-site errors were theirs alone.
+
+Three commits, on their own branch rather than on develop:
+
+- object **properties** are `List<T>`, constructors still take `IList<T>` and convert;
+- the analyzer follows x:Bind into `XamlBindingSetters`, which is how the 83 below became visible;
+- constructors take `List<T>` too, so `TdCollection.AsList` is gone.
+
+Call sites moved to `[x]` and `[]`, which allocates *less* than before - `AsList(new[] { x })` built
+an array and copied it. Four sites needed judgement:
+`TryGetColors` fills by `Add` rather than by index (capacity is not count - that is the crash that
+literal translation would give), `ClientService.ChatList`/`StoryList` the same, `VoipPage`'s
+gradients are `static readonly List<int>`, and `TextStyleRun` shares one empty list.
+
+Open, in the order I would take them:
+
+- **The shared empties are a footgun and a regression.** `TextStyleRun.NoEntities` and
+  `AnimatedImageSource.NoOutline` are shared *mutable* lists; one stray `Add` corrupts a
+  process-wide singleton. The old code failed fast, because `IList<T>.Add` on `Array.Empty<T>()`
+  throws `NotSupportedException`. Inheriting a `Frozen<T> : List<T>` cannot help - the members are
+  not virtual, so the guard is inert whenever the static type is `List<T>`, which it always is
+  (measured). Plan: return a fresh list from `GetEntities`, whose result callers may edit, keep the
+  shared instance only for stored-and-read fields, and add a `[Conditional("DEBUG")]` check that
+  the count is still zero.
+- **83 app collections still unregistered** - `DiffObservableCollection<T>`,
+  `IncrementalCollection<T>`, `ObservableCollection<T>`. Zero TDLib vectors remain, so this is now
+  a finite list rather than an open-ended blind spot. Each is a page that throws when opened.
+- **`CsWinRT.Vectors.cs` is now partly dead weight.** The analyzer can see TDLib vectors on its own,
+  so the 188 blanket registrations could shrink to the reachable set. Strip the file, rebuild, and
+  TG1001 names exactly what is needed.
+- **Nothing here is measured.** No binary-size or runtime figure for the change; NativeAOT
+  specialises per instantiation, so it may cost code size.
+
+`Telegram/Common/ThumbnailController.cs` is Fela's, unrelated, and in the same tree - not part of
+this.
 
 ### Still open
 


### PR DESCRIPTION
Generated TDLib **objects** expose their vectors as `List<T>` instead of `IList<T>`. Functions are
left alone.

### Why

A XAML binding assigns through the *declared* type, so with `IList<T>` the concrete type only exists
at runtime and nothing can see it at compile time. That is how `SettingsStoragePage` came to bind
`Statistics.ByChat` to `ItemsSource` and fail with `E_INVALIDARG`, with no warning anywhere. With
`List<T>` the type is visible in the generated binding code, and the analyzer reports it.

Two more reasons, both on paths that run per render:

- `foreach` over an `IList<T>` boxes the enumerator. `List<T>` has a struct one. `.Entities` alone is
  iterated in 23 places.
- The indexer and `Count` inline instead of dispatching through the interface.

Functions gain none of this - they are only ever written and serialised, never bound or iterated -
and keeping `IList<T>` there leaves 93 call sites able to pass an array. So they keep it.

### Shape

- Object properties and constructor parameters are `List<T>`; nested vectors are `List<List<T>>`.
- Both parsers already materialised a vector as a `List<T>`, so nothing changes at runtime for a
  parsed response. The nested readers now build `List<List<T>>` and the `WriteArray` overload for
  them was widened to match.
- Call sites moved from `new[] { x }` and `Array.Empty<T>()` to `[x]` and `[]`, which allocates
  *less* than the intermediate step did - the converter copied every array into a list.

### Worth a look in review

- `TryGetColors` and the two chat-list readers fill by `Add` rather than by index. A `List`'s
  capacity is not its count, so the literal translation of `new T[n]` would throw.
- `TextStyleRun.NoEntities` and `AnimatedImageSource.NoOutline` are shared empty lists, because
  `Array.Empty<T>()` was free and these sit on the render path. A shared *mutable* list is a
  footgun: `IList<T>.Add` on an array used to throw, and now it silently corrupts a singleton.
  Inheriting a frozen `List<T>` cannot help - the members are not virtual, so the guard is inert
  whenever the static type is `List<T>`, which it always is here. The plan is to return a fresh list
  from `GetEntities`, whose result callers may edit, and to add a debug-only check that the count is
  still zero.
- `MessageServiceText.ReplaceWithLink` loses an `if (Entities.IsReadOnly)` copy-guard that only
  existed because an `IList<T>` could be a read-only array wrapper.
- Three `foreach (… in x.Reverse())` became index loops: `List<T>.Reverse()` is in-place and returns
  void, so they no longer compile as written. The one bare `x.Reverse();` statement in the codebase
  is on a different type and is unaffected.

Builds clean. Not run.

### Note on the diff

This stacks on three commits that are on `develop` locally but not yet pushed, so the PR currently
shows six. The first three drop out once `develop` is pushed.
