### PR TITLE
Guard the location access request in CheckDeviceAccessAsync

### DIFF
--- a/Telegram/Services/LocationService.cs
+++ b/Telegram/Services/LocationService.cs
@@ -124,11 +124,16 @@ namespace Telegram.Services
             var access = DeviceAccessInformation.CreateFromDeviceClass(DeviceClass.Location);
             if (access.CurrentStatus == DeviceAccessStatus.Unspecified)
             {
-                var accessStatus = await Geolocator.RequestAccessAsync();
-                if (accessStatus == GeolocationAccessStatus.Allowed)
+                try
                 {
-                    return true;
+                    // Throws ERROR_SERVICE_DISABLED when the system location service is disabled.
+                    var accessStatus = await Geolocator.RequestAccessAsync();
+                    if (accessStatus == GeolocationAccessStatus.Allowed)
+                    {
+                        return true;
+                    }
                 }
+                catch { }
 
                 return false;
             }


### PR DESCRIPTION
`LocationService.CheckDeviceAccessAsync` calls `Geolocator.RequestAccessAsync()` unguarded. That is a cross-process call into the Windows Geolocation Service (`lfsvc`), and on a machine where the service is disabled it throws `ERROR_SERVICE_DISABLED` (0x80070422) — the same failure that was reported by crash telemetry for the identical call in `SendLocationPopup.FindLocation` and fixed in #3344.

The call is now wrapped in `try`/`catch` exactly as its neighbour in `StartTrackingAsync` already is, and a throw is treated as access not being available. The method is otherwise unchanged.

**Caller audit.** The fault does not currently escape, so this is defensive rather than a fix. `CheckDeviceAccessAsync` has a single caller, `LocationService.GetPositionAsync`, whose whole body is inside `try { } catch { }`, so the faulted task is observed there and the method returns `null`. Both callers of `GetPositionAsync` — `DialogViewModel.KeyboardButtonExecute` (`KeyboardButtonTypeRequestLocation`) and `SettingsNightModeViewModel.UpdateLocation` — check for `null`. Worth noting that `UpdateLocation` is `async void`, so if a future caller awaits `CheckDeviceAccessAsync` without that outer `catch`, or `GetPositionAsync`'s own guard is ever narrowed, the throw becomes an unhandled crash.

**Not built.** No UWP/.NET Native build was available here. The edited file was checked with `CSharpSyntaxTree.ParseText(...).GetDiagnostics()`, which reports no diagnostics — it confirms the file still parses and nothing more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
