### PR TITLE
Standardize screen reader message summaries

### DIFF
--- a/Documentation/Accessibility.md
+++ b/Documentation/Accessibility.md
@@ -1,0 +1,17 @@
+# Accessibility conventions
+
+## Screen-reader message summaries
+
+Every non-service message exposed through UI Automation starts with a stable sender prefix. The same policy is used for message-list items and compact history items.
+
+| Message | Prefix |
+| --- | --- |
+| Incoming private or group message | Sender display name |
+| Outgoing private or group message | Localized “You” label |
+| Channel post | Sender or channel title |
+| Saved Message | Original source title, when available |
+| Service message | No added prefix; the service text identifies its actor and action |
+
+The prefix is included on every message, even when adjacent messages are visually grouped. This keeps keyboard and screen-reader navigation unambiguous. A colon separates the prefix from the content summary.
+
+Messages with an inline keyboard add a concise localized “Message has inline buttons” indication to the summary. Button labels are not duplicated in the message summary; they remain available when the user navigates to the buttons.

--- a/Telegram/Common/Automation.cs
+++ b/Telegram/Common/Automation.cs
@@ -92,24 +92,65 @@ namespace Telegram.Common
 
         public static string GetSummaryWithName(MessageWithOwner message, bool details = false, bool addCaption = true)
         {
-            var summary = GetSummary(message, details, addCaption);
+            var summary = GetAccessibleSummary(message, details, addCaption);
+            var prefix = GetMessagePrefix(message);
+
+            if (!string.IsNullOrEmpty(prefix))
+            {
+                return $"{prefix}: {summary}";
+            }
+
+            return summary;
+        }
+
+        /// <summary>
+        /// Returns the stable sender prefix used by screen-reader message summaries.
+        /// </summary>
+        public static string GetMessagePrefix(MessageWithOwner message)
+        {
+            if (message == null || message.Content.IsService())
+            {
+                return null;
+            }
+
+            if (message.IsSaved)
+            {
+                return message.ClientService.GetTitle(message.ForwardInfo?.Origin, message.ImportInfo);
+            }
+
+            if (message.IsOutgoing && !message.IsChannelPost)
+            {
+                return Strings.FromYou;
+            }
 
             if (message.ClientService.TryGetUser(message.SenderId, out User user))
             {
-                if (user.Id == message.ClientService.Options.MyId)
-                {
-                    return $"{Strings.FromYou}: {summary}";
-                }
-
-                return $"{user.FullName()}: {summary}";
+                return user.FullName();
             }
-            //else if (message.IsChannelPost)
-            //{
-            //    return summary;
-            //}
-            else if (message.ClientService.TryGetChat(message.SenderId, out Chat chat))
+
+            if (message.ClientService.TryGetChat(message.SenderId, out Chat senderChat))
             {
-                return $"{chat.Title}: {summary}";
+                return message.ClientService.GetTitle(senderChat);
+            }
+
+            if (message.IsChannelPost)
+            {
+                return message.ClientService.GetTitle(message.Chat);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns the content summary plus concise interactive-content metadata.
+        /// Individual inline button labels remain available when navigating to the buttons.
+        /// </summary>
+        public static string GetAccessibleSummary(MessageWithOwner message, bool details = false, bool addCaption = true)
+        {
+            var summary = GetSummary(message, details, addCaption);
+            if (message?.ReplyMarkup is ReplyMarkupInlineKeyboard)
+            {
+                return $"{summary}{Strings.AccDescrMessageHasInlineButtons}. ";
             }
 
             return summary;

--- a/Telegram/Controls/Messages/MessageBubble.xaml.cs
+++ b/Telegram/Controls/Messages/MessageBubble.xaml.cs
@@ -373,29 +373,11 @@ namespace Telegram.Controls.Messages
 
             var chat = message.Chat;
 
-            var title = string.Empty;
-            var senderBot = false;
-
-            if (message.IsSaved)
-            {
-                title = message.ClientService.GetTitle(message.ForwardInfo?.Origin, message.ImportInfo);
-            }
-            else if (chat.Type is ChatTypeBasicGroup || chat.Type is ChatTypeSupergroup supergroup && !supergroup.IsChannel)
-            {
-                if (message.IsOutgoing)
-                {
-                    title = null;
-                }
-                else if (message.ClientService.TryGetUser(message.SenderId, out User senderUser))
-                {
-                    senderBot = senderUser.Type is UserTypeBot;
-                    title = senderUser.FullName();
-                }
-                else if (message.ClientService.TryGetChat(message.SenderId, out Chat senderChat))
-                {
-                    title = message.ClientService.GetTitle(senderChat);
-                }
-            }
+            var title = Automation.GetMessagePrefix(message);
+            var senderBot = !message.IsOutgoing
+                && (chat.Type is ChatTypeBasicGroup || chat.Type is ChatTypeSupergroup { IsChannel: false })
+                && message.ClientService.TryGetUser(message.SenderId, out User senderUser)
+                && senderUser.Type is UserTypeBot;
 
             var builder = new StringBuilder();
             if (title?.Length > 0)
@@ -484,7 +466,7 @@ namespace Telegram.Controls.Messages
                 }
             }
 
-            builder.Append(Automation.GetSummary(message, true));
+            builder.Append(Automation.GetAccessibleSummary(message, true));
 
             if (message.AuthorSignature.Length > 0)
             {

--- a/Telegram/Strings/en/Resources.cs
+++ b/Telegram/Strings/en/Resources.cs
@@ -442,6 +442,11 @@ namespace Telegram
         /// Localized resource similar to "Bot keyboard"
         /// </summary>
         public static string AccDescrBotKeyboard => Resource.GetString("AccDescrBotKeyboard");
+
+        /// <summary>
+        /// Localized resource similar to "Message has inline buttons"
+        /// </summary>
+        public static string AccDescrMessageHasInlineButtons => Resource.GetString("AccDescrMessageHasInlineButtons");
         
         /// <summary>
         /// Localized resource similar to "Cancel editing"

--- a/Telegram/Strings/en/Resources.resw
+++ b/Telegram/Strings/en/Resources.resw
@@ -112,6 +112,9 @@
   <data name="AccDescrBotKeyboard" xml:space="preserve">
     <value>Bot keyboard</value>
   </data>
+  <data name="AccDescrMessageHasInlineButtons" xml:space="preserve">
+    <value>Message has inline buttons</value>
+  </data>
   <data name="AccDescrCancelEdit" xml:space="preserve">
     <value>Cancel editing</value>
   </data>


### PR DESCRIPTION
- apply a stable sender prefix policy to accessible message descriptions
- indicate inline buttons and document the summary conventions

Fixes #2450
Fixes #2220