### PR TITLE
Stop the gallery ad taking clicks while it fades out

### DIFF
--- a/Telegram/Controls/Gallery/GallerySponsoredContent.xaml.cs
+++ b/Telegram/Controls/Gallery/GallerySponsoredContent.xaml.cs
@@ -213,8 +213,16 @@ namespace Telegram.Controls.Gallery
 
         private void SponsoredMessage_Click(object sender, RoutedEventArgs e)
         {
-            ViewModel.ClientService.Send(new ClickVideoMessageAdvertisement(_advertisement.UniqueId));
-            MessageHelper.OpenUrl(ViewModel.ClientService, ViewModel.NavigationService, _advertisement.Sponsor.Url);
+            // A focused button can still be invoked from the keyboard or by automation,
+            // neither of which hit tests.
+            var viewModel = ViewModel;
+            if (viewModel == null || _advertisement == null)
+            {
+                return;
+            }
+
+            viewModel.ClientService.Send(new ClickVideoMessageAdvertisement(_advertisement.UniqueId));
+            MessageHelper.OpenUrl(viewModel.ClientService, viewModel.NavigationService, _advertisement.Sponsor.Url);
         }
 
         private void About_Click(object sender, RoutedEventArgs e)
@@ -309,6 +317,10 @@ namespace Telegram.Controls.Gallery
 
             _collapsed = !show;
             Visibility = Visibility.Visible;
+
+            // Collapsing only happens when the fade completes, so the button stays visible
+            // for the whole animation, and by then the advertisement it serves is gone.
+            IsHitTestVisible = show;
 
             var visual = ElementComposition.GetElementVisual(this);
 

--- a/Telegram/Controls/Gallery/GalleryWindow.xaml.cs
+++ b/Telegram/Controls/Gallery/GalleryWindow.xaml.cs
@@ -850,9 +850,12 @@ namespace Telegram.Controls.Gallery
 
             if (ViewModel != null)
             {
-                ViewModel.Delegate = null;
                 ViewModel.Aggregator.Unsubscribe(this);
+
+                // PlaybackStopped clears the sponsored content through the delegate,
+                // so it has to run while the delegate is still attached.
                 ViewModel.PlaybackStopped();
+                ViewModel.Delegate = null;
             }
 
             // Closing is animated and Hide() only runs when the animation completes, so the


### PR DESCRIPTION
`NullReferenceException`, reported by crash telemetry on 12.9.1.

```
   0  Telegram.Controls.Gallery.GallerySponsoredContent.SponsoredMessage_Click+0x36
      Telegram/Controls/Gallery/GallerySponsoredContent.xaml.cs:216
   1  Windows.UI.Xaml.RoutedEventHandler.Invoke+0x2e
```

### Cause

`ShowHide(false)` sets `_collapsed = true` immediately, but only applies `Visibility = Collapsed` from the scoped batch's `Completed` callback. For the whole fade the button is therefore still visible and still hit-testable — after the state its click handler needs has been torn down.

Two routes get there. Swiping to another gallery item calls `Dispose()`, which reaches `ChatGalleryViewModel.PlaybackStopped()` → `UpdateAdvertisement(null)`, and that clears `_advertisement`. Closing does the same and then `Unload()`, which drops the data context so `ViewModel` goes null as well. A real click inside that sub-second window hits one or the other, and `_advertisement.UniqueId` throws.

### Why sequencing rather than a null check

A bare guard at the crash site would leave a dead but clickable strip on screen and hide the bug. The button should stop taking input at the moment its state is cleared, not when the animation ends — the same approach #3354 took for `GalleryWindow` itself.

### What changed

- `ShowHide` sets `IsHitTestVisible` up front, so hiding stops input straight away and showing restores it.
- `SponsoredMessage_Click` is still guarded, because `IsHitTestVisible` does not block keyboard activation of a focused control or a UI Automation `Invoke`, and this is a focusable `HyperlinkButtonEx` — same reasoning as the caption handler in #3354.
- `GalleryWindow.Unload()` nulled `ViewModel.Delegate` before calling `PlaybackStopped()`, so `UpdateAdvertisement(null)` had nothing to call and the control was left holding a stale advertisement next to a null data context. The two lines are swapped.

Not built: a UWP/.NET Native build isn't available here. Both files parse clean under `CSharpSyntaxTree.ParseText(...).GetDiagnostics()`, which catches syntax errors and nothing more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
