### PR TITLE
Announce new chat messages through UI Automation

### DIFF
--- a/Documentation/Accessibility.md
+++ b/Documentation/Accessibility.md
@@ -1,0 +1,17 @@
+# Accessibility conventions
+
+## Screen-reader message summaries
+
+Every non-service message exposed through UI Automation starts with a stable sender prefix. The same policy is used for message-list items and compact history items.
+
+| Message | Prefix |
+| --- | --- |
+| Incoming private or group message | Sender display name |
+| Outgoing private or group message | Localized “You” label |
+| Channel post | Sender or channel title |
+| Saved Message | Original source title, when available |
+| Service message | No added prefix; the service text identifies its actor and action |
+
+The prefix is included on every message, even when adjacent messages are visually grouped. This keeps keyboard and screen-reader navigation unambiguous. A colon separates the prefix from the content summary.
+
+Messages with an inline keyboard add a concise localized “Message has inline buttons” indication to the summary. Button labels are not duplicated in the message summary; they remain available when the user navigates to the buttons.

--- a/Documentation/Accessibility.md
+++ b/Documentation/Accessibility.md
@@ -15,3 +15,9 @@ Every non-service message exposed through UI Automation starts with a stable sen
 The prefix is included on every message, even when adjacent messages are visually grouped. This keeps keyboard and screen-reader navigation unambiguous. A colon separates the prefix from the content summary.
 
 Messages with an inline keyboard add a concise localized “Message has inline buttons” indication to the summary. Button labels are not duplicated in the message summary; they remain available when the user navigates to the buttons.
+
+## New-message notifications
+
+Newly inserted incoming and outgoing messages in the active chat raise a UI Automation notification event. Notifications use the same prefix and content-summary policy as message items, include the inline-button indication, and use `AutomationNotificationProcessing.All` so a burst of messages is announced in order. Loading existing history does not raise these notifications.
+
+UI code must use `AccessibilityService` for UI Automation listener detection and notification delivery instead of calling `AutomationPeer.ListenerExists` directly.

--- a/Telegram/Common/Automation.cs
+++ b/Telegram/Common/Automation.cs
@@ -92,24 +92,65 @@ namespace Telegram.Common
 
         public static string GetSummaryWithName(MessageWithOwner message, bool details = false, bool addCaption = true)
         {
-            var summary = GetSummary(message, details, addCaption);
+            var summary = GetAccessibleSummary(message, details, addCaption);
+            var prefix = GetMessagePrefix(message);
+
+            if (!string.IsNullOrEmpty(prefix))
+            {
+                return $"{prefix}: {summary}";
+            }
+
+            return summary;
+        }
+
+        /// <summary>
+        /// Returns the stable sender prefix used by screen-reader message summaries.
+        /// </summary>
+        public static string GetMessagePrefix(MessageWithOwner message)
+        {
+            if (message == null || message.Content.IsService())
+            {
+                return null;
+            }
+
+            if (message.IsSaved)
+            {
+                return message.ClientService.GetTitle(message.ForwardInfo?.Origin, message.ImportInfo);
+            }
+
+            if (message.IsOutgoing && !message.IsChannelPost)
+            {
+                return Strings.FromYou;
+            }
 
             if (message.ClientService.TryGetUser(message.SenderId, out User user))
             {
-                if (user.Id == message.ClientService.Options.MyId)
-                {
-                    return $"{Strings.FromYou}: {summary}";
-                }
-
-                return $"{user.FullName()}: {summary}";
+                return user.FullName();
             }
-            //else if (message.IsChannelPost)
-            //{
-            //    return summary;
-            //}
-            else if (message.ClientService.TryGetChat(message.SenderId, out Chat chat))
+
+            if (message.ClientService.TryGetChat(message.SenderId, out Chat senderChat))
             {
-                return $"{chat.Title}: {summary}";
+                return message.ClientService.GetTitle(senderChat);
+            }
+
+            if (message.IsChannelPost)
+            {
+                return message.ClientService.GetTitle(message.Chat);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns the content summary plus concise interactive-content metadata.
+        /// Individual inline button labels remain available when navigating to the buttons.
+        /// </summary>
+        public static string GetAccessibleSummary(MessageWithOwner message, bool details = false, bool addCaption = true)
+        {
+            var summary = GetSummary(message, details, addCaption);
+            if (message?.ReplyMarkup is ReplyMarkupInlineKeyboard)
+            {
+                return $"{summary}{Strings.AccDescrMessageHasInlineButtons}. ";
             }
 
             return summary;

--- a/Telegram/Common/WatchDog.cs
+++ b/Telegram/Common/WatchDog.cs
@@ -28,7 +28,6 @@ using Windows.ApplicationModel.Core;
 using Windows.Storage;
 using Windows.System;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using File = System.IO.File;
@@ -621,7 +620,7 @@ namespace Telegram
 
             if (WindowContext.Current != null)
             {
-                var reader = AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged);
+                var reader = AccessibilityService.IsScreenReaderActive;
                 var scaling = (WindowContext.Current.RasterizationScale * 100).ToString("N0");
                 var text = (BootStrapper.Current.TextScaleFactor * 100).ToString("N0");
                 var size = Window.Current.Bounds;

--- a/Telegram/Controls/Chats/ChatHistoryView.cs
+++ b/Telegram/Controls/Chats/ChatHistoryView.cs
@@ -12,6 +12,7 @@ using Telegram.Collections;
 using Telegram.Common;
 using Telegram.Controls.Messages;
 using Telegram.Navigation;
+using Telegram.Services;
 using Telegram.Td.Api;
 using Telegram.ViewModels;
 using Telegram.ViewModels.Delegates;
@@ -19,7 +20,6 @@ using Windows.Devices.Input;
 using Windows.Foundation;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Hosting;
@@ -496,7 +496,7 @@ namespace Telegram.Controls.Chats
         {
             try
             {
-                if ((options == null || options.MoveFocus) && AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+                if ((options == null || options.MoveFocus) && AccessibilityService.IsScreenReaderActive)
                 {
                     selectorItem.Focus(FocusState.Keyboard);
                 }

--- a/Telegram/Controls/Chats/ChatSearchBar.xaml.cs
+++ b/Telegram/Controls/Chats/ChatSearchBar.xaml.cs
@@ -12,11 +12,11 @@ using System.Numerics;
 using Telegram.Common;
 using Telegram.Controls.Cells;
 using Telegram.Navigation;
+using Telegram.Services;
 using Telegram.Td.Api;
 using Telegram.ViewModels;
 using Telegram.ViewModels.Chats;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Documents;
@@ -49,7 +49,7 @@ namespace Telegram.Controls.Chats
             _debouncer = new EventDebouncer<TextChangedEventArgs>(Constants.TypingTimeout, handler => Field.TextChanged += new TextChangedEventHandler(handler));
             _debouncer.Invoked += (s, args) =>
             {
-                if (Field.State != ChatSearchState.Members && !AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+                if (Field.State != ChatSearchState.Members && !AccessibilityService.IsScreenReaderActive)
                 {
                     ViewModel?.Search(Field.Text, Field.From, ViewModel.SavedMessagesTag, null);
                 }

--- a/Telegram/Controls/FileButton.cs
+++ b/Telegram/Controls/FileButton.cs
@@ -11,6 +11,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using Telegram.Controls.Media;
 using Telegram.Navigation;
+using Telegram.Services;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
@@ -118,7 +119,7 @@ namespace Telegram.Controls
                     ProgressBar.Value = value;
                 }
 
-                if (AutomationPeer.ListenerExists(AutomationEvents.PropertyChanged))
+                if (AccessibilityService.HasPropertyChangedListeners)
                 {
                     var peer = FrameworkElementAutomationPeer.FromElement(this);
                     peer?.RaisePropertyChangedEvent(ValuePatternIdentifiers.ValueProperty, _progress, value);

--- a/Telegram/Controls/MasterDetailView.cs
+++ b/Telegram/Controls/MasterDetailView.cs
@@ -583,10 +583,6 @@ namespace Telegram.Controls
 
                     ShowHideDetailHeader(true, hosted.ShowHeaderBackground);
 
-                    //if (AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
-                    //{
-                    //    VisualUtilities.QueueCallbackForCompositionRendering(() => DetailHeaderPresenter.Focus(FocusState.Keyboard));
-                    //}
                 }
                 else
                 {

--- a/Telegram/Controls/Messages/EmojiMenuFlyout.xaml.cs
+++ b/Telegram/Controls/Messages/EmojiMenuFlyout.xaml.cs
@@ -22,7 +22,6 @@ using Windows.Foundation;
 using Windows.UI;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Hosting;
@@ -107,7 +106,7 @@ namespace Telegram.Controls.Messages
             _drawer.Deactivate();
             _drawer.DataContext = null;
 
-            if (_bubble is FrameworkElement element && AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+            if (_bubble is FrameworkElement element && AccessibilityService.IsScreenReaderActive)
             {
                 var selector = element.GetParent<SelectorItem>();
                 selector?.Focus(FocusState.Keyboard);

--- a/Telegram/Controls/Messages/MessageBubble.xaml.cs
+++ b/Telegram/Controls/Messages/MessageBubble.xaml.cs
@@ -373,29 +373,11 @@ namespace Telegram.Controls.Messages
 
             var chat = message.Chat;
 
-            var title = string.Empty;
-            var senderBot = false;
-
-            if (message.IsSaved)
-            {
-                title = message.ClientService.GetTitle(message.ForwardInfo?.Origin, message.ImportInfo);
-            }
-            else if (chat.Type is ChatTypeBasicGroup || chat.Type is ChatTypeSupergroup supergroup && !supergroup.IsChannel)
-            {
-                if (message.IsOutgoing)
-                {
-                    title = null;
-                }
-                else if (message.ClientService.TryGetUser(message.SenderId, out User senderUser))
-                {
-                    senderBot = senderUser.Type is UserTypeBot;
-                    title = senderUser.FullName();
-                }
-                else if (message.ClientService.TryGetChat(message.SenderId, out Chat senderChat))
-                {
-                    title = message.ClientService.GetTitle(senderChat);
-                }
-            }
+            var title = Automation.GetMessagePrefix(message);
+            var senderBot = !message.IsOutgoing
+                && (chat.Type is ChatTypeBasicGroup || chat.Type is ChatTypeSupergroup { IsChannel: false })
+                && message.ClientService.TryGetUser(message.SenderId, out User senderUser)
+                && senderUser.Type is UserTypeBot;
 
             var builder = new StringBuilder();
             if (title?.Length > 0)
@@ -484,7 +466,7 @@ namespace Telegram.Controls.Messages
                 }
             }
 
-            builder.Append(Automation.GetSummary(message, true));
+            builder.Append(Automation.GetAccessibleSummary(message, true));
 
             if (message.AuthorSignature.Length > 0)
             {

--- a/Telegram/Controls/Messages/ReactionsMenuFlyout.xaml.cs
+++ b/Telegram/Controls/Messages/ReactionsMenuFlyout.xaml.cs
@@ -25,7 +25,6 @@ using Windows.UI;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
-using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Hosting;
@@ -970,7 +969,7 @@ namespace Telegram.Controls.Messages
         {
             _popup.IsOpen = false;
 
-            if (_bubble is FrameworkElement element && AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+            if (_bubble is FrameworkElement element && AccessibilityService.IsScreenReaderActive)
             {
                 var selector = element.GetParent<SelectorItem>();
                 selector?.Focus(FocusState.Keyboard);

--- a/Telegram/Services/AccessibilityService.cs
+++ b/Telegram/Services/AccessibilityService.cs
@@ -5,12 +5,13 @@
 // file LICENSE or copy at https://www.gnu.org/licenses/gpl-3.0.txt)
 //
 
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation.Peers;
 
 namespace Telegram.Services
 {
     /// <summary>
-    /// Centralizes UI Automation client detection.
+    /// Centralizes UI Automation client detection and notification events.
     /// </summary>
     public static class AccessibilityService
     {
@@ -19,5 +20,27 @@ namespace Telegram.Services
 
         public static bool HasPropertyChangedListeners =>
             AutomationPeer.ListenerExists(AutomationEvents.PropertyChanged);
+
+        public static bool RaiseNotification(
+            FrameworkElement owner,
+            string text,
+            string activityId,
+            AutomationNotificationKind kind = AutomationNotificationKind.Other,
+            AutomationNotificationProcessing processing = AutomationNotificationProcessing.ImportantMostRecent)
+        {
+            if (owner == null || string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
+            var peer = FrameworkElementAutomationPeer.CreatePeerForElement(owner);
+            if (peer == null)
+            {
+                return false;
+            }
+
+            peer.RaiseNotificationEvent(kind, processing, text, activityId);
+            return true;
+        }
     }
 }

--- a/Telegram/Services/AccessibilityService.cs
+++ b/Telegram/Services/AccessibilityService.cs
@@ -1,0 +1,23 @@
+//
+// Copyright (c) Fela Ameghino 2015-2026
+//
+// Distributed under the GNU General Public License v3.0. (See accompanying
+// file LICENSE or copy at https://www.gnu.org/licenses/gpl-3.0.txt)
+//
+
+using Windows.UI.Xaml.Automation.Peers;
+
+namespace Telegram.Services
+{
+    /// <summary>
+    /// Centralizes UI Automation client detection.
+    /// </summary>
+    public static class AccessibilityService
+    {
+        public static bool IsScreenReaderActive =>
+            AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged);
+
+        public static bool HasPropertyChangedListeners =>
+            AutomationPeer.ListenerExists(AutomationEvents.PropertyChanged);
+    }
+}

--- a/Telegram/Strings/en/Resources.cs
+++ b/Telegram/Strings/en/Resources.cs
@@ -442,6 +442,11 @@ namespace Telegram
         /// Localized resource similar to "Bot keyboard"
         /// </summary>
         public static string AccDescrBotKeyboard => Resource.GetString("AccDescrBotKeyboard");
+
+        /// <summary>
+        /// Localized resource similar to "Message has inline buttons"
+        /// </summary>
+        public static string AccDescrMessageHasInlineButtons => Resource.GetString("AccDescrMessageHasInlineButtons");
         
         /// <summary>
         /// Localized resource similar to "Cancel editing"

--- a/Telegram/Strings/en/Resources.resw
+++ b/Telegram/Strings/en/Resources.resw
@@ -112,6 +112,9 @@
   <data name="AccDescrBotKeyboard" xml:space="preserve">
     <value>Bot keyboard</value>
   </data>
+  <data name="AccDescrMessageHasInlineButtons" xml:space="preserve">
+    <value>Message has inline buttons</value>
+  </data>
   <data name="AccDescrCancelEdit" xml:space="preserve">
     <value>Cancel editing</value>
   </data>

--- a/Telegram/Telegram.csproj
+++ b/Telegram/Telegram.csproj
@@ -469,6 +469,7 @@
     <Compile Include="Services\ProxyService.cs" />
     <Compile Include="Services\Settings\ToolTipSettings.cs" />
     <Compile Include="Services\TextRecognitionService.cs" />
+    <Compile Include="Services\AccessibilityService.cs" />
     <Compile Include="Services\Session.Registrations.cs" />
     <Compile Include="Controls\Messages\MessageContentRecyclePool.cs" />
     <Compile Include="Streams\MediaRange.cs" />

--- a/Telegram/ViewModels/DialogViewModel.Handle.cs
+++ b/Telegram/ViewModels/DialogViewModel.Handle.cs
@@ -16,7 +16,6 @@ using Telegram.Services;
 using Telegram.Td.Api;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Automation.Peers;
 
 namespace Telegram.ViewModels
 {
@@ -1296,7 +1295,7 @@ namespace Telegram.ViewModels
             if (Settings.Notifications.InAppSounds)
             {
                 var muted = ClientService.Notifications.IsMuted(Chat);
-                var listeners = AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged);
+                var listeners = AccessibilityService.IsScreenReaderActive;
 
                 if (NavigationService.Window.ActivationMode != CoreWindowActivationMode.Deactivated && (listeners || !muted))
                 {

--- a/Telegram/Views/ChatView.xaml.cs
+++ b/Telegram/Views/ChatView.xaml.cs
@@ -881,6 +881,23 @@ namespace Telegram.Views
 
         private async void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
         {
+            if (args.Action == NotifyCollectionChangedAction.Add && args.NewItems != null)
+            {
+                foreach (var item in args.NewItems)
+                {
+                    if (item is MessageViewModel addedMessage
+                        && addedMessage.Id != long.MaxValue
+                        && addedMessage.AnimationState == MessageAnimationState.Added)
+                    {
+                        AccessibilityService.RaiseNotification(
+                            Messages,
+                            Automation.GetSummaryWithName(addedMessage, true),
+                            "ChatMessage",
+                            processing: AutomationNotificationProcessing.All);
+                    }
+                }
+            }
+
             var panel = Messages.ItemsPanelRoot as ItemsStackPanel;
             if (panel == null)
             {

--- a/Telegram/Views/ChatView.xaml.cs
+++ b/Telegram/Views/ChatView.xaml.cs
@@ -1422,7 +1422,7 @@ namespace Telegram.Views
 
         private void TrySetFocusState(FocusState state, bool fast)
         {
-            if (AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+            if (AccessibilityService.IsScreenReaderActive)
             {
                 return;
             }
@@ -5535,7 +5535,7 @@ namespace Telegram.Views
 
         private void ButtonAction_LosingFocus(UIElement sender, LosingFocusEventArgs args)
         {
-            if (_actionCollapsed && !AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+            if (_actionCollapsed && !AccessibilityService.IsScreenReaderActive)
             {
                 args.TrySetNewFocusedElement(TextField);
                 args.Handled = true;

--- a/Telegram/Views/MainPage.xaml.cs
+++ b/Telegram/Views/MainPage.xaml.cs
@@ -3109,7 +3109,7 @@ namespace Telegram.Views
 
         private void ChatsList_GettingFocus(UIElement sender, GettingFocusEventArgs args)
         {
-            if (!AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged))
+            if (!AccessibilityService.IsScreenReaderActive)
             {
                 if (Photo == sender)
                 {


### PR DESCRIPTION
- raise ordered UI Automation notifications for newly received messages in the active chat
- exclude loaded history and temporary message placeholders from announcements
- route notification events through the centralized accessibility service and document the behavior

Depends on #3394
Depends on #3395

Fixes #1363