### PR TITLE
Keep the playback playlist in step with the chat and the profile

### DIFF
--- a/Telegram/Controls/PlaybackSlider.cs
+++ b/Telegram/Controls/PlaybackSlider.cs
@@ -127,6 +127,11 @@ namespace Telegram.Controls
 
             if (ProgressBarIndicator == null)
             {
+                // Nothing is drawn yet, but the origin still has to describe this update: it is
+                // what OnApplyTemplate replays, and DrawnPosition would otherwise measure the
+                // time since an update that never happened.
+                _origin = position;
+                _originTicks = Logger.TickCount;
                 return;
             }
 
@@ -314,7 +319,7 @@ namespace Telegram.Controls
                 PositionStarted?.Invoke(this, null);
 
                 var position = CalculatePosition(point);
-                UpdateValue(position, _duration, false);
+                UpdateValue(position, _duration, false, _rate);
                 PositionChanging?.Invoke(this, new PlaybackSliderPositionChanged(position));
 
                 if (ComputedIsThumbToolTipEnabled)
@@ -329,7 +334,7 @@ namespace Telegram.Controls
             if (_pressed)
             {
                 var position = CalculatePosition(e.GetCurrentPoint(this));
-                UpdateValue(position, _duration, false);
+                UpdateValue(position, _duration, false, _rate);
                 PositionChanging?.Invoke(this, new PlaybackSliderPositionChanged(position));
             }
 

--- a/Telegram/Services/PlaybackService.cs
+++ b/Telegram/Services/PlaybackService.cs
@@ -52,6 +52,7 @@ namespace Telegram.Services
             ClientService = clientService;
             UserId = userId;
 
+            Value = audio;
             AudioValue = audio.AudioValue;
             ExternalAlbumCovers = audio.ExternalAlbumCovers;
             AlbumCoverThumbnail = audio.AlbumCoverThumbnail;
@@ -66,6 +67,12 @@ namespace Telegram.Services
         public IClientService ClientService { get; set; }
 
         public long UserId { get; set; }
+
+        /// <summary>
+        /// The audio the fields below were copied from, kept so it can be handed back to
+        /// anything that wants the whole thing rather than one field.
+        /// </summary>
+        public Audio Value { get; }
 
         /// <summary>
         /// File containing the audio.
@@ -137,6 +144,17 @@ namespace Telegram.Services
         void Clear();
 
         void MoveTo(PlaybackItem item, int index);
+
+        /// <summary>
+        /// Tells the service an audio was added to the current user's profile. There is no
+        /// update for it, so a profile audio playlist can only learn from whoever asked.
+        /// </summary>
+        void ProfileAudioAdded(PlaybackItem item);
+
+        /// <summary>
+        /// Tells the service an audio was removed from the current user's profile.
+        /// </summary>
+        void ProfileAudioRemoved(int fileId);
 
         void Play(XamlRoot xamlRoot, MessageWithOwner message, MessageTopic topic = null);
         void Play(XamlRoot xamlRoot, AudioWithOwner audio);
@@ -214,6 +232,10 @@ namespace Telegram.Services
         // handed over to say where it sits. The first page replaces it rather than being
         // appended to it, so the list ends up in the order the source reports.
         private bool _provisional;
+
+        // The aggregator of the session being played. Per session, so not the static one the
+        // file subscriptions go through.
+        private IEventAggregator _aggregator;
 
         public event TypedEventHandler<IPlaybackService, object> MediaFailed;
         public event TypedEventHandler<IPlaybackService, object> StateChanged;
@@ -515,6 +537,14 @@ namespace Telegram.Services
 
         public IReadOnlyList<PlaybackItem> Items => _items?.ToList() ?? (IReadOnlyList<PlaybackItem>)Array.Empty<PlaybackItem>();
 
+        // The track that took the place of the playing one after it was taken out of the
+        // playlist: a deleted message, or an audio removed from the profile, keeps playing
+        // from outside the list, and Next and Previous move from the gap it left rather than
+        // failing to find it. Holding the neighbour rather than an index is what keeps it
+        // true as the playlist changes around it. Null while the playing track is still in
+        // the playlist, and also when the gap is at the very end - both read the same way.
+        private PlaybackItem _orphanNext;
+
         private PlaybackItem _currentItem;
         public PlaybackItem CurrentItem
         {
@@ -522,6 +552,7 @@ namespace Telegram.Services
             private set
             {
                 _currentItem = value;
+                _orphanNext = null;
                 _positionChanged.Position = TimeSpan.Zero;
                 _positionChanged.Duration = TimeSpan.FromSeconds(value?.Duration ?? 0);
                 SourceChanged?.Invoke(this, value);
@@ -700,6 +731,67 @@ namespace Telegram.Services
             PositionChanged?.Invoke(this, _positionChanged);
         }
 
+        /// <summary>
+        /// Records the track after the playing one, so that Next and Previous can move on
+        /// from the gap the playing one is about to leave. Does nothing once it has left:
+        /// what takes it out of the playlist is what knows where it was.
+        /// </summary>
+        /// <param name="deleted">
+        /// Message ids going away along with it, skipped over so the neighbour recorded is
+        /// one that survives.
+        /// </param>
+        private void OrphanCurrent(IList<long> deleted = null)
+        {
+            var items = _items;
+            var index = items?.IndexOf(_currentItem) ?? -1;
+
+            if (index < 0)
+            {
+                return;
+            }
+
+            _orphanNext = null;
+
+            for (int i = index + 1; i < items.Count; i++)
+            {
+                if (deleted != null && items[i] is PlaybackItemMessage message && deleted.Contains(message.Id))
+                {
+                    continue;
+                }
+
+                _orphanNext = items[i];
+                break;
+            }
+        }
+
+        /// <summary>
+        /// The indices of the tracks on either side of the playing one, and whether it is
+        /// still in the playlist at all.
+        /// </summary>
+        /// <remarks>
+        /// A track taken out of the playlist while it plays holds no index of its own, so its
+        /// neighbours are the two sides of the gap it left rather than one either way.
+        /// </remarks>
+        private bool TryGetNeighbours(List<PlaybackItem> items, out int before, out int after)
+        {
+            var index = items.IndexOf(CurrentItem);
+            if (index >= 0)
+            {
+                before = index - 1;
+                after = index + 1;
+                return true;
+            }
+
+            // The gap is wherever the track that filled it is now. A null neighbour means it
+            // was at the end of the playlist, and one that has since gone too means the gap
+            // cannot be placed at all - both fall outside it, where playback ends.
+            var gap = _orphanNext != null ? items.IndexOf(_orphanNext) : items.Count;
+
+            before = gap - 1;
+            after = gap;
+            return false;
+        }
+
         public void MoveNext()
         {
             Run(MoveNextImpl);
@@ -713,25 +805,26 @@ namespace Telegram.Services
                 return;
             }
 
-            var index = items.IndexOf(CurrentItem);
-            if (index == -1 || index == (_isReversed ? 0 : items.Count - 1))
+            var present = TryGetNeighbours(items, out var before, out var after);
+            var next = _isReversed ? before : after;
+
+            if (next >= 0 && next < items.Count)
             {
-                if (CurrentItem is PlaybackItemMessage { Message.Content: MessageAudio } or PlaybackItemProfileAudio && _isRepeatEnabled == true)
-                {
-                    SetSource(player, items, _isReversed ? items.Count - 1 : 0);
-                }
-                else if (CurrentItem is not PlaybackItemMessage { Message.Content: MessageVoiceNote or MessageVideoNote })
-                {
-                    StopImpl(player);
-                }
-                else
-                {
-                    ClearImpl(player);
-                }
+                SetSource(player, items, next);
+            }
+            else if (items.Count > 0 && CurrentItem is PlaybackItemMessage { Message.Content: MessageAudio } or PlaybackItemProfileAudio && _isRepeatEnabled == true)
+            {
+                SetSource(player, items, _isReversed ? items.Count - 1 : 0);
+            }
+            else if (!present || CurrentItem is PlaybackItemMessage { Message.Content: MessageVoiceNote or MessageVideoNote })
+            {
+                // A track that is no longer in the playlist and has nothing to move on to
+                // must not stay in the bar: a deleted message would still be resumable.
+                ClearImpl(player);
             }
             else
             {
-                SetSource(player, items, _isReversed ? index - 1 : index + 1);
+                StopImpl(player);
             }
         }
 
@@ -748,25 +841,24 @@ namespace Telegram.Services
                 return;
             }
 
-            var index = items.IndexOf(CurrentItem);
-            if (index == -1 || index == (_isReversed ? items.Count - 1 : 0))
+            var present = TryGetNeighbours(items, out var before, out var after);
+            var previous = _isReversed ? after : before;
+
+            if (previous >= 0 && previous < items.Count)
             {
-                if (CurrentItem is PlaybackItemMessage { Message.Content: MessageAudio } or PlaybackItemProfileAudio && _isRepeatEnabled == true)
-                {
-                    SetSource(player, items, _isReversed ? 0 : items.Count - 1);
-                }
-                else if (CurrentItem is not PlaybackItemMessage { Message.Content: MessageVoiceNote or MessageVideoNote })
-                {
-                    StopImpl(player);
-                }
-                else
-                {
-                    ClearImpl(player);
-                }
+                SetSource(player, items, previous);
+            }
+            else if (items.Count > 0 && CurrentItem is PlaybackItemMessage { Message.Content: MessageAudio } or PlaybackItemProfileAudio && _isRepeatEnabled == true)
+            {
+                SetSource(player, items, _isReversed ? 0 : items.Count - 1);
+            }
+            else if (!present || CurrentItem is PlaybackItemMessage { Message.Content: MessageVoiceNote or MessageVideoNote })
+            {
+                ClearImpl(player);
             }
             else
             {
-                SetSource(player, items, _isReversed ? index + 1 : index - 1);
+                StopImpl(player);
             }
         }
 
@@ -877,6 +969,7 @@ namespace Telegram.Services
                 lock (_mediaPlayerLock)
                 {
                     _items = items;
+                    _orphanNext = null;
                 }
 
                 PlaylistChanged?.Invoke(this, EventArgs.Empty);
@@ -886,6 +979,293 @@ namespace Telegram.Services
             return false;
         }
 
+        #region Reconciliation
+
+        private void SubscribeUpdates(IClientService clientService)
+        {
+            UnsubscribeUpdates();
+
+            var aggregator = clientService.Session?.Resolve<IEventAggregator>();
+            if (aggregator == null)
+            {
+                return;
+            }
+
+            _aggregator = aggregator;
+
+            aggregator.Subscribe<UpdateNewMessage>(this, Handle)
+                .Subscribe<UpdateMessageSendSucceeded>(Handle)
+                .Subscribe<UpdateDeleteMessages>(Handle)
+                .Subscribe<UpdateMessageContent>(Handle);
+        }
+
+        private void UnsubscribeUpdates()
+        {
+            // Unsubscribe(subscriber) drops every type this service subscribed on that
+            // aggregator, which is all four and nothing else: the album cover file token
+            // lives on EventAggregator.Current instead.
+            var aggregator = _aggregator;
+            _aggregator = null;
+
+            aggregator?.Unsubscribe(this);
+        }
+
+        private void Handle(UpdateNewMessage update)
+        {
+            // A message still being sent carries an id from the pending range that the server
+            // replaces on success, so it waits for UpdateMessageSendSucceeded instead: adding
+            // it now would leave the playlist holding an id nothing else will ever match, and
+            // move the paging cursor onto one.
+            if (update.Message.SendingState != null)
+            {
+                return;
+            }
+
+            AddNewest(update.Message);
+        }
+
+        private void Handle(UpdateMessageSendSucceeded update)
+        {
+            AddNewest(update.Message);
+        }
+
+        private void AddNewest(Message message)
+        {
+            if (_source is not ChatPlaybackSource source || !source.Accepts(message))
+            {
+                return;
+            }
+
+            bool added;
+
+            lock (_mediaPlayerLock)
+            {
+                // The playlist can have been swapped out on another thread between the check
+                // above and here. Its cursor must not be moved once it has been: the source
+                // is abandoned, and the items would land in somebody else's playlist.
+                var items = _source == source ? _items : null;
+
+                // A message newer than the whole playlist can only be added once the newest
+                // end has been reached; before that there are messages in between, and moving
+                // the cursor over them would lose them.
+                added = items != null && source.CanAddNewest;
+                if (added)
+                {
+                    items.Insert(source.NewestFirst ? 0 : items.Count, source.Create(message));
+                    source.Extend(message.Id);
+                }
+            }
+
+            if (added)
+            {
+                PlaylistChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        private void Handle(UpdateDeleteMessages update)
+        {
+            // FromCache is TDLib forgetting a message, not the message going away, and a
+            // non-permanent delete is one it expects to see again.
+            if (update.FromCache || !update.IsPermanent)
+            {
+                return;
+            }
+
+            if (_source is not ChatPlaybackSource source || source.ChatId != update.ChatId)
+            {
+                return;
+            }
+
+            var current = _currentItem;
+            var removedCurrent = false;
+            var removed = false;
+
+            lock (_mediaPlayerLock)
+            {
+                // The playlist can have been swapped out on another thread between the check
+                // above and here, in which case these items are not the ones to touch.
+                var items = _source == source ? _items : null;
+                if (items == null)
+                {
+                    return;
+                }
+
+                OrphanCurrent(update.MessageIds);
+
+                for (int i = items.Count - 1; i >= 0; i--)
+                {
+                    if (items[i] is not PlaybackItemMessage message || !update.MessageIds.Contains(message.Id))
+                    {
+                        continue;
+                    }
+
+                    removedCurrent |= items[i] == current;
+                    items.RemoveAt(i);
+                    removed = true;
+                }
+            }
+
+            if (!removed)
+            {
+                return;
+            }
+
+            PlaylistChanged?.Invoke(this, EventArgs.Empty);
+
+            // A deleted message must not keep playing: whoever sent it took it back.
+            if (removedCurrent)
+            {
+                MoveNext();
+            }
+        }
+
+        private void Handle(UpdateMessageContent update)
+        {
+            if (_source is not ChatPlaybackSource source || source.ChatId != update.ChatId)
+            {
+                return;
+            }
+
+            var current = _currentItem;
+
+            PlaybackItem replacement = null;
+            var replacedCurrent = false;
+            var removedCurrent = false;
+
+            lock (_mediaPlayerLock)
+            {
+                // The playlist can have been swapped out on another thread between the check
+                // above and here, in which case these items are not the ones to touch.
+                var items = _source == source ? _items : null;
+                if (items == null)
+                {
+                    return;
+                }
+
+                var index = items.FindIndex(x => x is PlaybackItemMessage message && message.Id == update.MessageId);
+                if (index < 0)
+                {
+                    return;
+                }
+
+                var item = (PlaybackItemMessage)items[index];
+
+                if (source.Accepts(update.NewContent))
+                {
+                    // Everything an item exposes is read off the content when it is built, so
+                    // a new content makes a new item rather than a patched one.
+                    item.Message.Content = update.NewContent;
+
+                    replacement = new PlaybackItemMessage(item.XamlRoot, item.Message, item.TopicId);
+                    replacedCurrent = item == current;
+
+                    items[index] = replacement;
+                }
+                else
+                {
+                    // A voice note that expired, or media edited into something that is not
+                    // played at all.
+                    removedCurrent = item == current;
+
+                    if (removedCurrent)
+                    {
+                        OrphanCurrent();
+                    }
+
+                    items.RemoveAt(index);
+                }
+            }
+
+            if (replacedCurrent)
+            {
+                // An edit can replace the file as well, but the player is already streaming
+                // the old one: take the new item for what is shown and leave playback alone.
+                // Assigned directly rather than through the property, whose setter would
+                // rewind the position and overwrite the duration with the metadata one -
+                // only what is displayed for the track can have changed, not the track.
+                _currentItem = replacement;
+                UpdateTransport(replacement);
+                SourceChanged?.Invoke(this, replacement);
+            }
+
+            PlaylistChanged?.Invoke(this, EventArgs.Empty);
+
+            // Same as a delete: what is gone must not keep playing.
+            if (removedCurrent)
+            {
+                MoveNext();
+            }
+        }
+
+        public void ProfileAudioAdded(PlaybackItem item)
+        {
+            var audio = item?.Track;
+
+            // addProfileAudio puts the audio first, and only the current user's own profile
+            // can be added to.
+            if (audio == null || _source is not UserProfileAudioPlaybackSource source || source.UserId != source.ClientService.Options.MyId)
+            {
+                return;
+            }
+
+            var added = new PlaybackItemProfileAudio(item.XamlRoot, new AudioWithOwner(source.ClientService, _userId, audio));
+
+            lock (_mediaPlayerLock)
+            {
+                var items = _source == source ? _items : null;
+                if (items == null)
+                {
+                    return;
+                }
+
+                items.Insert(0, added);
+
+                // Paging is by position, so everything after it moved down one.
+                source.Skip(1);
+            }
+
+            PlaylistChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        public void ProfileAudioRemoved(int fileId)
+        {
+            if (_source is not UserProfileAudioPlaybackSource source || source.UserId != source.ClientService.Options.MyId)
+            {
+                return;
+            }
+
+            lock (_mediaPlayerLock)
+            {
+                var items = _source == source ? _items : null;
+                if (items == null)
+                {
+                    return;
+                }
+
+                var index = items.FindIndex(x => x.Document.Id == fileId);
+                if (index < 0)
+                {
+                    return;
+                }
+
+                // It plays on from outside the playlist, so the gap it leaves is what Next
+                // moves from when it ends.
+                if (items[index] == _currentItem)
+                {
+                    OrphanCurrent();
+                }
+
+                items.RemoveAt(index);
+                source.Skip(-1);
+            }
+
+            // Removing from your own profile is not somebody taking a message back, so an
+            // audio playing when it leaves the list plays on.
+            PlaylistChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        #endregion
+
         // The list is read from the player's dispatcher and from whichever window drives
         // playback, so it is only ever mutated under the lock those reads already take.
         private void AddItems(IList<PlaybackItem> page, bool forward)
@@ -894,6 +1274,28 @@ namespace Telegram.Services
             {
                 var items = _items;
                 if (items == null)
+                {
+                    return;
+                }
+
+                // Profile paging is positional, and an audio added or removed while a page was
+                // in flight moves everything under it: whether the server applied that before
+                // or after serving the page decides whether it comes back overlapping the
+                // playlist. Cheaper to drop the overlap here, once a page, than to try to
+                // guess the order it happened in.
+                for (int i = page.Count - 1; i >= 0; i--)
+                {
+                    for (int j = 0; j < items.Count; j++)
+                    {
+                        if (items[j].AreTheSame(page[i]))
+                        {
+                            page.RemoveAt(i);
+                            break;
+                        }
+                    }
+                }
+
+                if (page.Count == 0)
                 {
                     return;
                 }
@@ -951,7 +1353,16 @@ namespace Telegram.Services
             if (_previous != null)
             {
                 _items = _previous.Items;
+                _source = _previous.Source;
                 _playbackSpeed = _previous.CurrentItem.CanChangePlaybackRate ? AppSettings.Playback.AudioSpeed : 1;
+
+                // Only a chat playlist has updates to reconcile against, matching what the
+                // profile Play overload does: every handler would bail on the first check.
+                if (_previous.Source is ChatPlaybackSource chat)
+                {
+                    SubscribeUpdates(chat.ClientService);
+                }
+
                 CurrentItem = _previous.CurrentItem;
 
                 _isAdvancing = false;
@@ -1058,6 +1469,7 @@ namespace Telegram.Services
             source.Seed(message.Id);
 
             _source = source;
+            SubscribeUpdates(message.ClientService);
 
             SetSource(null, item);
 
@@ -1200,7 +1612,10 @@ namespace Telegram.Services
             _items = null;
             _source = null;
             _provisional = false;
+            _orphanNext = null;
             _type = type;
+
+            UnsubscribeUpdates();
         }
 
         private void OnStateChanged(AsyncMediaPlayer sender, AsyncMediaPlayerStateChangedEventArgs args)
@@ -1240,12 +1655,18 @@ namespace Telegram.Services
 
             public PlaybackState State { get; }
 
+            /// <summary>
+            /// Carried too, so the interrupted playlist can still grow once it comes back.
+            /// </summary>
+            public PlaybackSource Source { get; }
+
             public PlaybackPreviousState(PlaybackService service, AsyncMediaPlayer player)
             {
                 Items = service._items.ToList();
                 CurrentItem = service.CurrentItem;
                 Position = player.Position;
                 State = service.PlaybackState;
+                Source = service._source;
             }
         }
 
@@ -1315,6 +1736,16 @@ namespace Telegram.Services
         /// that isn't music.
         /// </summary>
         public Thumbnail AlbumCover { get; protected set; }
+
+        /// <summary>
+        /// The audio this item plays, or null for a voice or video note. Needed to move an
+        /// item into a profile audio playlist, which holds audio rather than messages.
+        /// </summary>
+        /// <remarks>
+        /// Not called Audio: PlaybackItemProfileAudio already has one of those, and it is an
+        /// AudioWithOwner rather than the audio itself.
+        /// </remarks>
+        public Audio Track { get; protected set; }
 
         public int Duration { get; protected set; }
 
@@ -1391,6 +1822,7 @@ namespace Telegram.Services
                 Duration = audio.Audio.Duration;
                 CanChangePlaybackRate = audio.Audio.Duration >= 10 * 60;
                 AlbumCover = SelectAlbumCover(audio.Audio.AlbumCoverThumbnail, audio.Audio.ExternalAlbumCovers);
+                Track = audio.Audio;
 
                 if (string.IsNullOrEmpty(audio.Audio.Title))
                 {
@@ -1453,6 +1885,7 @@ namespace Telegram.Services
                     Duration = previewAudio.Audio.Duration;
                     CanChangePlaybackRate = previewAudio.Audio.Duration >= 10 * 60;
                     AlbumCover = SelectAlbumCover(previewAudio.Audio.AlbumCoverThumbnail, previewAudio.Audio.ExternalAlbumCovers);
+                    Track = previewAudio.Audio;
 
                     if (string.IsNullOrEmpty(previewAudio.Audio.Title))
                     {
@@ -1517,6 +1950,7 @@ namespace Telegram.Services
                     Duration = blockAudio.Audio.Duration;
                     CanChangePlaybackRate = blockAudio.Audio.Duration >= 10 * 60;
                     AlbumCover = SelectAlbumCover(blockAudio.Audio.AlbumCoverThumbnail, blockAudio.Audio.ExternalAlbumCovers);
+                    Track = blockAudio.Audio;
 
                     if (string.IsNullOrEmpty(blockAudio.Audio.Title))
                     {
@@ -1583,6 +2017,7 @@ namespace Telegram.Services
             Duration = audio.Duration;
             CanChangePlaybackRate = audio.Duration >= 10 * 60;
             AlbumCover = SelectAlbumCover(audio.AlbumCoverThumbnail, audio.ExternalAlbumCovers);
+            Track = audio.Value;
 
             if (string.IsNullOrEmpty(audio.Title))
             {

--- a/Telegram/Services/PlaybackSource.cs
+++ b/Telegram/Services/PlaybackSource.cs
@@ -89,6 +89,54 @@ namespace Telegram.Services
         public MessageTopic Topic => _topic;
 
         /// <summary>
+        /// Whether the newest message is the start of the playlist rather than its end.
+        /// </summary>
+        public bool NewestFirst => _newestFirst;
+
+        /// <summary>
+        /// Whether a message newer than everything else can be added straight away. Until
+        /// the newest end has actually been reached there are messages between it and the
+        /// playlist, and adding past them would move the cursor over the gap.
+        /// </summary>
+        public bool CanAddNewest => !HasMore(!_newestFirst);
+
+        /// <summary>
+        /// Whether a message belongs in this playlist at all.
+        /// </summary>
+        public bool Accepts(Message message)
+        {
+            if (message.ChatId != _chatId)
+            {
+                return false;
+            }
+
+            // No topic means the whole chat. Comparing anyway would reject everything, since
+            // in a forum every message carries a topic and AreTheSame(null, x) is false.
+            if (_topic != null && !_topic.AreTheSame(message.TopicId))
+            {
+                return false;
+            }
+
+            return Accepts(message.Content);
+        }
+
+        /// <summary>
+        /// Whether a content is one this playlist plays. An expired voice note, or media
+        /// edited into something else, is not.
+        /// </summary>
+        public bool Accepts(MessageContent content)
+        {
+            return _filter is SearchMessagesFilterAudio
+                ? content is MessageAudio
+                : content is MessageVoiceNote or MessageVideoNote;
+        }
+
+        public PlaybackItem Create(Message message)
+        {
+            return new PlaybackItemMessage(_xamlRoot, new MessageWithOwner(ClientService, message), _topic);
+        }
+
+        /// <summary>
         /// Records the message the session starts from, so the first page in either
         /// direction is searched from it rather than from the end of the chat.
         /// </summary>
@@ -240,11 +288,13 @@ namespace Telegram.Services
         /// <remarks>
         /// Paging here is by position, so those items have to be the start of the profile
         /// list and in its order: an offset that does not match what the caller holds does
-        /// not just repeat items, it skips the ones in between.
+        /// not just repeat items, it skips the ones in between. Which is also why adding or
+        /// removing an audio at the front has to move the cursor with it - hence negative
+        /// counts.
         /// </remarks>
         public void Skip(int count)
         {
-            _offset += count;
+            _offset = Math.Max(0, _offset + count);
         }
 
         public override bool HasMore(bool forward)

--- a/Telegram/Views/Popups/PlaybackPopup.xaml.cs
+++ b/Telegram/Views/Popups/PlaybackPopup.xaml.cs
@@ -81,7 +81,18 @@ namespace Telegram.Views.Popups
 
         public void UpdateItem(PlaybackItem oldItem, PlaybackItem newItem)
         {
-            // Do nothing
+            // An edited message keeps its id, so the diff treats the rebuilt item as the same
+            // one and leaves the old instance in place. It is the instance the row displays
+            // and the one a click hands back to the service, so it has to be swapped: the
+            // playlist no longer holds it, and playing it would start a track from outside.
+            if (oldItem != newItem)
+            {
+                var index = _items.IndexOf(oldItem);
+                if (index >= 0)
+                {
+                    _items[index] = newItem;
+                }
+            }
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)
@@ -534,9 +545,13 @@ namespace Telegram.Views.Popups
             _navigationService.ShowPopup(new ChooseChatsPopup(), new ChooseChatsConfigurationPostMessage(audio.ToInputMessage()));
         }
 
-        private void SaveToProfile(PlaybackItem item)
+        private async void SaveToProfile(PlaybackItem item)
         {
-            _clientService.Send(new AddProfileAudio(new InputAudio(new InputFileId(item.Document.Id), null, 0, string.Empty, string.Empty)));
+            if (!await AddProfileAudioAsync(item))
+            {
+                return;
+            }
+
             _navigationService.ShowToast(Strings.AudioSaveToMyProfileSaved, ToastPopupIcon.SavedMessages);
 
             if (item.AreTheSame(LifetimeService.Current.Playback.CurrentItem))
@@ -722,20 +737,88 @@ namespace Telegram.Views.Popups
             }
         }
 
-        private void AddToProfile_Click(object sender, RoutedEventArgs e)
+        // A profile audio request is in flight. Both buttons stay visible and hit-testable
+        // through the swap animation, so without this a second click sends a second request
+        // and moves the playlist twice over.
+        private bool _profileAudioPending;
+
+        /// <summary>
+        /// Adds an audio to the current user's profile, telling the playback service only
+        /// once the server has taken it. Returns whether it did.
+        /// </summary>
+        /// <remarks>
+        /// Profile paging is positional, so an optimistic insert that the server then refuses
+        /// leaves a phantom item in the playlist and the paging cursor one off for the rest
+        /// of the session, repeating or skipping an audio on every page after it.
+        /// </remarks>
+        private async Task<bool> AddProfileAudioAsync(PlaybackItem item)
         {
-            if (LifetimeService.Current.Playback.CurrentItem is PlaybackItem item)
+            if (_profileAudioPending)
             {
-                _clientService.Send(new AddProfileAudio(new InputAudio(new InputFileId(item.Document.Id), null, 0, string.Empty, string.Empty)));
+                return false;
+            }
+
+            _profileAudioPending = true;
+
+            var response = await _clientService.SendAsync(new AddProfileAudio(new InputAudio(new InputFileId(item.Document.Id), null, 0, string.Empty, string.Empty)));
+
+            _profileAudioPending = false;
+
+            if (response is Error error)
+            {
+                ToastPopup.ShowError(XamlRoot, error);
+                return false;
+            }
+
+            LifetimeService.Current.Playback.ProfileAudioAdded(item);
+            return true;
+        }
+
+        private async Task<bool> RemoveProfileAudioAsync(PlaybackItem item)
+        {
+            if (_profileAudioPending)
+            {
+                return false;
+            }
+
+            _profileAudioPending = true;
+
+            var response = await _clientService.SendAsync(new RemoveProfileAudio(item.Document.Id));
+
+            _profileAudioPending = false;
+
+            if (response is Error error)
+            {
+                ToastPopup.ShowError(XamlRoot, error);
+                return false;
+            }
+
+            LifetimeService.Current.Playback.ProfileAudioRemoved(item.Document.Id);
+            return true;
+        }
+
+        private async void AddToProfile_Click(object sender, RoutedEventArgs e)
+        {
+            if (LifetimeService.Current.Playback.CurrentItem is not PlaybackItem item)
+            {
+                return;
+            }
+
+            if (await AddProfileAudioAsync(item) && item.AreTheSame(LifetimeService.Current.Playback.CurrentItem))
+            {
                 ShowHideRemove(true);
             }
         }
 
-        private void RemoveFromProfile_Click(object sender, TextUrlClickEventArgs e)
+        private async void RemoveFromProfile_Click(object sender, TextUrlClickEventArgs e)
         {
-            if (LifetimeService.Current.Playback.CurrentItem is PlaybackItem item)
+            if (LifetimeService.Current.Playback.CurrentItem is not PlaybackItem item)
             {
-                _clientService.Send(new RemoveProfileAudio(item.Document.Id));
+                return;
+            }
+
+            if (await RemoveProfileAudioAsync(item) && item.AreTheSame(LifetimeService.Current.Playback.CurrentItem))
+            {
                 ShowHideRemove(false);
             }
         }


### PR DESCRIPTION
Second of three. #3379 is merged, so this is on `develop`; #3381 sits on top.

The second commit is unrelated to any of this: two fixes to the playback bar that came out of
reviewing `develop`'s own 0b13d82c2, kept separate so it can be cherry-picked straight onto
`develop`. Scrubbing called the overload that defaults the rate back to 1, and `UpdateValue`
returned before recording an origin when there was no template yet, leaving `DrawnPosition` to
measure from a timestamp of zero.

An open playlist was a snapshot of the moment playback started. Audio arriving in the chat never
appeared in it, and a message deleted while playing carried on to the end of the track.

### Chat playlists

`PlaybackService` subscribes to the playing session's aggregator — the per-session one, not the
static instance the album cover file tokens go through — for `UpdateNewMessage`,
`UpdateMessageSendSucceeded`, `UpdateDeleteMessages` and `UpdateMessageContent`, and drops the
subscription with the playlist. Only a chat playlist subscribes: a profile one has no update to
reconcile against, and every handler would bail on its first check.

**A new message is only added once the newest end has been reached.** Before that there are
messages between the playlist and the new one, and `Extend`ing the cursor over them would move
it past the gap and lose them for good. `CanAddNewest` is what gates it, and note it depends on
the playlist rather than on the direction: the newest message is the *start* of an audio playlist
and the *end* of a voice note one.

`Accepts` deliberately only compares topics when the playlist has one. A null topic means the
whole chat, and comparing anyway would reject everything, since in a forum every message carries
a topic and `AreTheSame(null, x)` is false.

**A message still being sent is not added until it succeeds.** Its id comes from the pending
range and the server replaces it, so a playlist holding one holds an id that no later deletion,
`GetMessageProperties` or "show in chat" will ever match — and `Extend` would move the paging
cursor onto it. `UpdateMessageSendSucceeded` adds it through the same path once it has a real
one.

`UpdateMessageContent` replaces the item rather than patching it, because everything an item
exposes — file, duration, title, cover — is read off the content when it is built. A content the
playlist does not play, which is what a voice note becomes when it expires, takes the item out
instead, and if it was playing that stops it, for the same reason a deletion does. When the
replaced item is the playing one, `_currentItem` is assigned directly rather than through the
property — the setter would rewind the position and overwrite the duration with the metadata one,
and the player is still streaming the file it opened — and `SourceChanged` is raised by hand,
since that is what the header and the popup listen to for the title.

**Deleting the playing message moves on to the next one.** That is a privacy matter, not tidiness
— whoever sent it took it back, so it should stop. `FromCache` and non-permanent deletions are
ignored, following `GalleryWindow`.

A track taken out of the playlist while it plays holds no index of its own any more, so `Next`
and `Previous` cannot find it to move from. `OrphanCurrent` records the track that fills the gap
it leaves — the neighbour rather than an index, so nothing has to be shifted as the playlist
changes around it — and the two navigation methods move from the two sides of that gap. When
there is nothing to move on to, an orphan ends the playlist rather than pausing on it: `StopImpl`
leaves `CurrentItem` set, which would keep a deleted message in the bar and resumable.

### Profile audio

There is no server update for it, and the only changes are local ones made from `PlaybackPopup`,
so the popup reports them through `ProfileAudioAdded` / `ProfileAudioRemoved` — following the
precedent already set by `MoveTo` for drag-reorder. Removing an audio from your own profile is
not somebody taking a message back, so one playing when it leaves the list plays on, and moves to
the gap it left when it ends.

Both are reported only once the server has taken the change. Paging is positional, so an
optimistic insert that then fails leaves a phantom item in the playlist and the cursor one off
for the rest of the session, repeating or skipping an audio on every page after it. Both adjust
the cursor by one for the same reason: inserting at the front shifts everything after it down.

A page in flight while one of those lands can come back overlapping the playlist, depending on
whether the server applied the change before or after serving it. `AddItems` drops items the
playlist already holds rather than guessing the order it happened in.

### Threading

The update handlers run on the TDLib thread, so `_source` is re-checked inside `_mediaPlayerLock`
before anything is touched, and the cursor is moved under it too. Without that, a playlist
started on the UI thread between the check and the insert gets a message from the chat that was
playing before it, and an abandoned source's cursor moves for a playlist that no longer exists.
`LoadMoreAsync` already guarded itself this way after its await.

### Incidental

- `PlaybackPreviousState` now carries the source, so a music playlist interrupted by a voice note
  can still grow once it comes back. Without it the restore left `_source` null and paging was
  dead for the rest of the session.
- `AudioWithOwner.Value` keeps the `Audio` it copied its fields from, and `PlaybackItem.Track`
  exposes it, so an item can be moved into a profile playlist. `Track` rather than `Audio`
  because `PlaybackItemProfileAudio.Audio` already exists and is an `AudioWithOwner`.
- The service methods are named `ProfileAudioAdded` / `ProfileAudioRemoved` rather than after the
  td_api requests they follow, which would have shadowed `AddProfileAudio` / `RemoveProfileAudio`
  at the call site.
- `PlaybackPopup.UpdateItem` swaps the rebuilt instance into the row. The diff matches items by
  message id, so an edited one keeps the old instance — the one the row displays and the one a
  click hands back to the service, which the playlist no longer holds.

### Testing

Builds clean. Not exercised at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

