### PR TITLE
Grow the playback playlist, and fix the transport controls threading

### DIFF
--- a/Telegram/Services/PlaybackService.cs
+++ b/Telegram/Services/PlaybackService.cs
@@ -1102,12 +1102,22 @@ namespace Telegram.Services
             var item = new PlaybackItemProfileAudio(xamlRoot, audio);
             var items = new List<PlaybackItem>();
 
-            // A caller that already paged some of the profile in hands them over along with
-            // the source that loaded them, so the list keeps its real order and the service
-            // does not start again from the first page.
+            // A caller that already paged some of the profile in hands them over, so the list
+            // keeps its real order and the service does not start again from the first page.
             if (loaded != null)
             {
                 items.AddRange(loaded);
+            }
+
+            if (source == null)
+            {
+                source = new UserProfileAudioPlaybackSource(audio.ClientService, xamlRoot, audio.UserId);
+
+                // Handed the items but not the source that loaded them: paging is by position,
+                // so the cursor has to start past what was handed over or the first page
+                // repeats it. Counted before the item below may be inserted, which is the
+                // one case where the playlist holds something the source never yielded.
+                source.Skip(items.Count);
             }
 
             var index = items.FindIndex(x => audio.AreTheSame(x));
@@ -1128,7 +1138,7 @@ namespace Telegram.Services
             _provisional = loaded == null;
 
             _items = items;
-            _source = source ?? new UserProfileAudioPlaybackSource(audio.ClientService, xamlRoot, audio.UserId);
+            _source = source;
             _sessionId = audio.ClientService.SessionId;
             _userId = audio.UserId;
             _chatId = 0;

--- a/Telegram/Services/PlaybackService.cs
+++ b/Telegram/Services/PlaybackService.cs
@@ -17,6 +17,7 @@ using Telegram.ViewModels;
 using Windows.Foundation;
 using Windows.Storage;
 using Windows.Storage.Streams;
+using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using WM = Windows.Media;
@@ -207,9 +208,8 @@ namespace Telegram.Services
             _isRepeatEnabled = AppSettings.Playback.RepeatMode == PlaybackRepeatMode.Track
                 ? null
                 : AppSettings.Playback.RepeatMode == PlaybackRepeatMode.List;
+            _isShuffleEnabled = AppSettings.Playback.Shuffle;
             _playbackSpeed = AppSettings.Playback.AudioSpeed;
-
-            // TODO: System media transport controls are currently unsupported.
         }
 
         #region SystemMediaTransportControls
@@ -225,10 +225,51 @@ namespace Telegram.Services
             {
                 _transport = WM.SystemMediaTransportControls.GetForCurrentView();
                 _transportQueue = DispatcherQueue.GetForCurrentThread();
+
+                _transport.AutoRepeatMode = ToAutoRepeatMode(_isRepeatEnabled);
+                _transport.ShuffleEnabled = _isShuffleEnabled;
             }
             catch
             {
                 // All the remote procedure calls must be wrapped in a try-catch block
+            }
+        }
+
+        private static WM.MediaPlaybackAutoRepeatMode ToAutoRepeatMode(bool? value)
+        {
+            return value == true
+                ? WM.MediaPlaybackAutoRepeatMode.List
+                : value == null
+                ? WM.MediaPlaybackAutoRepeatMode.Track
+                : WM.MediaPlaybackAutoRepeatMode.None;
+        }
+
+        /// <summary>
+        /// Runs an action against <see cref="_transport"/> on the thread of the view it was
+        /// acquired for, doing nothing if there is no transport.
+        /// </summary>
+        /// <remarks>
+        /// The transport belongs to one view, but playback is driven from whichever window
+        /// started it, from the player's own dispatcher, and from TDLib file updates. Those
+        /// are the same thread only until a Clear is followed by playback from another
+        /// window, at which point the player is recreated on that window's thread while the
+        /// transport stays behind on the first one.
+        /// </remarks>
+        private void RunOnTransport(Action action)
+        {
+            var queue = _transportQueue;
+            if (queue == null || _transport == null)
+            {
+                return;
+            }
+
+            if (queue.HasThreadAccess)
+            {
+                action();
+            }
+            else
+            {
+                queue.TryEnqueue(new DispatcherQueueHandler(action));
             }
         }
 
@@ -351,6 +392,11 @@ namespace Telegram.Services
 
         private void UpdateTransport(PlaybackItem item)
         {
+            RunOnTransport(() => UpdateTransportImpl(item));
+        }
+
+        private void UpdateTransportImpl(PlaybackItem item)
+        {
             var items = _items;
             var transport = _transport;
 
@@ -423,20 +469,7 @@ namespace Telegram.Services
 
         private void SetAlbumCover(PlaybackItem item, string path)
         {
-            var queue = _transportQueue;
-            if (queue == null)
-            {
-                return;
-            }
-
-            if (queue.HasThreadAccess)
-            {
-                SetAlbumCoverImpl(item, path);
-            }
-            else
-            {
-                queue.TryEnqueue(() => SetAlbumCoverImpl(item, path));
-            }
+            RunOnTransport(() => SetAlbumCoverImpl(item, path));
         }
 
         private async void SetAlbumCoverImpl(PlaybackItem item, string path)
@@ -494,12 +527,14 @@ namespace Telegram.Services
                     _playbackState = value;
                     StateChanged?.Invoke(this, null);
 
-                    _transport?.PlaybackStatus = value switch
+                    var status = value switch
                     {
                         PlaybackState.Playing => WM.MediaPlaybackStatus.Playing,
                         PlaybackState.Paused => WM.MediaPlaybackStatus.Paused,
                         PlaybackState.None or _ => WM.MediaPlaybackStatus.Stopped
                     };
+
+                    RunOnTransport(() => _transport.PlaybackStatus = status);
                 }
             }
         }
@@ -511,11 +546,13 @@ namespace Telegram.Services
             set
             {
                 _isRepeatEnabled = value;
-                //Execute(player => player.SystemMediaTransportControls.AutoRepeatMode = AppSettings.Playback.RepeatMode = value == true
-                //    ? MediaPlaybackAutoRepeatMode.List
-                //    : value == null
-                //    ? MediaPlaybackAutoRepeatMode.Track
-                //    : MediaPlaybackAutoRepeatMode.None);
+                AppSettings.Playback.RepeatMode = value == true
+                    ? PlaybackRepeatMode.List
+                    : value == null
+                    ? PlaybackRepeatMode.Track
+                    : PlaybackRepeatMode.None;
+
+                RunOnTransport(() => _transport.AutoRepeatMode = ToAutoRepeatMode(value));
             }
         }
 
@@ -533,7 +570,9 @@ namespace Telegram.Services
             set
             {
                 _isShuffleEnabled = value;
-                //Execute(player => player.SystemMediaTransportControls.ShuffleEnabled = value);
+                AppSettings.Playback.Shuffle = value;
+
+                RunOnTransport(() => _transport.ShuffleEnabled = value);
             }
         }
 
@@ -962,12 +1001,14 @@ namespace Telegram.Services
 
                 if (type == PlaybackPlaylistType.None)
                 {
-                    if (_transport != null)
+                    RunOnTransport(() =>
                     {
                         _transport.ButtonPressed -= Transport_ButtonPressed;
-                    }
+                        _transport.AutoRepeatModeChangeRequested -= Transport_AutoRepeatModeChangeRequested;
 
-                    UpdateManager.Unsubscribe(this, ref _albumCoverToken);
+                        UpdateManager.Unsubscribe(this, ref _albumCoverToken);
+                    });
+
                     _previous = null;
 
                     //_mediaPlayer.SystemMediaTransportControls.ButtonPressed -= Transport_ButtonPressed;
@@ -1041,36 +1082,43 @@ namespace Telegram.Services
             }
         }
 
+        // Every player owns a whole libvlc instance and its audio output, so two of them
+        // competing is not a benign duplicate. Play(XamlRoot, ...) reaches here without
+        // holding the lock Run takes, and a chat opened in a second window has its own UI
+        // thread, so two windows starting playback at once could each build one and leave
+        // the loser running with nothing left to Close it.
         private AsyncMediaPlayer Create()
         {
-            if (_player == null)
+            lock (_mediaPlayerLock)
             {
-                // TODO: currently music player doesn't have a toggle for mute/unmute
-                var options = new AsyncMediaPlayerOptions
+                if (_player == null)
                 {
-                    CreateSwapChain = true,
-                    Mute = false, //AppSettings.VolumeMuted,
-                    Volume = AppSettings.VolumeLevel,
-                    Debug = AppSettings.VerbosityLevel >= 4,
-                };
+                    // TODO: currently music player doesn't have a toggle for mute/unmute
+                    var options = new AsyncMediaPlayerOptions
+                    {
+                        CreateSwapChain = true,
+                        Mute = false, //AppSettings.VolumeMuted,
+                        Volume = AppSettings.VolumeLevel,
+                        Debug = AppSettings.VerbosityLevel >= 4,
+                    };
 
-                _player = new AsyncMediaPlayer(options);
-                //_mediaPlayer.SystemMediaTransportControls.AutoRepeatMode = AppSettings.Playback.RepeatMode;
-                //_mediaPlayer.SystemMediaTransportControls.ButtonPressed += Transport_ButtonPressed;
-                //_mediaPlayer.PlaybackSession.PlaybackStateChanged += OnPlaybackStateChanged;
-                _player.PositionChanged += OnTimeChanged;
-                _player.DurationChanged += OnLengthChanged;
-                _player.StateChanged += OnStateChanged;
-                _player.Buffering += OnBuffering;
-                //_mediaPlayer.CommandManager.IsEnabled = false;
+                    _player = new AsyncMediaPlayer(options);
+                    //_mediaPlayer.PlaybackSession.PlaybackStateChanged += OnPlaybackStateChanged;
+                    _player.PositionChanged += OnTimeChanged;
+                    _player.DurationChanged += OnLengthChanged;
+                    _player.StateChanged += OnStateChanged;
+                    _player.Buffering += OnBuffering;
+                    //_mediaPlayer.CommandManager.IsEnabled = false;
 
-                if (_transport != null)
-                {
-                    _transport.ButtonPressed += Transport_ButtonPressed;
+                    RunOnTransport(() =>
+                    {
+                        _transport.ButtonPressed += Transport_ButtonPressed;
+                        _transport.AutoRepeatModeChangeRequested += Transport_AutoRepeatModeChangeRequested;
+                    });
                 }
-            }
 
-            return _player;
+                return _player;
+            }
         }
 
         public void Attach(SwapChainPanel panel)

--- a/Telegram/Services/PlaybackService.cs
+++ b/Telegram/Services/PlaybackService.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Telegram.Common;
 using Telegram.Converters;
 using Telegram.Native.Media;
@@ -140,6 +141,12 @@ namespace Telegram.Services
         void Play(XamlRoot xamlRoot, MessageWithOwner message, MessageTopic topic = null);
         void Play(XamlRoot xamlRoot, AudioWithOwner audio);
 
+        /// <summary>
+        /// Starts a profile audio playlist from what the caller has already loaded, handing
+        /// over the source that loaded it so the playlist keeps growing from there.
+        /// </summary>
+        void Play(XamlRoot xamlRoot, AudioWithOwner audio, UserProfileAudioPlaybackSource source, IList<PlaybackItem> loaded);
+
         void Play(PlaybackItem item);
 
         void Attach(SwapChainPanel panel);
@@ -195,6 +202,16 @@ namespace Telegram.Services
         private long _userId;
 
         private List<PlaybackItem> _items;
+
+        private PlaybackSource _source;
+
+        private bool _loadingStart;
+        private bool _loadingEnd;
+
+        // Set while the playlist is only the item playback started from, because nothing was
+        // handed over to say where it sits. The first page replaces it rather than being
+        // appended to it, so the list ends up in the order the source reports.
+        private bool _provisional;
 
         public event TypedEventHandler<IPlaybackService, object> MediaFailed;
         public event TypedEventHandler<IPlaybackService, object> StateChanged;
@@ -766,9 +783,135 @@ namespace Telegram.Services
             {
                 SetSource(player, items[index]);
 
-                if (index == 0 || index == items.Count - 1)
+                // Both ends are checked whichever way playback is going: IsReversed swaps
+                // what Next means, and the user can jump anywhere from the playlist popup.
+                if (index <= LoadMoreThreshold)
                 {
-                    // TODO: Load more items
+                    _ = LoadMoreAsync(false);
+                }
+
+                if (index >= items.Count - 1 - LoadMoreThreshold)
+                {
+                    _ = LoadMoreAsync(true);
+                }
+            }
+        }
+
+        // How close to an end of the playlist the current track has to get before the next
+        // page is fetched. Enough to cover a few quick skips at the cost of one request.
+        private const int LoadMoreThreshold = 3;
+
+        private async Task LoadMoreAsync(bool forward)
+        {
+            var source = _source;
+            if (source == null || !source.HasMore(forward))
+            {
+                return;
+            }
+
+            if (forward ? _loadingEnd : _loadingStart)
+            {
+                return;
+            }
+
+            if (forward)
+            {
+                _loadingEnd = true;
+            }
+            else
+            {
+                _loadingStart = true;
+            }
+
+            try
+            {
+                var page = await source.LoadMoreAsync(forward);
+
+                // Playback may have moved to another playlist entirely while the page was in
+                // flight, and the items in it belong to the one that asked for them.
+                if (_source != source || page.Count == 0)
+                {
+                    return;
+                }
+
+                if (forward && _provisional && ReplaceProvisional(page))
+                {
+                    return;
+                }
+
+                AddItems(page, forward);
+                PlaylistChanged?.Invoke(this, EventArgs.Empty);
+            }
+            finally
+            {
+                if (forward)
+                {
+                    _loadingEnd = false;
+                }
+                else
+                {
+                    _loadingStart = false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Swaps a provisional playlist for the first page, when that page turns out to
+        /// contain the item playback started from. Returns whether it did.
+        /// </summary>
+        private bool ReplaceProvisional(IList<PlaybackItem> page)
+        {
+            _provisional = false;
+
+            var current = _currentItem;
+            if (current == null)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < page.Count; i++)
+            {
+                if (!page[i].AreTheSame(current))
+                {
+                    continue;
+                }
+
+                // Keep the instance that is already playing, so CurrentItem stays the object
+                // the playlist holds and playback is not restarted to say so.
+                var items = new List<PlaybackItem>(page);
+                items[i] = current;
+
+                lock (_mediaPlayerLock)
+                {
+                    _items = items;
+                }
+
+                PlaylistChanged?.Invoke(this, EventArgs.Empty);
+                return true;
+            }
+
+            return false;
+        }
+
+        // The list is read from the player's dispatcher and from whichever window drives
+        // playback, so it is only ever mutated under the lock those reads already take.
+        private void AddItems(IList<PlaybackItem> page, bool forward)
+        {
+            lock (_mediaPlayerLock)
+            {
+                var items = _items;
+                if (items == null)
+                {
+                    return;
+                }
+
+                if (forward)
+                {
+                    items.AddRange(page);
+                }
+                else
+                {
+                    items.InsertRange(0, page);
                 }
             }
         }
@@ -844,11 +987,21 @@ namespace Telegram.Services
 
         public void MoveTo(PlaybackItem item, int index)
         {
-            if (_items.Contains(item))
-            {
-                _items.Remove(item);
-                _items.Insert(index, item);
+            bool moved;
 
+            lock (_mediaPlayerLock)
+            {
+                var items = _items;
+
+                moved = items != null && items.Remove(item);
+                if (moved)
+                {
+                    items.Insert(Math.Clamp(index, 0, items.Count), item);
+                }
+            }
+
+            if (moved)
+            {
                 PlaylistChanged?.Invoke(this, EventArgs.Empty);
             }
         }
@@ -888,58 +1041,39 @@ namespace Telegram.Services
                 : PlaybackPlaylistType.Voice);
 
             var item = new PlaybackItemMessage(xamlRoot, message, topic);
-            var items = _items = new List<PlaybackItem>();
 
-            _items.Add(item);
-
+            _items = new List<PlaybackItem> { item };
             _sessionId = message.ClientService.SessionId;
             _chatId = message.ChatId;
             _topic = topic;
             _userId = 0;
 
-            SetSource(null, item);
-
             if (message.Content is MessageText)
             {
+                // The audio of a link preview belongs to no chat playlist.
+                SetSource(null, item);
                 return;
             }
 
-            var offset = -49;
-            var filter = message.Content is MessageAudio ? new SearchMessagesFilterAudio() : (SearchMessagesFilter)new SearchMessagesFilterVoiceAndVideoNote();
+            var source = new ChatPlaybackSource(message.ClientService, xamlRoot, message.ChatId, topic, message.Content is MessageAudio);
+            source.Seed(message.Id);
 
-            var response = await message.ClientService.SendAsync(new SearchChatMessages(message.ChatId, _topic, string.Empty, null, message.Id, offset, 100, filter));
-            if (response is FoundChatMessages messages)
-            {
-                foreach (var add in message.Content is MessageAudio ? messages.Messages.OrderBy(x => x.Id) : messages.Messages.OrderByDescending(x => x.Id))
-                {
-                    if (add.Id > message.Id && add.Content is MessageAudio)
-                    {
-                        items.Insert(0, new PlaybackItemMessage(xamlRoot, new MessageWithOwner(message.ClientService, add), topic));
-                    }
-                    else if (add.Id < message.Id && (add.Content is MessageVoiceNote || add.Content is MessageVideoNote))
-                    {
-                        items.Insert(0, new PlaybackItemMessage(xamlRoot, new MessageWithOwner(message.ClientService, add), topic));
-                    }
-                }
+            _source = source;
 
-                foreach (var add in message.Content is MessageAudio ? messages.Messages.OrderByDescending(x => x.Id) : messages.Messages.OrderBy(x => x.Id))
-                {
-                    if (add.Id < message.Id && add.Content is MessageAudio)
-                    {
-                        items.Add(new PlaybackItemMessage(xamlRoot, new MessageWithOwner(message.ClientService, add), topic));
-                    }
-                    else if (add.Id > message.Id && (add.Content is MessageVoiceNote || add.Content is MessageVideoNote))
-                    {
-                        items.Add(new PlaybackItemMessage(xamlRoot, new MessageWithOwner(message.ClientService, add), topic));
-                    }
-                }
+            SetSource(null, item);
 
-                UpdateTransport(CurrentItem);
-                PlaylistChanged?.Invoke(this, EventArgs.Empty);
-            }
+            // Both ends at once: the first page in either direction is what the playlist was
+            // before it could grow, and waiting for one to decide the other would show the
+            // list filling in twice.
+            await Task.WhenAll(LoadMoreAsync(false), LoadMoreAsync(true));
         }
 
-        public async void Play(XamlRoot xamlRoot, AudioWithOwner audio)
+        public void Play(XamlRoot xamlRoot, AudioWithOwner audio)
+        {
+            Play(xamlRoot, audio, null, null);
+        }
+
+        public async void Play(XamlRoot xamlRoot, AudioWithOwner audio, UserProfileAudioPlaybackSource source, IList<PlaybackItem> loaded)
         {
             EnsureTransport();
 
@@ -966,10 +1100,35 @@ namespace Telegram.Services
             Dispose(PlaybackPlaylistType.ProfileAudio);
 
             var item = new PlaybackItemProfileAudio(xamlRoot, audio);
-            var items = _items = new List<PlaybackItem>();
+            var items = new List<PlaybackItem>();
 
-            _items.Add(item);
+            // A caller that already paged some of the profile in hands them over along with
+            // the source that loaded them, so the list keeps its real order and the service
+            // does not start again from the first page.
+            if (loaded != null)
+            {
+                items.AddRange(loaded);
+            }
 
+            var index = items.FindIndex(x => audio.AreTheSame(x));
+            if (index >= 0)
+            {
+                // Play the instance from the list rather than the one built here, so that
+                // CurrentItem is the object the list holds.
+                item = items[index] as PlaybackItemProfileAudio ?? item;
+                items[index] = item;
+            }
+            else
+            {
+                items.Insert(0, item);
+            }
+
+            // Nothing was handed over, so where this audio sits in the profile is unknown
+            // and the first page has to settle it.
+            _provisional = loaded == null;
+
+            _items = items;
+            _source = source ?? new UserProfileAudioPlaybackSource(audio.ClientService, xamlRoot, audio.UserId);
             _sessionId = audio.ClientService.SessionId;
             _userId = audio.UserId;
             _chatId = 0;
@@ -977,20 +1136,7 @@ namespace Telegram.Services
 
             SetSource(null, item);
 
-            var response = await audio.ClientService.SendAsync(new GetUserProfileAudios(audio.UserId, 0, 100));
-            if (response is Audios audios)
-            {
-                foreach (var add in audios.AudiosValue)
-                {
-                    if (add.AudioValue.Id != audio.AudioValue.Id)
-                    {
-                        items.Add(new PlaybackItemProfileAudio(xamlRoot, new AudioWithOwner(audio.ClientService, audio.UserId, add)));
-                    }
-                }
-
-                UpdateTransport(CurrentItem);
-                PlaylistChanged?.Invoke(this, EventArgs.Empty);
-            }
+            await LoadMoreAsync(true);
         }
 
         private void Dispose(PlaybackPlaylistType type)
@@ -1037,7 +1183,11 @@ namespace Telegram.Services
                 }
             }
 
+            // Dropping the source is what makes a page still in flight for the playlist being
+            // torn down land on nothing.
             _items = null;
+            _source = null;
+            _provisional = false;
             _type = type;
         }
 

--- a/Telegram/Services/PlaybackSource.cs
+++ b/Telegram/Services/PlaybackSource.cs
@@ -237,6 +237,11 @@ namespace Telegram.Services
         /// <summary>
         /// Moves the cursor past items the caller already loaded and is handing over.
         /// </summary>
+        /// <remarks>
+        /// Paging here is by position, so those items have to be the start of the profile
+        /// list and in its order: an offset that does not match what the caller holds does
+        /// not just repeat items, it skips the ones in between.
+        /// </remarks>
         public void Skip(int count)
         {
             _offset += count;

--- a/Telegram/Services/PlaybackSource.cs
+++ b/Telegram/Services/PlaybackSource.cs
@@ -1,0 +1,279 @@
+//
+// Copyright (c) Fela Ameghino 2015-2026
+//
+// Distributed under the GNU General Public License v3.0. (See accompanying
+// file LICENSE or copy at https://www.gnu.org/licenses/gpl-3.0.txt)
+//
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Telegram.Td.Api;
+using Telegram.ViewModels;
+using Windows.UI.Xaml;
+
+namespace Telegram.Services
+{
+    /// <summary>
+    /// Pages the items of one playback session in, in either direction.
+    /// </summary>
+    /// <remarks>
+    /// A source owns its cursors, so whoever holds it is the only one who may page it: a
+    /// caller handing its own source to <see cref="IPlaybackService"/> is giving it away,
+    /// not sharing it. It is deliberately not a collection - the playlist is mirrored into
+    /// per-window collections through PlaylistChanged, and an observable shared between
+    /// windows would raise CollectionChanged on the wrong thread.
+    /// </remarks>
+    public abstract class PlaybackSource
+    {
+        protected PlaybackSource(IClientService clientService)
+        {
+            ClientService = clientService;
+        }
+
+        public IClientService ClientService { get; }
+
+        /// <summary>
+        /// Whether more items may exist past the given end of the playlist. False here is
+        /// final; true only means the end has not been reached yet.
+        /// </summary>
+        /// <param name="forward">Towards the end of the playlist rather than its start.</param>
+        public abstract bool HasMore(bool forward);
+
+        /// <summary>
+        /// Loads the next page, or an empty list once there is none. Items come back in
+        /// playlist order, ready to be inserted at the matching end.
+        /// </summary>
+        public abstract Task<IList<PlaybackItem>> LoadMoreAsync(bool forward);
+    }
+
+    /// <summary>
+    /// The audio, or the voice and video notes, of one chat.
+    /// </summary>
+    public partial class ChatPlaybackSource : PlaybackSource
+    {
+        private readonly XamlRoot _xamlRoot;
+
+        private readonly long _chatId;
+        private readonly MessageTopic _topic;
+        private readonly SearchMessagesFilter _filter;
+
+        // Audio plays newest first, so the end of the playlist is older messages; voice and
+        // video notes play in the order they were sent, so it is the newer ones. Everything
+        // below talks in playlist directions and converts here, once.
+        private readonly bool _newestFirst;
+
+        // Message ids the playlist currently reaches, and what searching past them found.
+        private long _startId;
+        private long _endId;
+
+        private bool _hasMoreStart = true;
+        private bool _hasMoreEnd = true;
+
+        public ChatPlaybackSource(IClientService clientService, XamlRoot xamlRoot, long chatId, MessageTopic topic, bool audio)
+            : base(clientService)
+        {
+            _xamlRoot = xamlRoot;
+
+            _chatId = chatId;
+            _topic = topic;
+            _filter = audio
+                ? new SearchMessagesFilterAudio()
+                : new SearchMessagesFilterVoiceAndVideoNote();
+
+            _newestFirst = audio;
+        }
+
+        public long ChatId => _chatId;
+
+        public MessageTopic Topic => _topic;
+
+        /// <summary>
+        /// Records the message the session starts from, so the first page in either
+        /// direction is searched from it rather than from the end of the chat.
+        /// </summary>
+        public void Seed(long messageId)
+        {
+            _startId = messageId;
+            _endId = messageId;
+        }
+
+        /// <summary>
+        /// Widens the cursors after items were added from somewhere other than a page - a
+        /// message arriving while the session is open, or the seed page itself.
+        /// </summary>
+        public void Extend(long messageId)
+        {
+            // The start of the playlist is the highest message id when playing audio and the
+            // lowest when playing voice notes, which is why neither of these is a plain min
+            // or max on its own.
+            if (_newestFirst ? messageId > _startId : messageId < _startId)
+            {
+                _startId = messageId;
+            }
+
+            if (_newestFirst ? messageId < _endId : messageId > _endId)
+            {
+                _endId = messageId;
+            }
+        }
+
+        public override bool HasMore(bool forward)
+        {
+            return forward ? _hasMoreEnd : _hasMoreStart;
+        }
+
+        public override async Task<IList<PlaybackItem>> LoadMoreAsync(bool forward)
+        {
+            // Towards the end of the playlist is towards older messages for audio, and
+            // towards newer ones for voice and video notes.
+            var older = forward == _newestFirst;
+            var from = forward ? _endId : _startId;
+
+            // searchChatMessages returns in decreasing message id. A zero offset starts at
+            // from_message_id and walks down; a negative one walks up instead, and the API
+            // requires the limit to exceed it, hence the extra one.
+            var offset = older ? 0 : -Limit;
+            var limit = older ? Limit : Limit + 1;
+
+            var response = await ClientService.SendAsync(new SearchChatMessages(_chatId, _topic, string.Empty, null, from, offset, limit, _filter));
+            if (response is not FoundChatMessages messages)
+            {
+                // An error is not proof there is nothing left, but retrying on every move
+                // would hammer the server, so treat it as the end.
+                SetHasMore(forward, false);
+                return Array.Empty<PlaybackItem>();
+            }
+
+            var result = new List<PlaybackItem>(messages.Messages.Count);
+
+            // The search always answers in decreasing message id, which is playlist order
+            // only when the playlist is newest first. Direction does not come into it: what
+            // changes with direction is which end the caller puts the page on.
+            foreach (var message in _newestFirst ? messages.Messages : Reversed(messages.Messages))
+            {
+                // from_message_id comes back with the page it anchors, and it is already in
+                // the playlist.
+                if (older ? message.Id >= from : message.Id <= from)
+                {
+                    continue;
+                }
+
+                result.Add(new PlaybackItemMessage(_xamlRoot, new MessageWithOwner(ClientService, message), _topic));
+            }
+
+            // Nothing new past the anchor means the end, whatever total_count claims: the
+            // filtered search can legitimately return a page made only of the anchor.
+            SetHasMore(forward, result.Count > 0);
+
+            if (result.Count > 0)
+            {
+                // The item furthest from the anchor is the one the next page continues from,
+                // and it sits at the far end of the page in playlist order - which is the
+                // last item going forward and the first one going back.
+                var furthest = (PlaybackItemMessage)result[forward ? result.Count - 1 : 0];
+
+                if (forward)
+                {
+                    _endId = furthest.Id;
+                }
+                else
+                {
+                    _startId = furthest.Id;
+                }
+            }
+
+            return result;
+        }
+
+        private void SetHasMore(bool forward, bool value)
+        {
+            if (forward)
+            {
+                _hasMoreEnd = value;
+            }
+            else
+            {
+                _hasMoreStart = value;
+            }
+        }
+
+        private static IEnumerable<Message> Reversed(IList<Message> messages)
+        {
+            for (int i = messages.Count - 1; i >= 0; i--)
+            {
+                yield return messages[i];
+            }
+        }
+
+        private const int Limit = 50;
+    }
+
+    /// <summary>
+    /// The profile audio of one user.
+    /// </summary>
+    /// <remarks>
+    /// getUserProfileAudios pages by offset from the start of the list, so there is nothing
+    /// to load before what the session started with, and a caller that already paged some in
+    /// hands over this object rather than making the service start again from zero.
+    /// </remarks>
+    public partial class UserProfileAudioPlaybackSource : PlaybackSource
+    {
+        private readonly XamlRoot _xamlRoot;
+        private readonly long _userId;
+
+        private int _offset;
+        private bool _hasMore = true;
+
+        public UserProfileAudioPlaybackSource(IClientService clientService, XamlRoot xamlRoot, long userId)
+            : base(clientService)
+        {
+            _xamlRoot = xamlRoot;
+            _userId = userId;
+        }
+
+        public long UserId => _userId;
+
+        /// <summary>
+        /// Moves the cursor past items the caller already loaded and is handing over.
+        /// </summary>
+        public void Skip(int count)
+        {
+            _offset += count;
+        }
+
+        public override bool HasMore(bool forward)
+        {
+            return forward && _hasMore;
+        }
+
+        public override async Task<IList<PlaybackItem>> LoadMoreAsync(bool forward)
+        {
+            if (!forward)
+            {
+                return Array.Empty<PlaybackItem>();
+            }
+
+            var response = await ClientService.SendAsync(new GetUserProfileAudios(_userId, _offset, Limit));
+            if (response is not Audios audios || audios.AudiosValue.Count == 0)
+            {
+                _hasMore = false;
+                return Array.Empty<PlaybackItem>();
+            }
+
+            var result = new List<PlaybackItem>(audios.AudiosValue.Count);
+
+            foreach (var audio in audios.AudiosValue)
+            {
+                result.Add(new PlaybackItemProfileAudio(_xamlRoot, new AudioWithOwner(ClientService, _userId, audio)));
+            }
+
+            _offset += audios.AudiosValue.Count;
+            _hasMore = _offset < audios.TotalCount;
+
+            return result;
+        }
+
+        private const int Limit = 50;
+    }
+}

--- a/Telegram/Services/Settings/PlaybackSettings.cs
+++ b/Telegram/Services/Settings/PlaybackSettings.cs
@@ -21,6 +21,13 @@ namespace Telegram.Services.Settings
             set => AddOrUpdateValue(ref _repeatMode, "RepeatMode", (int)value);
         }
 
+        private bool? _shuffle;
+        public bool Shuffle
+        {
+            get => _shuffle ??= GetValueOrDefault("Shuffle", false);
+            set => AddOrUpdateValue(ref _shuffle, "Shuffle", value);
+        }
+
         private double? _audioSpeed;
         public double AudioSpeed
         {

--- a/Telegram/Telegram.csproj
+++ b/Telegram/Telegram.csproj
@@ -1786,6 +1786,7 @@
     <Compile Include="Services\Settings\PasscodeLockSettings.cs" />
     <Compile Include="Services\PasscodeService.cs" />
     <Compile Include="Services\PlaybackService.cs" />
+    <Compile Include="Services\PlaybackSource.cs" />
     <Compile Include="Services\ClientService.cs" />
     <Compile Include="Services\Session.cs" />
     <Compile Include="Services\SettingsService.cs" />


### PR DESCRIPTION
First of three. Groundwork for a playlist that keeps loading as it plays, plus the threading
problems found while reviewing the album cover work.

### Note on the diff

`playback-rework` was cut from local `develop`, which is ahead of `origin/develop`. Until that
is pushed, this PR also lists **Show album covers in the system media transport controls** —
same commit, so it drops out of the diff once `develop` goes up. Only the three commits below
are new here.

### Fix threading around the transport controls and the player

`SystemMediaTransportControls` belongs to the view it was acquired for, but playback is driven
from whichever window started it, from the player's own dispatcher, and from TDLib file
updates. Those are the same thread only until a `Clear()` is followed by playback from another
window — `Dispose` nulls `_player` but keeps `_transport` — after which `UpdateTransport` and
the `PlaybackState` setter poke a foreign view's transport. Every write now goes back to the
view's thread.

`Create()` ran outside `_mediaPlayerLock`: `Play(XamlRoot, ...)` reaches it through
`SetSource(null, ...)` without the lock that `Run` takes, while `Play(PlaybackItem)` does take
it. A chat opened in a second window has its own UI thread, so two windows starting playback at
once could each build an `AsyncMediaPlayer` and leave the loser running with nothing left to
`Close` it — and each one owns a whole libvlc instance and its audio output.

Repeat mode was also never persisted: the write to `PlaybackSettings.RepeatMode` was commented
out, so the value read at startup could never change. Shuffle had no setting at all. Both are
stored now and mirrored to the transport, and `AutoRepeatModeChangeRequested` is finally hooked.

### Grow the playback playlist as it is played

The playlist was a single `SearchChatMessages` of up to a hundred messages around the one that
started it, with a `// TODO: Load more items` where growth belonged. Profile audio was worse:
the first hundred audios with the played one moved to the front, which is not the profile order.

New `PlaybackSource` owns its cursors and pages in either direction:

- `ChatPlaybackSource` — `SearchChatMessages` outward from whichever boundary it is extending.
  Worth knowing if you touch it: the search always answers in decreasing message id, but audio
  playlists run newest-first and voice notes oldest-first, so whether to reverse a page depends
  on the playlist, not the direction; and the cursor for the next page is the item furthest from
  the anchor, which is the first element going backwards, not the last.
- `UserProfileAudioPlaybackSource` — `getUserProfileAudios` pages by position, so there is
  nothing before the start and `HasMore(false)` is always false.

`PlaybackService` fetches when the current track comes within three of either end, both ends
regardless of direction, since `IsReversed` swaps what Next means and the playlist popup can
jump anywhere.

`Play(xamlRoot, audio, source, loaded)` lets a caller hand over what it already loaded together
with the source that loaded it. Without a handover the service cannot know where the audio sits,
so the playlist starts as just that item and the first page replaces it in place — keeping the
playing instance at its real index rather than restarting playback to say so. With items but no
source, the cursor is skipped past them: positional paging means a wrong offset does not merely
repeat items, it silently skips the ones between, so handed-over items must be the start of the
profile list in its order.

`_items` mutation is now under the lock its readers already take, which also closes a case where
`MoveTo` could reorder the list while `MoveNextImpl` was indexing it.

### Still to come

- **Stage 2** — reconciling the playlist with `UpdateNewMessage`, `UpdateDeleteMessages` and
  `UpdateMessageSendSucceeded`, and with the local profile add/remove that only `PlaybackPopup`
  knows about. Deleting the playing item skips to next for chat messages and keeps playing for
  profile audio.
- **Stage 3** — shuffle, which has been a stubbed-out button in two places and no
  implementation.

### Testing

Builds clean. Not exercised at runtime — the transport flyout and the multi-window paths in
particular are unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)