### PR TITLE
Normalize TDLib fatal log lines before hashing

### DIFF
--- a/Telegram/Common/ExceptionSerializer.cs
+++ b/Telegram/Common/ExceptionSerializer.cs
@@ -416,6 +416,12 @@ namespace Telegram.Common
                     continue;
                 }
 
+                if (TryTranslateTdlibLog(part, out string tdlib))
+                {
+                    builder.Append(tdlib);
+                    continue;
+                }
+
                 // Only the sentence is localised, so the HRESULT .NET appends has to come off
                 // before it can be matched and go back on afterwards.
                 var suffix = _hresultSuffix.Match(part);
@@ -583,6 +589,62 @@ namespace Telegram.Common
 
             translated = null;
             return false;
+        }
+
+        // TDLib prefixes a log line with the level, the thread, the source location and any number of
+        // context tags: "[ 0][t 5][crypto.cpp:420][#1][!Session:4:main][&res != 1]". Matched by that
+        // shape rather than by file name, so a new assertion normalises without a change here.
+        private static readonly Regex _tdlibLog = new(@"^(\[\s*\d+\])\[t\s*\d+\](\[[^\]\\/]+\.[A-Za-z0-9]+:\d+\])((?:\[[^\]]*\])*)", RegexOptions.Compiled);
+
+        private static readonly Regex _tdlibLogContext = new(@"\[#\d+\]|\[![^\]]*\]", RegexOptions.Compiled);
+
+        private static readonly Regex _tdlibActorIndex = new(@"[:#]\d+(?=[:#\]]|$)", RegexOptions.Compiled);
+
+        // Alternation order is the rule: a stringified condition and a source location are identity and
+        // are kept whole, and only what is left over is read as a value the crash happened to print.
+        private static readonly Regex _tdlibLogValue = new(@"`[^`]*`|[A-Za-z_][\w.]*\.(?:cpp|cxx|cc|h|hpp)(?:\s+at\s+line)?[:\s]\s*\d+|""[^""]*""|-?\d[\d.]*", RegexOptions.Compiled);
+
+        // A LOG(FATAL) line reaches the report as the message, and the thread, the scheduler, the actor
+        // index and the values in the trailing text all differ per crash, so one assertion would
+        // otherwise be hashed into a group per report.
+        private static bool TryTranslateTdlibLog(string text, out string translated)
+        {
+            var match = _tdlibLog.Match(text);
+            if (!match.Success)
+            {
+                translated = null;
+                return false;
+            }
+
+            translated = match.Groups[1].Value
+                + match.Groups[2].Value
+                + _tdlibLogContext.Replace(match.Groups[3].Value, TranslateTdlibLogContext)
+                + _tdlibLogValue.Replace(text.Substring(match.Length), TranslateTdlibLogValue);
+            return true;
+        }
+
+        // "[#1]" is the scheduler the actor happened to run on, and "Session:4:download#0" names the
+        // datacenter and the connection slot - but "download" is a different code path from "main".
+        private static string TranslateTdlibLogContext(Match match)
+        {
+            return match.Value[1] == '#'
+                ? string.Empty
+                : _tdlibActorIndex.Replace(match.Value, string.Empty);
+        }
+
+        private static string TranslateTdlibLogValue(Match match)
+        {
+            var first = match.Value[0];
+            if (first == '"')
+            {
+                return "\"...\"";
+            }
+            else if (first == '-' || (first >= '0' && first <= '9'))
+            {
+                return "<...>";
+            }
+
+            return match.Value;
         }
 
         private static string TranslateText(string text)


### PR DESCRIPTION
When TDLib hits an internal `LOG(FATAL)` it aborts, and the log line it printed becomes the crash report's message — which is what the backend hashes. Those lines look like this:

```
[ 0][t 5][crypto.cpp:420][#1][!Session:4:download#0][&res != 1]
[ 0][t 3][crypto.cpp:420][#1][!Session:1:main][&res != 1]
[ 0][t 5][MessageInputReplyTo.cpp:129][#1][!MessagesManager] local message 840.18 in not a topic in chat 0 with flags 0
```

Everything volatile in them is in the message: the thread number, the scheduler tag, the datacenter index inside the session actor, and the message/chat/file ids and offsets in the trailing text. So one assertion fragments into a group per report, every group looks like a singleton, and the whole class reads as noise.

`TryTranslateTdlibLog` follows `TryTranslateAstaCall`: a recogniser that rewrites a line it recognises to a canonical form, and returns the line completely unchanged when it does not match. It matches TDLib's prefix by shape — level, thread, `file.ext:line`, then any number of context tags — not against a list of known files, so a new assertion normalises without a change here.

What it keeps, because it is the identity of the assertion:

- the source location (`crypto.cpp:420`),
- the actor name minus its instance index (`Session:4:download#0` → `Session:download`; `download` is a different code path from `main`, the `4` is only which datacenter the account is on),
- the stringified condition (`` `id == 0 || is_server()` ``, `[&res != 1]`) verbatim, digits included,
- any *second* source reference in the free text (`UserManager.cpp 4821`, `DialogDb.cpp at line 170`) — `Status.h` and `LogEvent.h` are generic helpers whose real site is that trailing reference, and two sites in one file would otherwise merge.

What it drops: the thread and scheduler tags, the actor's instance index, and — the one genuinely arguable call — the numbers and quoted strings left in the free text. Those are the values the assertion happened to print, the file:line above already identifies which assertion failed, and the quoted string is invariably the database path, which carries the user's profile directory into the report.

Checked against every distinct `TdException` message the dashboard holds for the last 28 days: the rule collapses that set to well under half as many distinct forms, it is idempotent, and it leaves every message of every other error type in that set byte-for-byte unchanged. Note only the first line of a message is hashed, so that is the line this has to get right.

**Not built.** A .NET Native build was not available; the file was checked with `CSharpSyntaxTree.ParseText(...).GetDiagnostics()` (clean, so no syntax errors — that catches typos, not type errors), and the four regexes were run as real .NET `Regex` objects over the message corpus described above, which is what produced the figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
