### PR TITLE
Anchor the message list per mutation instead of a global scroll mode

### DIFF
--- a/Telegram/Collections/SynchronizedList.cs
+++ b/Telegram/Collections/SynchronizedList.cs
@@ -23,8 +23,10 @@ namespace Telegram.Collections
     public interface ISynchronizedListDelegate<T>
     {
         /// <summary>
-        /// Raised just before the removal reaches the list, while the rows are still realized.
-        /// Index is the one the source raised, so this is where index bookkeeping belongs.
+        /// Raised just before the removal reaches the list, while the rows are still realized, so
+        /// this is where index bookkeeping belongs. The index is the one in this collection, not
+        /// the one the source raised: the two differ when the mirror is reversed, and this is the
+        /// space the panel indexes in.
         /// </summary>
         void Removing(int index, IList items);
 
@@ -230,10 +232,10 @@ namespace Telegram.Collections
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    pending = new Pending(e.Action, _reverse ? _source.Count - e.NewStartingIndex - e.NewItems.Count : e.NewStartingIndex, e.NewStartingIndex, e.NewItems);
+                    pending = new Pending(e.Action, _reverse ? _source.Count - e.NewStartingIndex - e.NewItems.Count : e.NewStartingIndex, e.NewItems);
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                    pending = new Pending(e.Action, _reverse ? _source.Count - e.OldStartingIndex : e.OldStartingIndex, e.OldStartingIndex, e.OldItems);
+                    pending = new Pending(e.Action, _reverse ? _source.Count - e.OldStartingIndex : e.OldStartingIndex, e.OldItems);
                     break;
                 default:
                     return;
@@ -291,7 +293,7 @@ namespace Telegram.Collections
                     return;
                 }
 
-                _delegate?.Inserting(pending.SourceIndex, pending.Items);
+                _delegate?.Inserting(pending.Index, pending.Items);
                 InsertRangeT(pending.Index, pending.Items);
             }
             else
@@ -303,7 +305,7 @@ namespace Telegram.Collections
                     return;
                 }
 
-                _delegate?.Removing(pending.SourceIndex, pending.Items);
+                _delegate?.Removing(pending.Index, pending.Items);
                 RemoveRange(pending.Index, pending.Items.Count);
             }
         }
@@ -362,18 +364,12 @@ namespace Telegram.Collections
             /// </summary>
             public readonly int Index;
 
-            /// <summary>
-            /// Where it landed in the source, which is what index bookkeeping outside is keyed on.
-            /// </summary>
-            public readonly int SourceIndex;
-
             public readonly IList Items;
 
-            public Pending(NotifyCollectionChangedAction action, int index, int sourceIndex, IList items)
+            public Pending(NotifyCollectionChangedAction action, int index, IList items)
             {
                 Action = action;
                 Index = index;
-                SourceIndex = sourceIndex;
                 Items = items;
             }
         }

--- a/Telegram/Controls/Chats/ChatHistoryView.cs
+++ b/Telegram/Controls/Chats/ChatHistoryView.cs
@@ -48,6 +48,135 @@ namespace Telegram.Controls.Chats
             }
         }
 
+        // Exact equality is not usable to decide whether the user is still at the end: a pixel of
+        // overscroll bounce or a fractional DPI offset would silently stop the list from following.
+        private const double FollowThreshold = 8;
+
+        /// <summary>
+        /// True while the user is resting at the end of the history, in which case every mutation
+        /// anchors there and new messages appear without having to be scrolled to.
+        /// </summary>
+        /// <remarks>
+        /// Only the user's own scrolling clears this. A message arriving, the composer growing or a
+        /// slice loading all move <see cref="ScrollViewer.ScrollableHeight"/> without meaning that
+        /// the user stopped following, so this is sampled once the view has come to rest and never
+        /// while it is moving.
+        /// </remarks>
+        public bool IsFollowingEnd { get; private set; } = true;
+
+        /// <summary>
+        /// In the saved messages tab the mirror the list is bound to is reversed, so the newest
+        /// message is at the top: following it means resting at offset zero rather than at the end.
+        /// </summary>
+        private bool IsReversed => ViewModel?.IsSavedMessagesTab is true;
+
+        /// <summary>
+        /// Records whether the list follows the end, and pushes the matching edge to the panel
+        /// straight away.
+        /// </summary>
+        /// <remarks>
+        /// For the paths that know their intent — navigation, an explicit scroll, a slice loaded
+        /// around a specific message. A reset never reaches <see cref="PrepareAnchor"/>, because
+        /// <see cref="SynchronizedList{T}"/> applies one wholesale, so the edge has to be on the
+        /// panel before it arrives.
+        /// </remarks>
+        public void SetFollowingEnd(bool value)
+        {
+            IsFollowingEnd = value;
+            ApplyAnchor();
+        }
+
+        internal void ApplyAnchor()
+        {
+            SetAnchor(IsFollowingEnd != IsReversed);
+        }
+
+        private void SetAnchor(bool end)
+        {
+            if (ItemsPanelRoot is ItemsStackPanel panel)
+            {
+                panel.ItemsUpdatingScrollMode = end
+                    ? ItemsUpdatingScrollMode.KeepLastItemInView
+                    : ItemsUpdatingScrollMode.KeepItemsInView;
+            }
+        }
+
+        private void UpdateFollowingEnd()
+        {
+            var scroll = ScrollingHost;
+            if (scroll == null)
+            {
+                return;
+            }
+
+            IsFollowingEnd = IsReversed
+                ? scroll.VerticalOffset < FollowThreshold
+                : scroll.ScrollableHeight - scroll.VerticalOffset < FollowThreshold;
+        }
+
+        // ItemsStackPanel.FirstVisibleIndex only catches up on the next layout pass, and a slice
+        // load raises one event per message (MessageCollection.PrependSlice/AppendSlice), so the
+        // panel is asked once and the index kept up to date by hand until layout runs again.
+        private int _anchorIndex = -1;
+
+        internal void InvalidateAnchor()
+        {
+            _anchorIndex = -1;
+        }
+
+        /// <summary>
+        /// Picks the edge the scroll offset anchors to for the mutation about to be applied at
+        /// <paramref name="index"/>, which displaces everything after it by <paramref name="delta"/>.
+        /// </summary>
+        /// <remarks>
+        /// While the list follows the end that edge is the answer for every mutation: a prepend is
+        /// compensated and leaves the user at the end, an append reveals the new message. Otherwise
+        /// the requirement is that content already on screen must not move, and only the part of
+        /// the list above the viewport can disturb it.
+        /// </remarks>
+        internal void PrepareAnchor(int index, int delta)
+        {
+            if (ItemsPanelRoot is not ItemsStackPanel panel)
+            {
+                return;
+            }
+
+            if (_anchorIndex < 0)
+            {
+                _anchorIndex = Math.Max(panel.FirstVisibleIndex, 0);
+            }
+
+            var above = index <= _anchorIndex;
+
+            panel.ItemsUpdatingScrollMode = (IsFollowingEnd ? !IsReversed : above)
+                ? ItemsUpdatingScrollMode.KeepLastItemInView
+                : ItemsUpdatingScrollMode.KeepItemsInView;
+
+            if (above)
+            {
+                // A range straddling the viewport edge is approximate here, and the layout that
+                // follows corrects it.
+                _anchorIndex = Math.Max(_anchorIndex + delta, 0);
+            }
+        }
+
+        /// <summary>
+        /// The side the rows moved on, for the size change and removal animations: the same
+        /// question <see cref="PrepareAnchor"/> just answered for the mutation in flight.
+        /// </summary>
+        internal static int GetShiftDirection(ItemsStackPanel panel, int index, SelectorItem selector, ScrollViewer scroll)
+        {
+            var direction = panel.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView ? -1 : 1;
+            var edge = (index == panel.LastVisibleIndex && direction == 1) || (index == panel.FirstVisibleIndex && direction == -1);
+
+            if (edge && !scroll.ViewportContains(selector))
+            {
+                direction *= -1;
+            }
+
+            return direction;
+        }
+
         private readonly DispatcherTimer _scrollTracker = new();
 
         private TaskCompletionSource<bool> _waitItemsPanelRoot = new();
@@ -72,7 +201,15 @@ namespace Telegram.Controls.Chats
         public void ScrollToBottom()
         {
             HasBeenScrolled = true;
+            SetFollowingEnd(!IsReversed);
             ScrollingHost?.TryChangeView(null, ScrollingHost.ScrollableHeight, null);
+        }
+
+        public void ScrollToTop()
+        {
+            HasBeenScrolled = true;
+            SetFollowingEnd(IsReversed);
+            ScrollingHost?.TryChangeView(null, 0, null);
         }
 
         public bool IsSuspended => !_raiseViewChanged;
@@ -97,7 +234,7 @@ namespace Telegram.Controls.Chats
                 ItemsPanelRoot.SizeChanged += OnSizeChanged;
 
                 _waitItemsPanelRoot.TrySetResult(true);
-                SetScrollingMode();
+                ApplyAnchor();
             }
 
             ViewChanging();
@@ -168,6 +305,7 @@ namespace Telegram.Controls.Chats
         private void OnDirectManipulationCompleted(object sender, object e)
         {
             _scrollTracker.Stop();
+            UpdateFollowingEnd();
         }
 
         private void OnTick(object sender, object e)
@@ -183,7 +321,10 @@ namespace Telegram.Controls.Chats
             if (offset < -1)
             {
                 _scrollTracker.Stop();
-                SetScrollingMode(ItemsUpdatingScrollMode.KeepItemsInView, true);
+
+                // The ad is revealed by the user pulling past the end, so the list must stop
+                // following: inserting it while anchored to the end would scroll it into view.
+                SetFollowingEnd(false);
 
                 ViewModel.PendingSponsoredMessage = null;
                 ViewModel.InsertMessageInOrder(ViewModel.CreateMessage(new Message(message.MessageId, null, null, ViewModel.ChatId, null, null, false, false, false, false, false, true, false, false, false, false, 0, 0, null, null, null, null, null, null, null, null, null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, new MessageSponsored(message), null, null)));
@@ -243,7 +384,7 @@ namespace Telegram.Controls.Chats
                 var point = e.GetCurrentPoint(ScrollingHost);
                 if (point.Properties.MouseWheelDelta < 0)
                 {
-                    SetScrollingMode(ItemsUpdatingScrollMode.KeepItemsInView, true);
+                    SetFollowingEnd(false);
 
                     ViewModel.PendingSponsoredMessage = null;
                     ViewModel.InsertMessageInOrder(ViewModel.CreateMessage(new Message(message.MessageId, null, null, ViewModel.ChatId, null, null, false, false, false, false, false, true, false, false, false, false, 0, 0, null, null, null, null, null, null, null, null, null, 0, 0, 0, null, 0, 0, string.Empty, 0, string.Empty, 0, 0, null, string.Empty, new MessageSponsored(message), null, null)));
@@ -271,6 +412,8 @@ namespace Telegram.Controls.Chats
                 return;
             }
 
+            UpdateFollowingEnd();
+
             ScrollingDirection = PanelScrollingDirection.None;
         }
 
@@ -294,89 +437,6 @@ namespace Telegram.Controls.Chats
         public void ViewChanging(PanelScrollingDirection direction = PanelScrollingDirection.None)
         {
             ScrollingDirection = direction;
-
-            if (ScrollingHost == null || ItemsPanelRoot is not ItemsStackPanel panel || ViewModel == null || IsDisconnected)
-            {
-                return;
-            }
-
-            var lastSlice = ViewModel.IsSavedMessagesTab ? ViewModel.IsNewestSliceLoaded != true : ViewModel.IsOldestSliceLoaded != true;
-            var firstSlice = ViewModel.IsSavedMessagesTab ? ViewModel.IsOldestSliceLoaded != true : ViewModel.IsNewestSliceLoaded != true;
-
-            if (direction != PanelScrollingDirection.Backward && panel.LastCacheIndex == ViewModel.Items.Count - 1)
-            {
-                LoadPreviousSlice(direction, firstSlice);
-            }
-        }
-
-        private void LoadPreviousSlice(PanelScrollingDirection direction, bool firstSlice)
-        {
-            if (firstSlice)
-            {
-                return;
-            }
-
-            SetScrollingMode(ItemsUpdatingScrollMode.KeepLastItemInView, true);
-        }
-
-        private ItemsUpdatingScrollMode _currentMode;
-        private ItemsUpdatingScrollMode? _pendingMode;
-        private bool? _pendingForce;
-
-        public void SetScrollingMode()
-        {
-            if (_pendingMode is ItemsUpdatingScrollMode mode && _pendingForce is bool force)
-            {
-                _pendingMode = null;
-                _pendingForce = null;
-
-                SetScrollingMode(mode, force);
-            }
-        }
-
-        public void SetScrollingMode(ItemsUpdatingScrollMode mode, bool force)
-        {
-            var panel = ItemsPanelRoot as ItemsStackPanel;
-            var scroll = ScrollingHost;
-
-            if (panel == null || scroll == null)
-            {
-                _pendingMode = mode;
-                _pendingForce = force;
-
-                return;
-            }
-
-            if (_currentMode == _pendingMode)
-            {
-                _pendingMode = null;
-                _pendingForce = null;
-                return;
-            }
-
-            if (ViewModel.IsSavedMessagesTab)
-            {
-                mode = mode == ItemsUpdatingScrollMode.KeepLastItemInView
-                    ? ItemsUpdatingScrollMode.KeepItemsInView
-                    : ItemsUpdatingScrollMode.KeepLastItemInView;
-            }
-
-            if (mode == ItemsUpdatingScrollMode.KeepItemsInView && (force || scroll.VerticalOffset < 200))
-            {
-                if (panel.ItemsUpdatingScrollMode != mode)
-                {
-                    Logger.Debug("Changed scrolling mode to KeepItemsInView");
-                    panel.ItemsUpdatingScrollMode = _currentMode = ItemsUpdatingScrollMode.KeepItemsInView;
-                }
-            }
-            else if (mode == ItemsUpdatingScrollMode.KeepLastItemInView && (force || scroll.ScrollableHeight - scroll.VerticalOffset < 200))
-            {
-                if (panel.ItemsUpdatingScrollMode != mode)
-                {
-                    Logger.Debug("Changed scrolling mode to KeepLastItemInView");
-                    panel.ItemsUpdatingScrollMode = _currentMode = ItemsUpdatingScrollMode.KeepLastItemInView;
-                }
-            }
         }
 
         public async void ScrollToItem(MessageViewModel item, VerticalAlignment alignment, MessageBubbleHighlightOptions options, double? pixel = null, ScrollIntoViewAlignment direction = ScrollIntoViewAlignment.Leading, bool? disableAnimation = null, TaskCompletionSource<bool> tsc = null)
@@ -905,14 +965,6 @@ namespace Telegram.Controls.Chats
                     CheckNonScrollableState();
                 }
             }
-            else if (e.Direction == PanelScrollingDirection.Backward)
-            {
-                //_listView.SetScrollingMode(ItemsUpdatingScrollMode.KeepItemsInView, force: false);
-            }
-            else if (e.Direction == PanelScrollingDirection.Forward)
-            {
-                //_listView.SetScrollingMode(ItemsUpdatingScrollMode.KeepLastItemInView, force: false);
-            }
         }
 
         private void OnListViewLoaded(object sender, RoutedEventArgs e)
@@ -1108,15 +1160,6 @@ namespace Telegram.Controls.Chats
                 return;
 
             Interlocked.Increment(ref _activeLoadOperations);
-
-            //if (direction == PanelScrollingDirection.Backward)
-            //{
-            //    _listView.SetScrollingMode(ItemsUpdatingScrollMode.KeepItemsInView, force: true);
-            //}
-            //else if (direction == PanelScrollingDirection.Forward)
-            //{
-            //    _listView.SetScrollingMode(ItemsUpdatingScrollMode.KeepLastItemInView, force: true);
-            //}
 
             _ = LoadItemsInternalAsync(direction);
         }

--- a/Telegram/Controls/Messages/MessageBubble.xaml.cs
+++ b/Telegram/Controls/Messages/MessageBubble.xaml.cs
@@ -2729,13 +2729,7 @@ namespace Telegram.Controls.Messages
 
             var index = selector.Owner.IndexFromContainer(selector);
 
-            var direction = panel.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView ? -1 : 1;
-            var edge = (index == panel.LastVisibleIndex && direction == 1) || (index == panel.FirstVisibleIndex && direction == -1);
-
-            if (edge && !selector.Owner.ScrollingHost.ViewportContains(selector))
-            {
-                direction *= -1;
-            }
+            var direction = ChatHistoryView.GetShiftDirection(panel, index, selector, selector.Owner.ScrollingHost);
 
             var first = direction == 1 ? panel.FirstCacheIndex : index + 1;
             var last = direction == 1 ? index : panel.LastCacheIndex;

--- a/Telegram/ViewModels/DialogEventLogViewModel.cs
+++ b/Telegram/ViewModels/DialogEventLogViewModel.cs
@@ -140,8 +140,7 @@ namespace Telegram.ViewModels
 
                 if (events.Events.Count > 0)
                 {
-                    SetScrollMode(ItemsUpdatingScrollMode.KeepLastItemInView, true);
-                    Logger.Debug("Setting scroll mode to KeepLastItemInView");
+                    SetFollowingEnd(true);
                 }
 
                 var replied = ProcessEvents(events);
@@ -186,12 +185,6 @@ namespace Telegram.ViewModels
             var response = await ClientService.SendAsync(new GetChatEventLog(chat.Id, string.Empty, _minEventId, 50, _filters, _userIds));
             if (response is ChatEvents events)
             {
-                if (events.Events.Count > 0)
-                {
-                    SetScrollMode(ItemsUpdatingScrollMode.KeepLastItemInView, true);
-                    Logger.Debug("Setting scroll mode to KeepLastItemInView");
-                }
-
                 var replied = ProcessEvents(events);
                 ProcessMessages(chat, replied);
 

--- a/Telegram/ViewModels/DialogViewModel.cs
+++ b/Telegram/ViewModels/DialogViewModel.cs
@@ -663,15 +663,9 @@ namespace Telegram.ViewModels
             }
         }
 
-        public void SetScrollMode(ItemsUpdatingScrollMode mode, bool force)
+        public void SetFollowingEnd(bool value)
         {
-            var field = HistoryField;
-            if (field == null)
-            {
-                return;
-            }
-
-            field.SetScrollingMode(mode, force);
+            HistoryField?.SetFollowingEnd(value);
         }
 
         public override FormattedText GetFormattedText(bool clear = false, bool parseMarkdown = true)
@@ -913,12 +907,10 @@ namespace Telegram.ViewModels
 
                     if (direction == PanelScrollingDirection.Backward)
                     {
-                        SetScrollMode(ItemsUpdatingScrollMode.KeepLastItemInView, true);
                         Items.PrependSlice(replied, true, out bool empty);
                     }
                     else
                     {
-                        SetScrollMode(ItemsUpdatingScrollMode.KeepItemsInView, true);
                         Items.AppendSlice(replied, true, out bool empty);
                     }
 
@@ -938,10 +930,6 @@ namespace Telegram.ViewModels
                             Items.RemoveAt(direction == PanelScrollingDirection.Backward ? Items.Count - 1 : 0);
                         }
                     }
-                }
-                else if (direction != PanelScrollingDirection.Backward)
-                {
-                    SetScrollMode(ItemsUpdatingScrollMode.KeepLastItemInView, true);
                 }
 
                 if (direction == PanelScrollingDirection.Backward)
@@ -1315,7 +1303,7 @@ namespace Telegram.ViewModels
                 pixel = slice.Pixel;
                 alignment = slice.Alignment;
 
-                SetScrollMode(slice.ScrollMode, true);
+                SetFollowingEnd(slice.IsFollowingEnd);
 
                 var messages = slice.Items;
                 var endReached = IsEndReached(messages);
@@ -1662,10 +1650,10 @@ namespace Telegram.ViewModels
                 }
 
                 IEnumerable<Message> values;
-                ItemsUpdatingScrollMode scrollMode;
+                bool following;
                 if (alignment == VerticalAlignment.Bottom)
                 {
-                    scrollMode = ItemsUpdatingScrollMode.KeepLastItemInView;
+                    following = true;
                     values = messages.MessagesValue;
                 }
                 else if (alignment == VerticalAlignment.Top)
@@ -1675,14 +1663,14 @@ namespace Telegram.ViewModels
                         firstVisibleIndex++;
                     }
 
-                    scrollMode = ItemsUpdatingScrollMode.KeepItemsInView;
+                    following = false;
                     values = firstVisibleIndex == -1 || messages.MessagesValue.Count == firstVisibleIndex + 1
                         ? messages.MessagesValue
                         : messages.MessagesValue.Take(firstVisibleIndex + 1);
                 }
                 else
                 {
-                    scrollMode = direction == ScrollIntoViewAlignment.Default ? ItemsUpdatingScrollMode.KeepLastItemInView : ItemsUpdatingScrollMode.KeepItemsInView;
+                    following = direction == ScrollIntoViewAlignment.Default;
                     values = messages.MessagesValue;
                 }
 
@@ -1699,7 +1687,7 @@ namespace Telegram.ViewModels
                 }
 
                 var replied = new MessageCollection(this, null, values, false, Type);
-                return new LoadSliceResult(replied, fromMessageId, scrollMode, alignment, pixel, unread, messages.TotalCount);
+                return new LoadSliceResult(replied, fromMessageId, following, alignment, pixel, unread, messages.TotalCount);
             }
 
             return null;
@@ -1707,11 +1695,11 @@ namespace Telegram.ViewModels
 
         private class LoadSliceResult
         {
-            public LoadSliceResult(MessageCollection items, long fromMessageId, ItemsUpdatingScrollMode scrollMode, VerticalAlignment alignment, double? pixel, bool unread, int totalCount)
+            public LoadSliceResult(MessageCollection items, long fromMessageId, bool following, VerticalAlignment alignment, double? pixel, bool unread, int totalCount)
             {
                 Items = items;
                 FromMessageId = fromMessageId;
-                ScrollMode = scrollMode;
+                IsFollowingEnd = following;
                 Alignment = alignment;
                 Pixel = pixel;
                 IsUnread = unread;
@@ -1722,7 +1710,7 @@ namespace Telegram.ViewModels
 
             public long FromMessageId { get; }
 
-            public ItemsUpdatingScrollMode ScrollMode { get; }
+            public bool IsFollowingEnd { get; }
 
             public VerticalAlignment Alignment { get; }
 
@@ -1795,8 +1783,7 @@ namespace Telegram.ViewModels
 
                 if (messages.MessagesValue.Count > 0)
                 {
-                    SetScrollMode(ItemsUpdatingScrollMode.KeepLastItemInView, true);
-                    Logger.Debug("Setting scroll mode to KeepLastItemInView");
+                    SetFollowingEnd(true);
                 }
 
                 // The slice walks its source newest-first, inserting each one at the top,
@@ -1869,7 +1856,6 @@ namespace Telegram.ViewModels
                 }
 
                 field.ScrollToBottom();
-                field.SetScrollingMode(ItemsUpdatingScrollMode.KeepLastItemInView, true);
             }
         }
 
@@ -1884,7 +1870,6 @@ namespace Telegram.ViewModels
                 }
 
                 field.ScrollToTop();
-                field.SetScrollingMode(ItemsUpdatingScrollMode.KeepItemsInView, true);
             }
         }
 
@@ -2384,7 +2369,7 @@ namespace Telegram.ViewModels
                 Delegate?.DisableScreenCapture();
             }
 
-            SetScrollMode(ItemsUpdatingScrollMode.KeepLastItemInView, true);
+            SetFollowingEnd(true);
             SetTranslating();
 
             if (state.TryRemove("access_token", out string accessToken))

--- a/Telegram/Views/ChatView.Bubbles.xaml.cs
+++ b/Telegram/Views/ChatView.Bubbles.xaml.cs
@@ -80,6 +80,10 @@ namespace Telegram.Views
 
             _messagesShift.Clear();
 
+            // The panel's visible range is current again, so the anchor can stop being tracked by
+            // hand until the next run of mutations.
+            Messages.InvalidateAnchor();
+
             if (_viewChanged)
             {
                 _viewChanged = false;
@@ -1556,13 +1560,7 @@ namespace Telegram.Views
 
             if (index >= panel.FirstVisibleIndex && index <= panel.LastVisibleIndex)
             {
-                var direction = panel.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView ? -1 : 1;
-                var edge = (index == panel.LastVisibleIndex && direction == 1) || (index == panel.FirstVisibleIndex && direction == -1);
-
-                if (edge && !Messages.ScrollingHost.ViewportContains(selector))
-                {
-                    direction *= -1;
-                }
+                var direction = ChatHistoryView.GetShiftDirection(panel, index, selector, Messages.ScrollingHost);
 
                 var first = direction == 1 ? panel.FirstCacheIndex : index + 1;
                 var last = direction == 1 ? index : panel.LastCacheIndex;

--- a/Telegram/Views/ChatView.xaml.cs
+++ b/Telegram/Views/ChatView.xaml.cs
@@ -601,11 +601,14 @@ namespace Telegram.Views
         /// </summary>
         public void Inserting(int index, IList items)
         {
+            Messages.PrepareAnchor(index, items.Count);
             _messagesShift.RegisterInsert(index);
         }
 
         public void Removing(int index, IList items)
         {
+            Messages.PrepareAnchor(index, -items.Count);
+
             if (Messages.ItemsPanelRoot is not ItemsStackPanel panel)
             {
                 return;
@@ -618,6 +621,8 @@ namespace Telegram.Views
                 var translated = _messagesShift.Translate(index);
                 if (translated >= panel.FirstVisibleIndex && translated <= panel.LastVisibleIndex && _messageIdToSelector.TryGetValue(message.Id, out ChatHistoryViewItem selector))
                 {
+                    // Not the direction: the row is gone by the time the shift is animated, so what
+                    // is stored is whether it sat at the edge, and the direction is derived then.
                     var direction = panel.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView ? -1 : 1;
                     var edge = (translated == panel.LastVisibleIndex && direction == 1) || (translated == panel.FirstVisibleIndex && direction == -1);
 
@@ -731,7 +736,7 @@ namespace Telegram.Views
 
             ViewModel.SetText(null, false);
 
-            Messages.SetScrollingMode(ItemsUpdatingScrollMode.KeepLastItemInView, true);
+            Messages.SetFollowingEnd(true);
             Messages.ItemsSource ??= _messages;
 
             CheckMessageBoxEmpty();
@@ -5235,7 +5240,7 @@ namespace Telegram.Views
         private void ItemsPanelRoot_Loading(FrameworkElement sender, object args)
         {
             sender.MaxWidth = AppSettings.IsAdaptiveWideEnabled ? 1024 : double.PositiveInfinity;
-            Messages.SetScrollingMode();
+            Messages.ApplyAnchor();
         }
 
         private void ServiceMessage_Click(object sender, RoutedEventArgs e)

--- a/notes/chat-history-scroll-mode-todo.md
+++ b/notes/chat-history-scroll-mode-todo.md
@@ -1,0 +1,283 @@
+# ChatHistoryView — ItemsUpdatingScrollMode
+
+Findings from a read-through of `Telegram/Controls/Chats/ChatHistoryView.cs`, its writers in
+`DialogViewModel{,.Handle}.cs` and `DialogEventLogViewModel.cs`, its readers in
+`ChatView.xaml.cs`, `ChatView.Bubbles.xaml.cs` and `MessageBubble.xaml.cs`, and the mirror that
+actually delivers the mutations, `Telegram/Collections/SynchronizedList.cs`.
+
+**All of it is implemented and compiles (Modern, Debug x64); none of it has been run.** The
+sections below are kept as written so the reasoning survives; what actually landed is at the foot
+of the file, along with what is worth watching for when it is first exercised.
+
+---
+
+## How it works today
+
+`ItemsStackPanel.ItemsUpdatingScrollMode` is one bit naming the edge the scroll offset is
+anchored to across a collection change:
+
+- `KeepLastItemInView` — anchored to the end. Prepending at 0 does not move the view; appending
+  pulls the view to the bottom. This is what gives stick-to-bottom.
+- `KeepItemsInView` — anchored to the start. Appending does not move the view; prepending pushes
+  everything down.
+
+The rule is therefore *flip the bit to match whichever end the next mutation touches, then
+mutate*. `ChatHistoryView.SetScrollingMode` is the only writer; `DialogViewModel.SetScrollMode`
+is a forwarder. Callers:
+
+| Site | Compensating for |
+| --- | --- |
+| `DialogViewModel.cs:916/921` | `RawInsertRange(0, ...)` / `RawAddRange(...)` in `LoadNextSliceAsync` |
+| `DialogViewModel.cs:1317` | the mode `LoadMessageSliceImpl` derived from the requested alignment |
+| `DialogViewModel.cs:1789`, `DialogEventLogViewModel.cs:144/191` | scheduled and event-log loads |
+| `DialogViewModel.cs:1861/1876` | `ScrollToBottom` / `ScrollToTop` |
+| `DialogViewModel.cs:2355`, `ChatView.xaml.cs:735` | navigation-time default |
+| `ChatHistoryView.cs:319` (`LoadPreviousSlice`) | every scroll frame, from `OnViewChanging` |
+| `ChatHistoryView.cs:186/246` | sponsored message insertion |
+
+`InsertMessageInOrder` — the path every incoming message takes — sets nothing and inherits
+whatever the bit happens to be.
+
+The bit is also **read**, as "which edge is the layout anchored to", by the size-change
+compensation in `ChatView.Bubbles.xaml.cs:69`, `:1554`, `:1593`, `ChatView.xaml.cs:622` and
+`MessageBubble.xaml.cs:2752`. It is not only an insertion hint.
+
+**Why it is brittle**, in one sentence: it is an implicit global whose correctness rests on
+temporal coupling — whoever mutates the collection next must have been preceded by whoever set
+the bit — with no link between the two, three writers on unrelated triggers, and a mirror
+collection that can deliver the mutation a frame after the bit was set.
+
+---
+
+## Task 1 — Cleanups with no behaviour change
+
+- [x] **1.1** `ChatHistoryView.cs:347` compares against the wrong variable:
+
+  ```csharp
+  if (_currentMode == _pendingMode)
+  ```
+
+  `_pendingMode` here is leftover state from an earlier deferred call, not the argument. The
+  block is only reached once the panel exists, so it fires when a call landed before the panel
+  was ready (stashing a pending mode) and a second call arrives before `OnLoaded` drains it. If
+  the stale pending equals `_currentMode`, the **new** mode is silently dropped. Reads as if it
+  were meant to be `_currentMode == mode`.
+
+- [x] **1.2** Even the intended check is redundant: `if (panel.ItemsUpdatingScrollMode != mode)`
+  two lines down does the same job correctly, by reading the panel instead of a shadow copy.
+  `_currentMode` has no other reader — delete the field and the early-out together rather than
+  fixing 1.1 in place.
+
+- [x] **1.3** Half the method is unreachable. Every live call site passes `force: true`; the only
+  `force: false` calls in the tree are the two commented-out lines in
+  `BidirectionalIncrementalLoader` (`:910`, `:914`). The `|| scroll.VerticalOffset < 200` and
+  `|| scroll.ScrollableHeight - scroll.VerticalOffset < 200` proximity heuristics never run.
+  Drop the parameter and both clauses, or keep the parameter and delete the clauses — but not
+  the current state, where the scariest-looking code in the method is dead.
+
+- [x] **1.4** `ViewChanging` (`:292`) computes `lastSlice` and never uses it.
+
+- [x] **1.5** `LoadPreviousSlice` loads nothing — it only sets the mode. The loading moved to
+  `BidirectionalIncrementalLoader`. Rename or inline it.
+
+- [x] **1.6** `ViewModel` is dereferenced unguarded in `SetScrollingMode` (`:357`),
+  `OnDirectManipulationStarted` (`:161`) and `OnPointerWheelChanged` (`:235`), while
+  `ViewChanging` just above null-checks it. The pending path (`OnLoaded` → `SetScrollingMode()`)
+  can reach `:357` before `Messages.ViewModel` is assigned.
+
+---
+
+## Task 2 — The bit is slammed on every scroll frame
+
+- [x] **2.1** `ChatHistoryView.cs:298`:
+
+  ```csharp
+  if (direction != PanelScrollingDirection.Backward && panel.LastCacheIndex == ViewModel.Items.Count - 1)
+  ```
+
+  The trigger is `LastCacheIndex`, not the viewport. The cache reaches well past the visible
+  range, so this forces `KeepLastItemInView` while the user is still comfortably above the
+  bottom — after which an incoming message yanks the view down. The condition asks "is the end
+  realized" where it means "is the user at the end"; `IsBottomReached` (`:38`) already answers
+  the second question.
+
+  **Reproduce before fixing.** Scroll up by roughly one viewport in a busy chat and have someone
+  send a message.
+
+  This is not only a bug: it is the `pinned` flag of Task 4, in the wrong units. The intent —
+  "the user is following the end, so keep anchoring there" — is right, and it is the reason
+  stick-to-bottom works at all today. Fixing it in place and fixing it properly are the same
+  work, so consider doing 2.1 as `pinned` directly rather than twice.
+
+- [x] **2.2** Same line: `panel.LastCacheIndex` indexes the ListView's `ItemsSource` — `_messages`,
+  a `SynchronizedList` that is *reversed* in the saved-messages tab and can lag the source by a
+  frame. It is compared against the view model's count. Compare against the list's own count.
+
+---
+
+## Task 3 — Set-then-mutate is not actually guaranteed
+
+- [x] **3.1** `SynchronizedList.OnCollectionChanged` (`:238-256`) applies an `Add` straight
+  through *unless* a capture-worthy `Remove` is queued for the dust effect, in which case it
+  queues behind it and applies up to a frame or 100 ms later. So `SetScrollMode(...)` followed
+  immediately by `RawInsertRange(...)` is only tightly coupled most of the time; any scroll event
+  in that window re-runs 2.1 and flips the bit before the panel ever sees the insert.
+
+  Nothing to fix here on its own — this is the argument for Task 4.
+
+- [x] **3.2** Pending state is never cleared on unload, and only `OnLoaded` drains it, and only
+  if `ItemsPanelRoot != null` at that moment. Navigate away with a pending mode and a stale one
+  is applied on the way back.
+
+- [x] **3.3** Three overlapping owners: `BidirectionalIncrementalLoader` was evidently meant to
+  own this (its calls are commented out), `DialogViewModel.LoadNextSliceAsync` actually does it,
+  and `ChatHistoryView.ViewChanging` does it a third time on a different trigger. Settle on one.
+
+---
+
+## Task 4 — Ask the question the panel is actually being asked
+
+The mode is not a setting. It is the answer to one question, asked once per mutation:
+
+> the collection is about to be mutated — is that mutation inside the viewport, and on which
+> side of it?
+
+with one term in front of it, which is what a chat is actually for: **is the list pinned to the
+end?** If it is, the user is following the conversation and new messages must appear without
+being scrolled to.
+
+```
+anchor = pinned || i <= first ? KeepLastItemInView : KeepItemsInView
+```
+
+`pinned` needs no case analysis: end-anchoring is correct for *every* mutation while pinned. A
+prepend compensates and leaves the user at the bottom; an append reveals the new message. It is
+the dominant case and it costs one term.
+
+The index comparison only has to answer for the *un*pinned case — the user reading history above,
+where the invariant is that content already on screen must not move. With `first`/`last` the
+visible range:
+
+| Where | Anchor | Why |
+| --- | --- | --- |
+| `i <= first` | end (`KeepLastItemInView`) | the content above changes height, the offset has to absorb the delta |
+| `i > last` | start (`KeepItemsInView`) | nothing above changes, so nothing moves |
+| `first < i <= last` | start | something must move; the convention is that the rows below the mutation point do |
+
+So a single comparison, `i <= first`. "Direction" is that same comparison — it is what the four
+hand-rolled `direction` computations in `AnimateSizeChanged` and `MessageBubble.ComputeDirection`
+are reconstructing after the fact, complete with a `TODO: I'm not sure it's correct`.
+
+What this buys beyond deleting the writers: **mutations nobody currently sets the bit for come
+out right.** `MoveMessageInOrder` is a remove followed by an insert, and the two can need
+opposite anchors; today both inherit one global bit. Same for any mid-list insert — a scheduled
+message going live, a date or topic separator materialising, the sponsored message.
+
+### `pinned` is the part to get right
+
+It is the only state left, so it carries the whole design.
+
+- **It has to be sticky, not a live query at apply time.** Inertial scrolling, the `Suspend`
+  /`Resume` window inside `ScrollToItem`, and the deferred flush in Task 3.1 all read a transient
+  offset. What is wanted is "the user last came to rest at the end", updated on
+  `ViewChanged` with `IsIntermediate == false` and on `DirectManipulationCompleted`.
+- **`IsBottomReached` (`ChatHistoryView.cs:38`) is too strict to reuse as-is.** It is
+  `VerticalOffset.AlmostEquals(ScrollableHeight)`, and `AlmostEquals` defaults to `epsilon = 1e-5`
+  (`Extensions.cs:963`) — exact equality in practice. A pixel of overscroll bounce, a fractional
+  DPI offset or a composer mid-resize would silently unpin. It needs a real threshold of a few
+  DIPs. Note this is *not* the 200 px of 1.3, which was asking a different and wrong question at
+  a different time.
+- **Unpinning must be the user's act, never a layout event.** A message arriving, the composer
+  growing, or a slice loading all change `ScrollableHeight`; none of them mean the user stopped
+  following.
+- **Tall messages.** Pinned + append of a message taller than the viewport lands its *bottom* at
+  the viewport bottom, cutting off the top. `LoadMessageSliceImpl` already knows about this case
+  (`DialogViewModel.cs:1630`, "it might be taller than the window height"). Decide whether pinned
+  means "bottom of the list visible" or "top of the new message visible".
+
+### Traps
+
+- **Index space.** `Inserting`/`Removing` are handed `pending.SourceIndex`, but panel indices are
+  mirror indices, and the two diverge in the saved-messages tab (`_reverse`). `ChatView.Removing`
+  (`ChatView.xaml.cs:611`) already compares that source index against `panel.FirstCacheIndex` and
+  `LastCacheIndex` — check that case before building on it. Either `Apply` passes `pending.Index`
+  as well, or the anchor is decided inside `Apply`.
+- **Staleness within a batch.** `panel.FirstVisibleIndex` does not update until layout runs, so
+  the second and later mutations of one flush would compare against a stale value. That is what
+  `_messagesShift.Translate` exists for — reuse it rather than reading the panel raw.
+- **The header.** `ListView.Header` (`SavedMessagesTabHeader`) — confirm whether it participates
+  in the panel's index space before trusting any comparison against `FirstVisibleIndex`.
+
+### Steps
+
+- [x] **4.1** Give `SynchronizedList.Apply` (`:283`) the mirror index and the visible range, and
+  have it set the anchor from the comparison above immediately before `InsertRange`/`RemoveRange`.
+  It is the single funnel every mutation passes through to reach the panel, it already accounts
+  for the reversal, and it runs on the frame the panel will process the change — which removes
+  the pending/deferred machinery, the saved-messages inversion in `SetScrollingMode`, and every
+  ordering hazard in Task 3.
+
+- [x] **4.2** Introduce `pinned` per the section above, and short-circuit 4.1 with it. This
+  replaces what `ViewChanging`/`LoadPreviousSlice` is attempting in 2.1 — same intent, measured
+  against the viewport instead of the realized range.
+
+- [x] **4.3** Delete the ~15 writers. `SetScrollingMode` becomes private, or disappears.
+
+- [x] **4.4** Have the animation sites read the anchor that was just computed for the mutation in
+  flight, rather than recomputing a direction from the panel bit. Fold
+  `MessageBubble.ComputeDirection` and both `AnimateSizeChanged` overloads onto it.
+
+---
+
+## What landed
+
+`ItemsUpdatingScrollMode` is no longer set by anyone outside the control. Two things replaced the
+fifteen writers, both on `ChatHistoryView`:
+
+- **`IsFollowingEnd`** — sticky, sampled in `UpdateFollowingEnd` from `OnViewChanged` (only when
+  `IsIntermediate` is false) and `OnDirectManipulationCompleted`, against a `FollowThreshold` of 8
+  DIPs. `SetFollowingEnd(bool)` is the explicit form for the paths that know their intent, and it
+  pushes the edge to the panel immediately because a reset never reaches `PrepareAnchor`.
+- **`PrepareAnchor(index, delta)`** — called from `ChatView.Inserting`/`Removing`, which
+  `SynchronizedList.Apply` raises immediately before it mutates. Picks the edge from
+  `IsFollowingEnd ? !IsReversed : index <= first`, and keeps `first` current by hand between layout
+  passes (`InvalidateAnchor` clears it from `ItemsPanelRoot_LayoutUpdated`).
+
+`ISynchronizedListDelegate<T>.Inserting`/`Removing` now carry the **mirror** index rather than the
+source index — `Pending.SourceIndex` is gone, nothing wanted it. That also fixes the trap noted
+above: `ChatView.Removing` was comparing a source index against `panel.FirstCacheIndex`, which only
+agreed with itself outside the saved-messages tab.
+
+Translations of the old writers, rather than deletions, where intent existed:
+
+| Was | Is |
+| --- | --- |
+| `SetScrollMode(..., true)` before `RawReplaceWith` / `ReplaceWith` (a reset) | `SetFollowingEnd(...)` |
+| `LoadSliceResult.ScrollMode`, derived from the alignment | `LoadSliceResult.IsFollowingEnd` |
+| navigation default, `ChatView.Update` | `SetFollowingEnd(true)` |
+| `ScrollToBottom` / `ScrollToTop` followed by a mode set | folded into the control's own methods |
+| the two sponsored-message insertions | `SetFollowingEnd(false)` — the ad is revealed by the user pulling past the end, so it must not pull the view |
+
+Deleted outright, because the edge is now derived per mutation: the pair around
+`RawInsertRange`/`RawAddRange` in `LoadNextSliceAsync`, the empty-response case beside them, the
+prepend in `DialogEventLogViewModel.LoadNextSliceAsync`, `LoadPreviousSlice` and the body of
+`ViewChanging`, the whole pending/`_currentMode` machinery, and the commented-out calls in
+`BidirectionalIncrementalLoader`.
+
+`ChatHistoryView.GetShiftDirection` is the one copy of the direction computation, used by
+`MessageBubble.ComputeDirection` and `ChatView.Bubbles.AnimateSizeChanged`. The removal site in
+`ChatView.Removing` deliberately still computes `edge` itself: it stores a flag for later, not a
+direction, because the row is gone by the time the shift is animated.
+
+## Worth watching on the first run
+
+- **The 8 DIP threshold** is a guess. Too small and the list stops following after a bounce; too
+  large and it follows when the user deliberately nudged up a little.
+- **Tall messages.** Still open, and untouched: a pinned append of a message taller than the
+  viewport lands its bottom at the viewport bottom.
+- **`_anchorIndex` between layout passes.** A removal range straddling the viewport edge moves it
+  approximately. Layout corrects it, so the worst case is one mutation anchored to the wrong edge.
+- **The saved-messages tab**, where `IsReversed` inverts both the measurement and the pinned edge,
+  and where the index bookkeeping was demonstrably wrong before.
+- `ViewChanging` now only assigns `ScrollingDirection`, which nothing reads, and `OnSizeChanged`
+  calls it for no remaining reason. Left alone rather than widening the diff.


### PR DESCRIPTION
`ItemsUpdatingScrollMode` was an implicit global: whoever mutated `Items` next had to have been preceded by whoever set the mode, with no link between the two, three writers on unrelated triggers, and a mirror collection that can deliver the mutation a frame after the mode was set.

This replaces it with the question the panel is actually being asked — *the collection is about to be mutated, is that inside the viewport, and on which side?* — with stick-to-bottom as a term in front of it rather than an exception behind it:

```
anchor = IsFollowingEnd || index <= first ? KeepLastItemInView : KeepItemsInView
```

## What replaces the ~15 writers

Two members on `ChatHistoryView`:

- **`IsFollowingEnd`** — sticky, sampled from `OnViewChanged` (only when `IsIntermediate` is false) and `OnDirectManipulationCompleted`, against a threshold of 8 DIPs. Exact equality was not usable: a pixel of overscroll bounce would have silently stopped the list following. `SetFollowingEnd(bool)` is the explicit form for the paths that know their intent, and it pushes the edge to the panel immediately, because a reset never reaches the per-mutation hook.
- **`PrepareAnchor(index, delta)`** — called from `ChatView.Inserting`/`Removing`, which `SynchronizedList.Apply` raises immediately before it mutates. It keeps the first visible index current by hand between layout passes, because `MessageCollection.RawInsertRange`/`RawAddRange` raise one event per message, so a slice load is a burst of mutations with no layout between them.

`ISynchronizedListDelegate<T>` now carries the **mirror** index rather than the source index (`Pending.SourceIndex` is gone, nothing wanted it). That also fixes `ChatView.Removing`, which was comparing a source index against `panel.FirstCacheIndex` — the two only agree outside the saved-messages tab, where the mirror is reversed.

Writers were translated rather than deleted wherever intent existed, since a reset bypasses the per-mutation hook: the initial-load, scheduled, event-log and navigation paths still say `SetFollowingEnd(...)`, and `LoadSliceResult.ScrollMode` became `IsFollowingEnd`. The pairs around `RawInsertRange`/`RawAddRange`, `LoadPreviousSlice`, the body of `ViewChanging`, the whole pending/`_currentMode` machinery and the commented-out calls in `BidirectionalIncrementalLoader` are gone.

## Bugs fixed on the way

- `SetScrollingMode` compared `_currentMode == _pendingMode` — leftover state from an earlier deferred call, not the argument — and silently dropped the new mode when they matched.
- `ViewChanging` forced `KeepLastItemInView` whenever `panel.LastCacheIndex` reached the end of the list. The cache extends well past the viewport, so an incoming message yanked the view down while the user was still reading above it. That condition asked "is the end realized" where it meant "is the user at the end".
- The same line compared a panel index against the view model's count rather than the list's.
- `force` was `true` at every live call site, so the 200 px proximity heuristics in `SetScrollingMode` never ran.
- `MoveMessageInOrder` is a remove followed by an insert, which can need opposite anchors; both used to inherit one global bit. Mid-list inserts — a scheduled message going live, a date separator materialising, the sponsored message — were in the same position.

`ChatHistoryView.GetShiftDirection` is now the single copy of the direction computation used by `MessageBubble.ComputeDirection` and `AnimateSizeChanged`. The removal site still computes `edge` itself on purpose: it stores a flag for later, not a direction, because the row is gone by the time the shift animates.

## Notes

`notes/chat-history-scroll-mode-todo.md` carries the full review, the reasoning and what to watch. Still open and deliberately untouched: a pinned append of a message taller than the viewport lands its bottom at the viewport bottom rather than showing its top. The 8 DIP threshold is a first guess.

**Not for the current release** — parked here deliberately.
