### PR TITLE
Refuse a drag whose data view cannot be inspected

### DIFF
--- a/Telegram/Views/ChatView.xaml.cs
+++ b/Telegram/Views/ChatView.xaml.cs
@@ -2167,13 +2167,22 @@ namespace Telegram.Views
 
         private void OnDragOver(object sender, DragEventArgs e)
         {
-            if (e.DataView.Contains("application/x-tl-message"))
+            try
             {
-                e.AcceptedOperation = DataPackageOperation.None;
+                if (e.DataView.Contains("application/x-tl-message"))
+                {
+                    e.AcceptedOperation = DataPackageOperation.None;
+                }
+                else
+                {
+                    e.AcceptedOperation = DataPackageOperation.Copy;
+                }
             }
-            else
+            catch (Exception ex)
             {
-                e.AcceptedOperation = DataPackageOperation.Copy;
+                // Contains is a cross-process call into the drag source, which can deny it or go away mid-drag.
+                Logger.Error(ex);
+                e.AcceptedOperation = DataPackageOperation.None;
             }
         }
 


### PR DESCRIPTION
`UnauthorizedAccessException` — "Access is denied. (Exception from HRESULT: 0x80070005)" — reported by crash telemetry on 12.9.1.0, in `ChatView.OnDragOver`:

```
   0  $8_System::Runtime::InteropServices::McgMarshal.ThrowOnExternalCallFailed+0x21
   1  $60___Interop::ComCallHelpers.Call+0xc2
   2  $60___Interop::ForwardComStubs.Stub_33<System.__Canon>+0x9c
   3  $0_Telegram::Views::ChatView.OnDragOver+0x3f
      Telegram\Views\ChatView.xaml.cs:2142
```

Line 2142 at 12.9.1 is `e.DataView.Contains("application/x-tl-message")`, and the forward COM stub above it is that call marshalling out.

## Cause

`IDataPackageView::Contains` is a cross-process COM call into whichever process started the drag, and it returned `E_ACCESSDENIED`. The realistic producers are a drag originating from a higher-integrity process — UIPI blocks the lower-integrity target from calling back — or a source process that exited mid-drag. A single report cannot separate the two, and the app can control neither.

It is not a stale or captured `DataPackageView`: the handler is synchronous and uses `e` directly. `OnDragOver` is the only `DataView.Contains` call in the codebase.

## The change

Catch around the call and decline the drop, the same way the handler already declines a dragged message, plus a `Logger.Error` on the failure path.

This is a guard without a proven root cause, which is normally the wrong shape for a crash fix. It is deliberate here because the failing call is external by construction — the app asks another process a question and that process is allowed to refuse. There is no local state to correct. The log line is what keeps the cause from becoming invisible once the crash stops being reported: it records the actual HRESULT, so `E_ACCESSDENIED` can be told apart from an RPC disconnection in a later report's log tail.

## Build

Not built — a UWP/.NET Native build was not available here. The file parses clean under `CSharpSyntaxTree.ParseText(...).GetDiagnostics()` (0 diagnostics), which catches syntax errors and nothing more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
