### PR TITLE
Tidy up the record button's press handling

### DIFF
--- a/Telegram/Controls/Chats/ChatRecordButton.cs
+++ b/Telegram/Controls/Chats/ChatRecordButton.cs
@@ -355,11 +355,14 @@ namespace Telegram.Controls.Chats
                     return;
                 }
 
+                _pressed = true;
                 ClickMode = ClickMode.Release;
 
                 var restricted = await ViewModel.VerifyRightsAsync(x => Mode == ChatRecordMode.Video ? x.CanSendVideoNotes : x.CanSendVoiceNotes, Strings.GlobalAttachMediaRestricted, Strings.AttachMediaRestrictedForever, Strings.AttachMediaRestricted);
-                if (restricted)
+                if (restricted || !_pressed)
                 {
+                    // Let go while the rights were being checked, so there is no press left to
+                    // begin a recording for.
                     return;
                 }
 
@@ -417,6 +420,7 @@ namespace Telegram.Controls.Chats
 
         private void OnRelease()
         {
+            _pressed = false;
             ClickMode = ClickMode.Press;
 
             if (_session.IsLocked)
@@ -468,6 +472,9 @@ namespace Telegram.Controls.Chats
         private bool _pointerEntered;
         private bool _pointerReleased;
 
+        // The pointer is still down. Only meaningful across the rights check, which is awaited
+        // between the press and the recording.
+        private bool _pressed;
 
         public event EventHandler RecordingStarting;
         public event EventHandler<MediaCapture> RecordingStarted;

--- a/Telegram/Controls/Chats/ChatRecordButton.cs
+++ b/Telegram/Controls/Chats/ChatRecordButton.cs
@@ -216,9 +216,6 @@ namespace Telegram.Controls.Chats
 
         private async void StartRecording()
         {
-            _calledRecordRunnable = true;
-            _recordAudioVideoRunnableStarted = false;
-
             // Inherited from the permission check this replaced, which found consent status
             // always Unspecified on Xbox and gave up asking. Unverified against AppCapability,
             // and cheaper to keep than to be wrong about.
@@ -372,8 +369,6 @@ namespace Telegram.Controls.Chats
                 {
                     Logger.Debug("Can record videos, start timer to allow switch");
 
-                    _calledRecordRunnable = false;
-                    _recordAudioVideoRunnableStarted = true;
                     _timer.Start();
                 }
                 else
@@ -393,7 +388,7 @@ namespace Telegram.Controls.Chats
         /// </summary>
         public void Complete()
         {
-            if (_session.IsLocked && (!_hasRecordVideo || _calledRecordRunnable))
+            if (_session.IsLocked)
             {
                 Logger.Debug("Completing a locked recording");
                 _session.Complete();
@@ -429,7 +424,7 @@ namespace Telegram.Controls.Chats
                 Logger.Debug("Recording is locked, abort");
                 return;
             }
-            if (_recordAudioVideoRunnableStarted && _timer.IsEnabled)
+            if (_timer.IsEnabled)
             {
                 Logger.Debug("Timer should still tick, change mode to: " + (Mode == ChatRecordMode.Video ? ChatRecordMode.Voice : ChatRecordMode.Video));
 
@@ -438,7 +433,7 @@ namespace Telegram.Controls.Chats
 
                 ShowHoldHint();
             }
-            else if (!_hasRecordVideo || _calledRecordRunnable)
+            else
             {
                 Logger.Debug("Timer has tick, stopping recording");
                 _session.Complete();
@@ -473,8 +468,6 @@ namespace Telegram.Controls.Chats
         private bool _pointerEntered;
         private bool _pointerReleased;
 
-        private bool _calledRecordRunnable;
-        private bool _recordAudioVideoRunnableStarted;
 
         public event EventHandler RecordingStarting;
         public event EventHandler<MediaCapture> RecordingStarted;

--- a/chat-record-rewrite.md
+++ b/chat-record-rewrite.md
@@ -367,6 +367,10 @@ says it took.
   public `Pause()` draws the waveform, the duration and the send glyph — so the limit becomes a
   pause the user did not ask for, and the recording waits to be sent or thrown away. A recording
   that is still held by the pointer has to lock first, or the release that follows would send it.
+  **There is no resuming from it**: sixty seconds is all a video message gets, so `PauseRoot` has
+  to go rather than sit there showing its checked glyph. That makes it a different end state from
+  a pause the user asked for, not the same one reached another way — `Pause()` cannot simply be
+  called and left alone.
 
 ## Task 5 — The bar and the leftovers
 

--- a/chat-record-rewrite.md
+++ b/chat-record-rewrite.md
@@ -315,7 +315,7 @@ read-and-reasoned only. The two things most worth watching on first run: whether
 acquisition really delivers every frame through `TryAcquireLatestFrame`, and which path the log
 says it took.
 
-## Task 3 — Permissions and start-up — **3.2 still open**
+## Task 3 — Permissions and start-up
 
 - [x] **3.1** Replace `CheckAccessAsync`/`CheckDeviceAccessAsync` (:534–613) with
   `MediaDevicePermissions.CheckAccessAsync`, so the first press after granting actually records.
@@ -324,15 +324,32 @@ says it took.
   weight. Cheaper to keep than to be wrong about, and it is three lines with a comment saying so.*
   `MediaDevicePermissions` grew a `MediaDevicePurpose`, so the denial keeps the recording wording
   (`PermissionNoAudio`) instead of borrowing the call one.
-- [ ] **3.2** Start the engine on press and discard on an early release, instead of waiting 300 ms
-  to learn whether it was a hold. The mode-switch tap then cancels a session that already began
-  warming the device, and the felt latency drops by the whole timer plus init.
+- [x] **3.2** ~~Start the engine on press and discard on an early release, instead of waiting 300 ms
+  to learn whether it was a hold.~~ **Built, tested, and rejected — see below. Don't try it again.**
 - [x] **3.3** `MediaCapture.Failed` must fail the session and reset the UI (:843), not just log.
   It now cancels the recording and raises `RecordingFailed`, so unplugging the microphone ends the
   recording instead of leaving the bar up forever.
 - [x] **3.4** Give `RecordingTooShort` a consumer — a toast, matching the Android/desktop wording.
   *No new string: it shows `HoldToAudio`/`HoldToVideo`, the same hint the mode-switch tap shows,
   which is what Android says when a press is too short to be a recording.*
+
+**Why 3.2 can't be had.** The session grew a second phase — a `Start(commit: false)` that opened
+the device silently, a `Commit()` that made the recording exist, a `Cancel()` that threw the warm-up
+away — so that device init ran underneath the 300 ms timer instead of after it. It worked, and it
+is not worth having: every tap that switches mode opens a device the user never asked to use. That
+is not a detail the app gets to decide is harmless. Windows puts the app in the camera's and the
+microphone's recently-accessed list on the open, and hardware with a privacy LED lights it — so
+switching from video to voice turns the webcam on for a moment.
+
+Nor is it a flicker that could be tuned away. `Cancel` goes onto the same single-slot queue as
+`Start`, so a release at 120 ms interrupts nothing: `InitializeAsync`, the frame reader and the
+file all finish first, and only then does the teardown run. The device is fully open and streaming
+before the cancel is even looked at.
+
+Warming only the microphone was considered and turned down for the same reason: an indicator that
+says a device is in use when it isn't is wrong whichever device it is. What survives the revert are
+the two things that never needed the warm-up — the flags the timer already answered for, and the
+press that carried on recording after being let go mid-check.
 
 ## Task 4 — Video
 

--- a/chat-record-rewrite.md
+++ b/chat-record-rewrite.md
@@ -362,6 +362,11 @@ says it took.
 - [ ] **4.5** `_mirroringPreview` decides both the preview transform *and* the encoded flip
   (:1210). Confirm that a non-mirrored external camera still sends the right way round — the
   preview is hard-coded to `ScaleX = -1` (`ChatRecordBar.xaml.cs:165`) regardless.
+- [ ] **4.6** At sixty seconds, stop capturing but show the pause UI rather than sending. This is
+  what the official apps do, and 4.3 sends instead. The bar already has the state to show — its
+  public `Pause()` draws the waveform, the duration and the send glyph — so the limit becomes a
+  pause the user did not ask for, and the recording waits to be sent or thrown away. A recording
+  that is still held by the pointer has to lock first, or the release that follows would send it.
 
 ## Task 5 — The bar and the leftovers
 
@@ -405,6 +410,20 @@ touching anything above it.
   see whether MF's mp4 sink ever rewrites what it already wrote. If it doesn't, video reuses the
   same path. If it does, video keeps upload-on-release — owning the mp4 muxing to fix that is a
   separate project, not this one.
+
+## Task 7 — Voice and video message drafts
+
+Other clients keep an unsent recording as a draft: lock a recording, leave the chat, come back and
+it is still there, waiting to be sent. Unigram has no such thing — leaving throws the recording
+away. Nothing above depends on this, but 4.6 makes it the obvious next step, because after the
+sixty-second stop the app is already holding a finished recording that has not been sent.
+
+- [ ] **7.1** Establish what a draft is on the wire: whether the file lives in the temporary folder
+  or somewhere durable, and what survives a restart of the app.
+- [ ] **7.2** Persist the paused recording per chat — the file, the duration and the waveform —
+  and restore the bar into its paused state when the chat is opened again.
+- [ ] **7.3** Decide when a draft is discarded: sending it, the delete button, and whatever the
+  official apps do when a second recording is started in the same chat.
 
 ---
 


### PR DESCRIPTION
Opening the recording device on the press was built and tested, and is not being kept: warming the device under the hold timer means every tap that switches mode opens a device the user never asked to use. Windows lists the app as having accessed the camera and the microphone, and hardware with a privacy LED lights it, so switching from video to voice turns the webcam on for a moment. The cancel can't shorten it either — it queues behind the whole open, so a release at 120 ms interrupts nothing.

What's left here are the parts that never needed it:

- **Two flags removed.** `_recordAudioVideoRunnableStarted` said what `_timer.IsEnabled` says, and `_calledRecordRunnable` was only read where a recording already exists.
- **A press let go during the rights check no longer records.** The check is awaited between the press and the timer, so releasing during it left the timer to start a recording nobody was holding.
- **The plan doc** records the sixty-second pause and message drafts as todos, and writes 3.2 off so it isn't attempted again.
