### PR TITLE
Don't run the editing shortcuts in a read-only composer

### DIFF
--- a/Telegram/Controls/FormattedTextBox.cs
+++ b/Telegram/Controls/FormattedTextBox.cs
@@ -380,6 +380,13 @@ namespace Telegram.Controls
             //    Height = double.NaN;
             //}
 
+            // The shortcuts below edit the document, and RichEdit fails those calls with E_ACCESSDENIED while it's write-protected.
+            if (IsReadOnly)
+            {
+                base.OnKeyDown(e);
+                return;
+            }
+
             var modifiers = WindowContext.KeyModifiers();
 
             switch (e.Key)


### PR DESCRIPTION
`UnauthorizedAccessException` — "Access is denied. (Exception from HRESULT: 0x80070005)" — reported by crash telemetry on 12.9.1.0.

```
   3  Windows::UI::Text::ITextRange__Impl::Dispatcher.ITextRange.SetText
   4  Telegram::Controls::FormattedTextBox.OnKeyDown
      Telegram\Controls\FormattedTextBox.cs:404
   5  Telegram::Controls::Chats::ChatTextBox.OnKeyDown
      Telegram\Controls\Chats\ChatTextBox.cs:313
```

## Cause

`ChatView` makes the composer read-only whenever the user cannot post — `chat.Permissions.CanSendBasicMessages is false` and friends — while leaving it visible and focusable. `FormattedTextBox.OnKeyDown` never looked at `IsReadOnly`, so with send-by-Enter off, a plain Enter took the "insert a vertical tab instead of a hard paragraph" path and called `Document.Selection.SetText` on a document the app itself had write-protected. RichEdit returns `E_ACCESSDENIED` from `ITextRange::SetText` in that state, and the marshaller turns it into an exception.

Pressing Enter in any chat you can't post in is enough to reproduce it.

Every other branch of that `switch` — the emoji-aware Backspace/Delete, redo, the formatting toggles, Ctrl+K, Alt+X — mutates the document the same way and had the same hole.

## Change

One early-out at the top of `FormattedTextBox.OnKeyDown`: when `IsReadOnly`, defer to the base implementation and skip the shortcuts, which is what the class already does at its other `IsReadOnly` guards. RichEdit ignores its own editing shortcuts on a read-only document, so nothing that used to work stops working.

Not built: no UWP/.NET Native toolchain here. `CSharpSyntaxTree.ParseText` on the edited file reports no diagnostics — that confirms it still parses, and nothing more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)