### PR TITLE
Tolerate a null file in DelayedFileSource

### DIFF
--- a/Telegram/Controls/Drawers/EmojiDrawer.xaml.cs
+++ b/Telegram/Controls/Drawers/EmojiDrawer.xaml.cs
@@ -389,7 +389,7 @@ namespace Telegram.Controls.Drawers
 
                             foreach (var item in group.Stickers)
                             {
-                                if (_itemIdToContent.TryGetValue(item, out Grid content))
+                                if (item.StickerValue != null && _itemIdToContent.TryGetValue(item, out Grid content))
                                 {
                                     var animation = content.Children[0] as AnimatedImage;
                                     animation.Source = new DelayedFileSource(ViewModel.ClientService, item);

--- a/Telegram/Streams/DelayedFileSource.cs
+++ b/Telegram/Streams/DelayedFileSource.cs
@@ -178,12 +178,18 @@ namespace Telegram.Streams
 
         public override string FilePath => _file?.Local.Path;
 
-        public override long Id => _file.Id;
+        public override long Id => _file?.Id ?? 0;
 
         public bool IsDownloadingCompleted => _file?.Local.IsDownloadingCompleted ?? false;
 
         public virtual void DownloadFile(object sender, DelayedFileDownload download, UpdateHandler<File> handler)
         {
+            // Subclasses resolve a null file on their own; the base class has nothing to download.
+            if (_file == null)
+            {
+                return;
+            }
+
             if (_file.Local.IsDownloadingCompleted && download != DelayedFileDownload.Unloaded)
             {
                 handler?.Invoke(sender, _file);


### PR DESCRIPTION
`NullReferenceException` — "Object reference not set to an instance of an object", reported by crash telemetry on 12.9.1.0.

```
0  Telegram.Streams.DelayedFileSource.get_Id
   Telegram/Streams/DelayedFileSource.cs:181
1  Telegram.Streams.DelayedFileSource.GetHashCode
   Telegram/Streams/DelayedFileSource.cs:228
2  System.Collections.Generic.ObjectEqualityComparer`1.GetHashCode
3  Telegram.Controls.AnimatedImagePresentation.GetHashCode
4  Telegram.Controls.AnimatedImageLoader.GetOrCreate
   Telegram/Controls/AnimatedImage.cs:1857
5  Telegram.Controls.AnimatedImage.Load
   Telegram/Controls/AnimatedImage.cs:519
6  Telegram.Controls.AnimatedImage.OnLoaded
   Telegram/Controls/AnimatedImage.cs:122
```

### Cause

A `DelayedFileSource` built from a sticker whose `StickerValue` is null ends up with a null `_file`. That is a supported state everywhere else in the hierarchy — the constructor guards `if (file != null)`, `FilePath` and `IsDownloadingCompleted` use `_file?.`, `LocalFileSource` returns early on a null file, and all four delayed subclasses override `Id` because their `_file` starts null. The base `Id` was the one accessor that dereferenced it unconditionally, and `GetHashCode` (`HashCode.Combine(Id, IsAnimated)`) makes it unavoidable as soon as `AnimatedImageLoader.GetOrCreate` hashes the presentation. The crashing instance is the base class, not a subclass.

`EmojiDrawerViewModel` deliberately inserts placeholder stickers with a null `StickerValue`, so this is reachable from the emoji drawer.

### Change

- `DelayedFileSource.Id` falls back to `0` on a null file, matching `LocalFileSource`, whose `Id` is left at `0` for exactly this case.
- `DelayedFileSource.DownloadFile` returns early on a null file instead of dereferencing it three times. Subclasses fully override this method to resolve the file themselves, so nothing in that path is lost.
- `EmojiDrawer`'s "+N" expand path assigns a file source without the `StickerValue != null` check that its two sibling call sites in the same file already have; added.

Not built — a .NET Native build isn't available here. Both files parse clean under `CSharpSyntaxTree.ParseText(...).GetDiagnostics()`, which catches syntax errors and nothing more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
