### PR TITLE
Screen readers fixes

### DIFF
--- a/Documentation/Accessibility.md
+++ b/Documentation/Accessibility.md
@@ -1,0 +1,23 @@
+# Accessibility conventions
+
+## Screen-reader message summaries
+
+Every non-service message exposed through UI Automation starts with a stable sender prefix. The same policy is used for message-list items, compact history items, and notifications for new messages.
+
+| Message | Prefix |
+| --- | --- |
+| Incoming private or group message | Sender display name |
+| Outgoing private or group message | Localized “You” label |
+| Channel post | Sender or channel title |
+| Saved Message | Original source title, when available |
+| Service message | No added prefix; the service text identifies its actor and action |
+
+The prefix is included on every message, even when adjacent messages are visually grouped. This keeps keyboard and screen-reader navigation unambiguous. A colon separates the prefix from the content summary.
+
+Messages with an inline keyboard add a concise localized “Message has inline buttons” indication to the summary. Button labels are not duplicated in the message summary; they remain available when the user navigates to the buttons.
+
+## New-message notifications
+
+Newly inserted incoming and outgoing messages in the active chat raise a UI Automation notification event. Notifications use the same prefix and content-summary policy as message items, include the inline-button indication, and use `AutomationNotificationProcessing.All` so a burst of messages is announced in order. Loading existing history does not raise these notifications.
+
+UI code must use `AccessibilityService` for UI Automation listener detection and notification delivery instead of calling `AutomationPeer.ListenerExists` directly.

--- a/Telegram/Common/Automation.cs
+++ b/Telegram/Common/Automation.cs
@@ -92,24 +92,65 @@ namespace Telegram.Common
 
         public static string GetSummaryWithName(MessageWithOwner message, bool details = false, bool addCaption = true)
         {
-            var summary = GetSummary(message, details, addCaption);
+            var summary = GetAccessibleSummary(message, details, addCaption);
+            var prefix = GetMessagePrefix(message);
+
+            if (!string.IsNullOrEmpty(prefix))
+            {
+                return $"{prefix}: {summary}";
+            }
+
+            return summary;
+        }
+
+        /// <summary>
+        /// Returns the stable sender prefix used by screen-reader message summaries.
+        /// </summary>
+        public static string GetMessagePrefix(MessageWithOwner message)
+        {
+            if (message == null || message.Content.IsService())
+            {
+                return null;
+            }
+
+            if (message.IsSaved)
+            {
+                return message.ClientService.GetTitle(message.ForwardInfo?.Origin, message.ImportInfo);
+            }
+
+            if (message.IsOutgoing && !message.IsChannelPost)
+            {
+                return Strings.FromYou;
+            }
 
             if (message.ClientService.TryGetUser(message.SenderId, out User user))
             {
-                if (user.Id == message.ClientService.Options.MyId)
-                {
-                    return $"{Strings.FromYou}: {summary}";
-                }
-
-                return $"{user.FullName()}: {summary}";
+                return user.FullName();
             }
-            //else if (message.IsChannelPost)
-            //{
-            //    return summary;
-            //}
-            else if (message.ClientService.TryGetChat(message.SenderId, out Chat chat))
+
+            if (message.ClientService.TryGetChat(message.SenderId, out Chat senderChat))
             {
-                return $"{chat.Title}: {summary}";
+                return message.ClientService.GetTitle(senderChat);
+            }
+
+            if (message.IsChannelPost)
+            {
+                return message.ClientService.GetTitle(message.Chat);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns the content summary plus concise interactive-content metadata.
+        /// Individual inline button labels remain available when navigating to the buttons.
+        /// </summary>
+        public static string GetAccessibleSummary(MessageWithOwner message, bool details = false, bool addCaption = true)
+        {
+            var summary = GetSummary(message, details, addCaption);
+            if (message?.ReplyMarkup is ReplyMarkupInlineKeyboard)
+            {
+                return $"{summary}{Strings.AccDescrMessageHasInlineButtons}. ";
             }
 
             return summary;

--- a/Telegram/Common/WatchDog.cs
+++ b/Telegram/Common/WatchDog.cs
@@ -28,7 +28,6 @@ using Windows.ApplicationModel.Core;
 using Windows.Storage;
 using Windows.System;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using File = System.IO.File;
@@ -621,7 +620,7 @@ namespace Telegram
 
             if (WindowContext.Current != null)
             {
-                var reader = AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged);
+                var reader = AccessibilityService.IsScreenReaderActive;
                 var scaling = (WindowContext.Current.RasterizationScale * 100).ToString("N0");
                 var text = (BootStrapper.Current.TextScaleFactor * 100).ToString("N0");
                 var size = Window.Current.Bounds;

--- a/Telegram/Controls/ChatListListView.cs
+++ b/Telegram/Controls/ChatListListView.cs
@@ -759,6 +759,7 @@ namespace Telegram.Controls
             {
                 ChatCell chat => chat.GetAutomationName(),
                 ForumTopicCell topic => topic.GetAutomationName(),
+                ForumTopicVerticalCell topic => topic.GetAutomationName(),
                 _ => null
             };
 

--- a/Telegram/Controls/Chats/ChatActionBarView.xaml
+++ b/Telegram/Controls/Chats/ChatActionBarView.xaml
@@ -25,6 +25,7 @@
         </Grid>
 
         <controls:GlyphButton x:Name="RemoveButton"
+                              AutomationProperties.Name="{CustomResource AccDescrDismissBar}"
                               Click="Remove_Click"
                               Glyph="&#xE711;"
                               Height="32"

--- a/Telegram/Controls/Chats/ChatHistoryView.cs
+++ b/Telegram/Controls/Chats/ChatHistoryView.cs
@@ -12,6 +12,7 @@ using Telegram.Collections;
 using Telegram.Common;
 using Telegram.Controls.Messages;
 using Telegram.Navigation;
+using Telegram.Services;
 using Telegram.Td.Api;
 using Telegram.ViewModels;
 using Telegram.ViewModels.Delegates;
@@ -20,7 +21,6 @@ using Windows.Foundation;
 using Windows.UI.Core;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Hosting;
@@ -495,7 +495,7 @@ namespace Telegram.Controls.Chats
 
         private void TryFocus(SelectorItem selectorItem, MessageBubbleHighlightOptions options)
         {
-            if ((options == null || options.MoveFocus) && AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+            if ((options == null || options.MoveFocus) && AccessibilityService.IsScreenReaderActive)
             {
                 TryFocus(selectorItem, false);
             }

--- a/Telegram/Controls/Chats/ChatHistoryView.cs
+++ b/Telegram/Controls/Chats/ChatHistoryView.cs
@@ -17,6 +17,7 @@ using Telegram.ViewModels;
 using Telegram.ViewModels.Delegates;
 using Windows.Devices.Input;
 using Windows.Foundation;
+using Windows.UI.Core;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation.Peers;
@@ -494,16 +495,46 @@ namespace Telegram.Controls.Chats
 
         private void TryFocus(SelectorItem selectorItem, MessageBubbleHighlightOptions options)
         {
+            if ((options == null || options.MoveFocus) && AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+            {
+                TryFocus(selectorItem, false);
+            }
+        }
+
+        private void TryFocus(SelectorItem selectorItem, bool isRetry)
+        {
+            var destination = selectorItem.Content?.GetType().Name ?? selectorItem.GetType().Name;
+
             try
             {
-                if ((options == null || options.MoveFocus) && AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+                if (selectorItem.Focus(FocusState.Keyboard))
                 {
-                    selectorItem.Focus(FocusState.Keyboard);
+                    return;
                 }
+
+                Logger.Warning($"Accessibility focus was not moved to {destination} (retry: {isRetry}).");
             }
-            catch
+            catch (Exception ex)
             {
-                // Focus cannot be moved while getting or losing focus.
+                Logger.Error($"Failed to move accessibility focus to {destination} (retry: {isRetry}).", ex);
+            }
+
+            if (!isRetry)
+            {
+                try
+                {
+                    _ = selectorItem.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                    {
+                        if (selectorItem.IsLoaded)
+                        {
+                            TryFocus(selectorItem, true);
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Failed to schedule accessibility focus retry for {destination}.", ex);
+                }
             }
         }
 

--- a/Telegram/Controls/Chats/ChatRecordBar.xaml
+++ b/Telegram/Controls/Chats/ChatRecordBar.xaml
@@ -25,6 +25,7 @@
                     <ColumnDefinition />
                 </Grid.ColumnDefinitions>
                 <controls:GlyphButton x:Name="DeleteButton"
+                                      AutomationProperties.Name="{CustomResource AccDescrCancelRecording}"
                                       Click="ButtonCancelRecording_Click"
                                       Glyph="&#xE74D;"
                                       Visibility="Collapsed" />

--- a/Telegram/Controls/Chats/ChatSearchBar.xaml.cs
+++ b/Telegram/Controls/Chats/ChatSearchBar.xaml.cs
@@ -12,11 +12,11 @@ using System.Numerics;
 using Telegram.Common;
 using Telegram.Controls.Cells;
 using Telegram.Navigation;
+using Telegram.Services;
 using Telegram.Td.Api;
 using Telegram.ViewModels;
 using Telegram.ViewModels.Chats;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Documents;
@@ -49,7 +49,7 @@ namespace Telegram.Controls.Chats
             _debouncer = new EventDebouncer<TextChangedEventArgs>(Constants.TypingTimeout, handler => Field.TextChanged += new TextChangedEventHandler(handler));
             _debouncer.Invoked += (s, args) =>
             {
-                if (Field.State != ChatSearchState.Members && !AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+                if (Field.State != ChatSearchState.Members && !AccessibilityService.IsScreenReaderActive)
                 {
                     ViewModel?.Search(Field.Text, Field.From, ViewModel.SavedMessagesTag, null);
                 }

--- a/Telegram/Controls/FileButton.cs
+++ b/Telegram/Controls/FileButton.cs
@@ -11,6 +11,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using Telegram.Controls.Media;
 using Telegram.Navigation;
+using Telegram.Services;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
@@ -118,7 +119,7 @@ namespace Telegram.Controls
                     ProgressBar.Value = value;
                 }
 
-                if (AutomationPeer.ListenerExists(AutomationEvents.PropertyChanged))
+                if (AccessibilityService.HasPropertyChangedListeners)
                 {
                     var peer = FrameworkElementAutomationPeer.FromElement(this);
                     peer?.RaisePropertyChangedEvent(ValuePatternIdentifiers.ValueProperty, _progress, value);

--- a/Telegram/Controls/LoopingPicker.cs
+++ b/Telegram/Controls/LoopingPicker.cs
@@ -8,6 +8,9 @@
 using System;
 using Windows.Foundation;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 
@@ -26,6 +29,11 @@ namespace Telegram.Controls
         {
             DefaultStyleKey = typeof(LoopingPicker);
             Click += OnClick;
+        }
+
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new LoopingPickerAutomationPeer(this);
         }
 
         private void OnClick(object sender, RoutedEventArgs e)
@@ -64,6 +72,14 @@ namespace Telegram.Controls
             ValueText?.Text = newValue.ToString($"D{_digits}");
 
             ValueChanged?.Invoke(this, new LoopingPickerValueChangedEventArgs(oldValue, newValue));
+
+            if (FrameworkElementAutomationPeer.FromElement(this) is LoopingPickerAutomationPeer peer)
+            {
+                peer.RaisePropertyChangedEvent(
+                    RangeValuePatternIdentifiers.ValueProperty,
+                    (double)oldValue,
+                    (double)newValue);
+            }
         }
 
         protected void OnMaximumChanged(int oldMaximum, int newMaximum)
@@ -233,5 +249,64 @@ namespace Telegram.Controls
         public int OldValue { get; }
 
         public int NewValue { get; }
+    }
+
+    public partial class LoopingPickerAutomationPeer : FrameworkElementAutomationPeer, IRangeValueProvider
+    {
+        private readonly LoopingPicker _owner;
+
+        public LoopingPickerAutomationPeer(LoopingPicker owner)
+            : base(owner)
+        {
+            _owner = owner;
+        }
+
+        protected override string GetClassNameCore()
+        {
+            return nameof(LoopingPicker);
+        }
+
+        protected override string GetNameCore()
+        {
+            var name = base.GetNameCore();
+            return string.IsNullOrEmpty(name) ? _owner.Header : name;
+        }
+
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            return AutomationControlType.Spinner;
+        }
+
+        protected override object GetPatternCore(PatternInterface patternInterface)
+        {
+            if (patternInterface == PatternInterface.RangeValue)
+            {
+                return this;
+            }
+
+            return base.GetPatternCore(patternInterface);
+        }
+
+        public bool IsReadOnly => false;
+
+        public double LargeChange => 1;
+
+        public double SmallChange => 1;
+
+        public double Minimum => 0;
+
+        public double Maximum => _owner.Maximum;
+
+        public double Value => _owner.Value;
+
+        public void SetValue(double value)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value) || value < Minimum || value > Maximum)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            _owner.Value = (int)Math.Round(value);
+        }
     }
 }

--- a/Telegram/Controls/MasterDetailView.cs
+++ b/Telegram/Controls/MasterDetailView.cs
@@ -583,10 +583,6 @@ namespace Telegram.Controls
 
                     ShowHideDetailHeader(true, hosted.ShowHeaderBackground);
 
-                    //if (AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
-                    //{
-                    //    VisualUtilities.QueueCallbackForCompositionRendering(() => DetailHeaderPresenter.Focus(FocusState.Keyboard));
-                    //}
                 }
                 else
                 {

--- a/Telegram/Controls/Messages/EmojiMenuFlyout.xaml.cs
+++ b/Telegram/Controls/Messages/EmojiMenuFlyout.xaml.cs
@@ -22,7 +22,6 @@ using Windows.Foundation;
 using Windows.UI;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Hosting;
@@ -107,7 +106,7 @@ namespace Telegram.Controls.Messages
             _drawer.Deactivate();
             _drawer.DataContext = null;
 
-            if (_bubble is FrameworkElement element && AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+            if (_bubble is FrameworkElement element && AccessibilityService.IsScreenReaderActive)
             {
                 var selector = element.GetParent<SelectorItem>();
                 selector?.Focus(FocusState.Keyboard);

--- a/Telegram/Controls/Messages/MessageBubble.xaml.cs
+++ b/Telegram/Controls/Messages/MessageBubble.xaml.cs
@@ -373,29 +373,11 @@ namespace Telegram.Controls.Messages
 
             var chat = message.Chat;
 
-            var title = string.Empty;
-            var senderBot = false;
-
-            if (message.IsSaved)
-            {
-                title = message.ClientService.GetTitle(message.ForwardInfo?.Origin, message.ImportInfo);
-            }
-            else if (chat.Type is ChatTypeBasicGroup || chat.Type is ChatTypeSupergroup supergroup && !supergroup.IsChannel)
-            {
-                if (message.IsOutgoing)
-                {
-                    title = null;
-                }
-                else if (message.ClientService.TryGetUser(message.SenderId, out User senderUser))
-                {
-                    senderBot = senderUser.Type is UserTypeBot;
-                    title = senderUser.FullName();
-                }
-                else if (message.ClientService.TryGetChat(message.SenderId, out Chat senderChat))
-                {
-                    title = message.ClientService.GetTitle(senderChat);
-                }
-            }
+            var title = Automation.GetMessagePrefix(message);
+            var senderBot = !message.IsOutgoing
+                && (chat.Type is ChatTypeBasicGroup || chat.Type is ChatTypeSupergroup { IsChannel: false })
+                && message.ClientService.TryGetUser(message.SenderId, out User senderUser)
+                && senderUser.Type is UserTypeBot;
 
             var builder = new StringBuilder();
             if (title?.Length > 0)
@@ -484,7 +466,7 @@ namespace Telegram.Controls.Messages
                 }
             }
 
-            builder.Append(Automation.GetSummary(message, true));
+            builder.Append(Automation.GetAccessibleSummary(message, true));
 
             if (message.AuthorSignature.Length > 0)
             {

--- a/Telegram/Controls/Messages/ReactionsMenuFlyout.xaml.cs
+++ b/Telegram/Controls/Messages/ReactionsMenuFlyout.xaml.cs
@@ -25,7 +25,6 @@ using Windows.UI;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
-using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Hosting;
@@ -970,7 +969,7 @@ namespace Telegram.Controls.Messages
         {
             _popup.IsOpen = false;
 
-            if (_bubble is FrameworkElement element && AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+            if (_bubble is FrameworkElement element && AccessibilityService.IsScreenReaderActive)
             {
                 var selector = element.GetParent<SelectorItem>();
                 selector?.Focus(FocusState.Keyboard);

--- a/Telegram/Controls/PlaybackSlider.cs
+++ b/Telegram/Controls/PlaybackSlider.cs
@@ -11,6 +11,7 @@ using Windows.Foundation;
 using Windows.UI.Composition;
 using Windows.UI.Input;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Automation.Provider;
 using Windows.UI.Xaml.Controls;
@@ -87,9 +88,19 @@ namespace Telegram.Controls
 
         public void UpdateValue(TimeSpan position, TimeSpan duration, bool playing)
         {
+            var previousPosition = _position;
+
             _position = position;
             _duration = duration;
             _playing = playing;
+
+            if (previousPosition != position && FrameworkElementAutomationPeer.FromElement(this) is PlaybackSliderAutomationPeer peer)
+            {
+                peer.RaisePropertyChangedEvent(
+                    RangeValuePatternIdentifiers.ValueProperty,
+                    previousPosition.TotalSeconds,
+                    position.TotalSeconds);
+            }
 
             if (ProgressBarIndicator == null)
             {
@@ -328,6 +339,11 @@ namespace Telegram.Controls
             PositionChanged?.Invoke(this, new PlaybackSliderPositionChanged(TimeSpan.FromSeconds(position)));
         }
 
+        internal void SetValue(double position)
+        {
+            SetValue(position, _duration.TotalSeconds, _playing);
+        }
+
         public bool ComputedIsThumbToolTipEnabled => IsThumbToolTipEnabled && ThumbToolTip != null && ThumbToolTipPopup != null;
 
         #region IsThumbToolTipEnabled
@@ -357,7 +373,7 @@ namespace Telegram.Controls
         #endregion
     }
 
-    public partial class PlaybackSliderAutomationPeer : FrameworkElementAutomationPeer, IRangeValueProvider, IValueProvider
+    public partial class PlaybackSliderAutomationPeer : FrameworkElementAutomationPeer, IRangeValueProvider
     {
         private readonly PlaybackSlider _owner;
 
@@ -374,12 +390,18 @@ namespace Telegram.Controls
 
         protected override string GetNameCore()
         {
-            return "Seek";
+            var name = base.GetNameCore();
+            return string.IsNullOrEmpty(name) ? Strings.AccDescrSeek : name;
+        }
+
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            return AutomationControlType.Slider;
         }
 
         protected override object GetPatternCore(PatternInterface patternInterface)
         {
-            if (patternInterface is PatternInterface.RangeValue or PatternInterface.Value)
+            if (patternInterface == PatternInterface.RangeValue)
             {
                 return this;
             }
@@ -389,7 +411,7 @@ namespace Telegram.Controls
 
         public bool IsReadOnly => false;
 
-        public double LargeChange => 1;
+        public double LargeChange => Math.Max(1, Maximum / 10);
 
         public double SmallChange => 1;
 
@@ -399,16 +421,14 @@ namespace Telegram.Controls
 
         public double Value => _owner.Position.TotalSeconds;
 
-        string IValueProvider.Value => _owner.Position.ToDuration();
-
         public void SetValue(double value)
         {
-            throw new NotImplementedException();
-        }
+            if (double.IsNaN(value) || double.IsInfinity(value) || value < Minimum || value > Maximum)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
 
-        public void SetValue(string value)
-        {
-            throw new NotImplementedException();
+            _owner.SetValue(value);
         }
     }
 }

--- a/Telegram/Controls/TabbedPageHeader.xaml
+++ b/Telegram/Controls/TabbedPageHeader.xaml
@@ -20,11 +20,13 @@
             <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
         <controls:GlyphButton x:Name="BackButton"
+                              AutomationProperties.Name="{CustomResource AccDescrGoBack}"
                               ContextRequested="BackButton_ContextRequested"
                               Glyph="&#xE72B;"
                               IsEnabled="False"
                               Width="48" />
         <controls:GlyphButton x:Name="ForwardButton"
+                              AutomationProperties.Name="{CustomResource AccDescrGoForward}"
                               ContextRequested="ForwardButton_ContextRequested"
                               Glyph="&#xE72A;"
                               IsEnabled="False"

--- a/Telegram/Services/AccessibilityService.cs
+++ b/Telegram/Services/AccessibilityService.cs
@@ -1,0 +1,46 @@
+//
+// Copyright (c) Fela Ameghino 2015-2026
+//
+// Distributed under the GNU General Public License v3.0. (See accompanying
+// file LICENSE or copy at https://www.gnu.org/licenses/gpl-3.0.txt)
+//
+
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation.Peers;
+
+namespace Telegram.Services
+{
+    /// <summary>
+    /// Centralizes UI Automation client detection and notification events.
+    /// </summary>
+    public static class AccessibilityService
+    {
+        public static bool IsScreenReaderActive =>
+            AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged);
+
+        public static bool HasPropertyChangedListeners =>
+            AutomationPeer.ListenerExists(AutomationEvents.PropertyChanged);
+
+        public static bool RaiseNotification(
+            FrameworkElement owner,
+            string text,
+            string activityId,
+            AutomationNotificationKind kind = AutomationNotificationKind.Other,
+            AutomationNotificationProcessing processing = AutomationNotificationProcessing.ImportantMostRecent)
+        {
+            if (owner == null || string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
+            var peer = FrameworkElementAutomationPeer.CreatePeerForElement(owner);
+            if (peer == null)
+            {
+                return false;
+            }
+
+            peer.RaiseNotificationEvent(kind, processing, text, activityId);
+            return true;
+        }
+    }
+}

--- a/Telegram/Strings/en/Resources.cs
+++ b/Telegram/Strings/en/Resources.cs
@@ -442,6 +442,11 @@ namespace Telegram
         /// Localized resource similar to "Bot keyboard"
         /// </summary>
         public static string AccDescrBotKeyboard => Resource.GetString("AccDescrBotKeyboard");
+
+        /// <summary>
+        /// Localized resource similar to "Message has inline buttons"
+        /// </summary>
+        public static string AccDescrMessageHasInlineButtons => Resource.GetString("AccDescrMessageHasInlineButtons");
         
         /// <summary>
         /// Localized resource similar to "Cancel editing"

--- a/Telegram/Strings/en/Resources.resw
+++ b/Telegram/Strings/en/Resources.resw
@@ -115,6 +115,9 @@
   <data name="AccDescrCancelEdit" xml:space="preserve">
     <value>Cancel editing</value>
   </data>
+  <data name="AccDescrCancelRecording" xml:space="preserve">
+    <value>Cancel recording</value>
+  </data>
   <data name="AccDescrCancelReply" xml:space="preserve">
     <value>Cancel reply</value>
   </data>
@@ -148,6 +151,9 @@
   <data name="AccDescrCustomEmoji2" xml:space="preserve">
     <value>Custom emoji</value>
   </data>
+  <data name="AccDescrDismissBar" xml:space="preserve">
+    <value>Dismiss</value>
+  </data>
   <data name="AccDescrEmojiButton" xml:space="preserve">
     <value>Emoji, stickers, and GIFs</value>
   </data>
@@ -174,6 +180,9 @@
   </data>
   <data name="AccDescrGoBack" xml:space="preserve">
     <value>Go back</value>
+  </data>
+  <data name="AccDescrGoForward" xml:space="preserve">
+    <value>Go forward</value>
   </data>
   <data name="AccDescrGroup" xml:space="preserve">
     <value>Group</value>
@@ -303,6 +312,9 @@
   </data>
   <data name="AccDescrSeek" xml:space="preserve">
     <value>Seek</value>
+  </data>
+  <data name="AccDescrSetTimer" xml:space="preserve">
+    <value>Set self-destruct timer</value>
   </data>
   <data name="AccDescrSentDate" xml:space="preserve">
     <value>Sent {0}</value>

--- a/Telegram/Strings/en/Resources.resw
+++ b/Telegram/Strings/en/Resources.resw
@@ -112,6 +112,9 @@
   <data name="AccDescrBotKeyboard" xml:space="preserve">
     <value>Bot keyboard</value>
   </data>
+  <data name="AccDescrMessageHasInlineButtons" xml:space="preserve">
+    <value>Message has inline buttons</value>
+  </data>
   <data name="AccDescrCancelEdit" xml:space="preserve">
     <value>Cancel editing</value>
   </data>

--- a/Telegram/Telegram.csproj
+++ b/Telegram/Telegram.csproj
@@ -469,6 +469,7 @@
     <Compile Include="Services\ProxyService.cs" />
     <Compile Include="Services\Settings\ToolTipSettings.cs" />
     <Compile Include="Services\TextRecognitionService.cs" />
+    <Compile Include="Services\AccessibilityService.cs" />
     <Compile Include="Services\Session.Registrations.cs" />
     <Compile Include="Controls\Messages\MessageContentRecyclePool.cs" />
     <Compile Include="Streams\MediaRange.cs" />

--- a/Telegram/ViewModels/DialogViewModel.Handle.cs
+++ b/Telegram/ViewModels/DialogViewModel.Handle.cs
@@ -16,7 +16,6 @@ using Telegram.Services;
 using Telegram.Td.Api;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Automation.Peers;
 
 namespace Telegram.ViewModels
 {
@@ -1296,7 +1295,7 @@ namespace Telegram.ViewModels
             if (Settings.Notifications.InAppSounds)
             {
                 var muted = ClientService.Notifications.IsMuted(Chat);
-                var listeners = AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged);
+                var listeners = AccessibilityService.IsScreenReaderActive;
 
                 if (NavigationService.Window.ActivationMode != CoreWindowActivationMode.Deactivated && (listeners || !muted))
                 {

--- a/Telegram/Views/Calls/GroupCallPage.xaml
+++ b/Telegram/Views/Calls/GroupCallPage.xaml
@@ -286,6 +286,7 @@
             </Border>
 
             <controls:GlyphButton x:Name="Menu"
+                                  AutomationProperties.Name="{CustomResource AccDescrMoreOptions}"
                                   Click="Menu_ContextRequested"
                                   Glyph="&#xE9E9;"
                                   Width="48"

--- a/Telegram/Views/ChatView.xaml
+++ b/Telegram/Views/ChatView.xaml
@@ -1212,6 +1212,7 @@
                                                           Foreground="{ThemeResource MessageHeaderBorderBrush}" />
 
                                 <controls:GlyphButton x:Name="ComposerHeaderCancel"
+                                                      AutomationProperties.Name="{CustomResource AccDescrCancelReply}"
                                                       Click="{x:Bind ViewModel.ClearReply}"
                                                       FontSize="{StaticResource GlyphLargeFontSize}"
                                                       Foreground="{ThemeResource MessageHeaderBorderBrush}"
@@ -1343,6 +1344,7 @@
 
                                     <!-- Button to change self-destructing timer, secret chats only -->
                                     <controls:GlyphButton x:Name="ButtonTimer"
+                                                          AutomationProperties.Name="{CustomResource AccDescrSetTimer}"
                                                           Glyph="&#xE9DB;"
                                                           Click="{x:Bind ViewModel.SetTimer}"
                                                           FontSize="{StaticResource GlyphLargeFontSize}"
@@ -1585,6 +1587,7 @@
                     <Border Background="Transparent" />
 
                     <controls:GlyphButton x:Name="ButtonManage"
+                                          AutomationProperties.Name="{CustomResource Cancel}"
                                           Glyph="&#xE711;"
                                           Click="{x:Bind ViewModel.UnselectMessages}" />
 

--- a/Telegram/Views/ChatView.xaml.cs
+++ b/Telegram/Views/ChatView.xaml.cs
@@ -881,6 +881,23 @@ namespace Telegram.Views
 
         private async void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
         {
+            if (args.Action == NotifyCollectionChangedAction.Add && args.NewItems != null)
+            {
+                foreach (var item in args.NewItems)
+                {
+                    if (item is MessageViewModel addedMessage
+                        && addedMessage.Id != long.MaxValue
+                        && addedMessage.AnimationState == MessageAnimationState.Added)
+                    {
+                        AccessibilityService.RaiseNotification(
+                            Messages,
+                            Automation.GetSummaryWithName(addedMessage, true),
+                            "ChatMessage",
+                            processing: AutomationNotificationProcessing.All);
+                    }
+                }
+            }
+
             var panel = Messages.ItemsPanelRoot as ItemsStackPanel;
             if (panel == null)
             {
@@ -1422,7 +1439,7 @@ namespace Telegram.Views
 
         private void TrySetFocusState(FocusState state, bool fast)
         {
-            if (AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+            if (AccessibilityService.IsScreenReaderActive)
             {
                 return;
             }
@@ -5535,7 +5552,7 @@ namespace Telegram.Views
 
         private void ButtonAction_LosingFocus(UIElement sender, LosingFocusEventArgs args)
         {
-            if (_actionCollapsed && !AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+            if (_actionCollapsed && !AccessibilityService.IsScreenReaderActive)
             {
                 args.TrySetNewFocusedElement(TextField);
                 args.Handled = true;

--- a/Telegram/Views/MainPage.xaml.cs
+++ b/Telegram/Views/MainPage.xaml.cs
@@ -3109,7 +3109,7 @@ namespace Telegram.Views
 
         private void ChatsList_GettingFocus(UIElement sender, GettingFocusEventArgs args)
         {
-            if (!AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+            if (!AccessibilityService.IsScreenReaderActive)
             {
                 if (Photo == sender)
                 {


### PR DESCRIPTION
## Summary

This PR improves screen-reader support across chat navigation, message announcements, and custom controls.

- announces new incoming and outgoing messages in the active chat through UI Automation notification events;
- standardizes sender prefixes and reports when a message contains inline buttons;
- centralizes UI Automation listener detection and notification delivery;
- improves focus recovery and accessible names for chat, call, navigation, recording, timer, and selection controls;
- corrects the UIA contracts of `PlaybackSlider` and `LoopingPicker`.

## Related issues

Fixes #1363
Fixes #2220
Fixes #2450
Fixes #2921
Addresses #2113

## Changes

### Message announcements and summaries

- Added `AccessibilityService` as the single location for `AutomationPeer.ListenerExists` and UIA notification delivery.
- Raised `AutomationNotificationProcessing.All` events for real new messages while `ChatView` is active.
- Excluded loaded history and temporary `long.MaxValue` placeholders from announcements.
- Added a shared message-prefix policy:
  - incoming private and group messages use the sender name;
  - outgoing private and group messages use the localized `You` label;
  - channel posts use the sender or channel title;
  - Saved Messages use the original source when available;
  - service messages keep their existing action text without an extra prefix.
- Added a localized “Message has inline buttons” marker without duplicating every button label.
- Documented these conventions in `Documentation/Accessibility.md`.

### Focus, peers, and control names

- Included `ForumTopicVerticalCell` in `ChatListListViewItemAutomationPeer`.
- Added one deferred retry and diagnostic logging when moving focus to a message fails.
- Added missing accessible names for cancel recording/reply, dismiss action bar, web back/forward, group-call menu, secret-chat timer, and clear selection.
- Added `LoopingPickerAutomationPeer` with a writable `RangeValue` pattern and `Spinner` control type.
- Corrected `PlaybackSliderAutomationPeer` to expose the writable `RangeValue` contract used by its seek path.


## Screenshots

Not applicable; these changes affect UI Automation metadata and behavior rather than visual UI.