### PR TITLE
Don't show a streamed download on the file buttons

### DIFF
--- a/Telegram/Controls/Cells/PlaybackItemCell.xaml.cs
+++ b/Telegram/Controls/Cells/PlaybackItemCell.xaml.cs
@@ -220,7 +220,9 @@ namespace Telegram.Controls.Cells
             }
 
             var size = Math.Max(file.Size, file.ExpectedSize);
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(item.ClientService);
+
+            if (state == MessageContentState.Downloading)
             {
                 FileButton target;
                 if (AppSettings.IsStreamingEnabled)
@@ -239,7 +241,7 @@ namespace Telegram.Controls.Cells
 
                 Subtitle.Text = string.Format("{0} / {1}", FileSizeConverter.Convert(file.Local.DownloadedSize, size), FileSizeConverter.Convert(size));
             }
-            else if (file.Remote.IsUploadingActive)
+            else if (state == MessageContentState.Uploading)
             {
                 DownloadRoot.Visibility = Visibility.Collapsed;
 
@@ -248,7 +250,7 @@ namespace Telegram.Controls.Cells
 
                 Subtitle.Text = string.Format("{0} / {1}", FileSizeConverter.Convert(file.Remote.UploadedSize, size), FileSizeConverter.Convert(size));
             }
-            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingCompleted)
+            else if (state == MessageContentState.Download)
             {
                 FileButton target;
                 if (AppSettings.IsStreamingEnabled)
@@ -316,7 +318,7 @@ namespace Telegram.Controls.Cells
                 Button.SetGlyph(file.Id, MessageContentState.Play);
                 Button.Progress = 1;
 
-                if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingCompleted && !file.Local.IsDownloadingActive && !file.Remote.IsUploadingActive)
+                if (file.GetFileState(item.ClientService) == MessageContentState.Download)
                 {
                     Subtitle.Text = audio.GetDuration() + " - " + FileSizeConverter.Convert(Math.Max(file.Size, file.ExpectedSize));
                 }
@@ -446,18 +448,20 @@ namespace Telegram.Controls.Cells
             }
 
             var file = audio.AudioValue;
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(_item.ClientService);
+
+            if (state == MessageContentState.Downloading)
             {
                 _item.ClientService.CancelDownloadFile(file);
             }
-            else if (file.Remote.IsUploadingActive)
+            else if (state == MessageContentState.Uploading)
             {
                 if (_item is PlaybackItemMessage message)
                 {
                     _item.ClientService.Send(new DeleteMessages(message.ChatId, new[] { message.Id }, true));
                 }
             }
-            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingActive && !file.Local.IsDownloadingCompleted)
+            else if (state == MessageContentState.Download)
             {
                 if (_item is PlaybackItemMessage message && message.Message.CanBeAddedToDownloads)
                 {

--- a/Telegram/Controls/Cells/SharedAudioCell.xaml.cs
+++ b/Telegram/Controls/Cells/SharedAudioCell.xaml.cs
@@ -224,7 +224,9 @@ namespace Telegram.Controls.Cells
             }
 
             var size = Math.Max(file.Size, file.ExpectedSize);
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(message);
+
+            if (state == MessageContentState.Downloading)
             {
                 FileButton target;
                 if (AppSettings.IsStreamingEnabled)
@@ -243,7 +245,7 @@ namespace Telegram.Controls.Cells
 
                 Subtitle.Text = string.Format("{0} / {1}", FileSizeConverter.Convert(file.Local.DownloadedSize, size), FileSizeConverter.Convert(size));
             }
-            else if (file.Remote.IsUploadingActive || message.SendingState is MessageSendingStateFailed || (message.SendingState is MessageSendingStatePending && !file.Remote.IsUploadingCompleted))
+            else if (state == MessageContentState.Uploading)
             {
                 DownloadRoot.Visibility = Visibility.Collapsed;
 
@@ -252,7 +254,7 @@ namespace Telegram.Controls.Cells
 
                 Subtitle.Text = string.Format("{0} / {1}", FileSizeConverter.Convert(file.Remote.UploadedSize, size), FileSizeConverter.Convert(size));
             }
-            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingCompleted)
+            else if (state == MessageContentState.Download)
             {
                 FileButton target;
                 if (AppSettings.IsStreamingEnabled)
@@ -320,7 +322,7 @@ namespace Telegram.Controls.Cells
                 Button.SetGlyph(file.Id, MessageContentState.Play);
                 Button.Progress = 1;
 
-                if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingCompleted && !file.Local.IsDownloadingActive && !file.Remote.IsUploadingActive)
+                if (file.GetFileState(message) == MessageContentState.Download)
                 {
                     Subtitle.Text = audio.GetDuration() + " - " + FileSizeConverter.Convert(Math.Max(file.Size, file.ExpectedSize));
                 }
@@ -446,15 +448,17 @@ namespace Telegram.Controls.Cells
             }
 
             var file = audio.AudioValue;
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(_message);
+
+            if (state == MessageContentState.Downloading)
             {
                 _message.ClientService.CancelDownloadFile(file);
             }
-            else if (file.Remote.IsUploadingActive || _message.SendingState is MessageSendingStateFailed)
+            else if (state == MessageContentState.Uploading)
             {
                 _message.ClientService.Send(new DeleteMessages(_message.ChatId, new[] { _message.Id }, true));
             }
-            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingActive && !file.Local.IsDownloadingCompleted)
+            else if (state == MessageContentState.Download)
             {
                 if (_message.CanBeAddedToDownloads)
                 {

--- a/Telegram/Controls/Cells/SharedFileCell.xaml.cs
+++ b/Telegram/Controls/Cells/SharedFileCell.xaml.cs
@@ -148,7 +148,9 @@ namespace Telegram.Controls.Cells
             }
 
             var size = Math.Max(file.Size, file.ExpectedSize);
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(message);
+
+            if (state == MessageContentState.Downloading)
             {
                 //Button.Glyph = Icons.Cancel;
                 Button.SetGlyph(file.Id, MessageContentState.Downloading);
@@ -156,7 +158,7 @@ namespace Telegram.Controls.Cells
 
                 Subtitle.Text = string.Format("{0} / {1}", FileSizeConverter.Convert(file.Local.DownloadedSize, size), FileSizeConverter.Convert(size));
             }
-            else if (file.Remote.IsUploadingActive)
+            else if (state == MessageContentState.Uploading)
             {
                 //Button.Glyph = Icons.Cancel;
                 Button.SetGlyph(file.Id, MessageContentState.Uploading);
@@ -164,7 +166,7 @@ namespace Telegram.Controls.Cells
 
                 Subtitle.Text = string.Format("{0} / {1}", FileSizeConverter.Convert(file.Remote.UploadedSize, size), FileSizeConverter.Convert(size));
             }
-            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingCompleted)
+            else if (state == MessageContentState.Download)
             {
                 //Button.Glyph = Icons.Download;
                 Button.SetGlyph(file.Id, MessageContentState.Download);
@@ -288,7 +290,9 @@ namespace Telegram.Controls.Cells
                 return;
             }
 
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(_message);
+
+            if (state == MessageContentState.Downloading)
             {
                 if (_viewModel != null)
                 {
@@ -299,7 +303,7 @@ namespace Telegram.Controls.Cells
                     _message.ClientService.Send(new ToggleDownloadIsPaused(file.Id, true));
                 }
             }
-            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingActive && !file.Local.IsDownloadingCompleted)
+            else if (state == MessageContentState.Download)
             {
                 if (_viewModel != null)
                 {

--- a/Telegram/Controls/Cells/SharedVoiceCell.xaml.cs
+++ b/Telegram/Controls/Cells/SharedVoiceCell.xaml.cs
@@ -304,15 +304,17 @@ namespace Telegram.Controls.Cells
                 return;
             }
 
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(_message);
+
+            if (state == MessageContentState.Downloading)
             {
                 _message.ClientService.CancelDownloadFile(file, false);
             }
-            else if (file.Remote.IsUploadingActive || _message.SendingState is MessageSendingStateFailed)
+            else if (state == MessageContentState.Uploading)
             {
                 _message.ClientService.Send(new DeleteMessages(_message.ChatId, new[] { _message.Id }, true));
             }
-            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingActive && !file.Local.IsDownloadingCompleted)
+            else if (state == MessageContentState.Download)
             {
                 if (_message.Content is MessageAudio)
                 {

--- a/Telegram/Controls/Gallery/GalleryContent.xaml.cs
+++ b/Telegram/Controls/Gallery/GalleryContent.xaml.cs
@@ -243,19 +243,21 @@ namespace Telegram.Controls.Gallery
             }
 
             var size = Math.Max(file.Size, file.ExpectedSize);
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(item.ClientService);
+
+            if (state == MessageContentState.Downloading)
             {
                 Button.SetGlyph(file.Id, MessageContentState.Downloading);
                 Button.Progress = (double)file.Local.DownloadedSize / size;
                 Button.Opacity = 1;
             }
-            else if (file.Remote.IsUploadingActive)
+            else if (state == MessageContentState.Uploading)
             {
                 Button.SetGlyph(file.Id, MessageContentState.Uploading);
                 Button.Progress = (double)file.Remote.UploadedSize / size;
                 Button.Opacity = 1;
             }
-            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingCompleted)
+            else if (state == MessageContentState.Download)
             {
                 Button.SetGlyph(file.Id, MessageContentState.Download);
                 Button.Progress = 0;
@@ -379,11 +381,13 @@ namespace Telegram.Controls.Gallery
                 return;
             }
 
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(item.ClientService);
+
+            if (state == MessageContentState.Downloading)
             {
                 item.ClientService.CancelDownloadFile(file, false);
             }
-            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingActive && !file.Local.IsDownloadingCompleted)
+            else if (state == MessageContentState.Download)
             {
                 if (AppSettings.IsStreamingEnabled && item.IsVideo && item.IsStreamable)
                 {

--- a/Telegram/Controls/Messages/Content/AnimationContent.xaml.cs
+++ b/Telegram/Controls/Messages/Content/AnimationContent.xaml.cs
@@ -109,18 +109,11 @@ namespace Telegram.Controls.Messages.Content
                 return;
             }
 
-            var canBeDownloaded = file.Local.CanBeDownloaded
-                && !file.Local.IsDownloadingCompleted
-                && !file.Local.IsDownloadingActive;
-
             var size = Math.Max(file.Size, file.ExpectedSize);
-            if (file.Local.IsDownloadingActive || (canBeDownloaded && message.Delegate.CanBeDownloaded(animation, file)))
-            {
-                if (canBeDownloaded)
-                {
-                    _message.ClientService.DownloadFile(file.Id, 32);
-                }
+            var state = file.GetFileState(message, animation);
 
+            if (state == MessageContentState.Downloading)
+            {
                 Button.SetGlyph(file.Id, MessageContentState.Downloading);
                 Button.Progress = (double)file.Local.DownloadedSize / size;
 
@@ -129,7 +122,7 @@ namespace Telegram.Controls.Messages.Content
 
                 Player.Source = null;
             }
-            else if (file.Remote.IsUploadingActive || message.SendingState is MessageSendingStateFailed || (message.SendingState is MessageSendingStatePending && !file.Remote.IsUploadingCompleted))
+            else if (state == MessageContentState.Uploading)
             {
                 Button.SetGlyph(file.Id, MessageContentState.Uploading);
                 Button.Progress = (double)file.Remote.UploadedSize / size;
@@ -139,7 +132,7 @@ namespace Telegram.Controls.Messages.Content
 
                 Player.Source = null;
             }
-            else if (canBeDownloaded)
+            else if (state == MessageContentState.Download)
             {
                 Button.SetGlyph(file.Id, MessageContentState.Download);
                 Button.Progress = 0;
@@ -320,11 +313,13 @@ namespace Telegram.Controls.Messages.Content
             }
 
             var file = animation.AnimationValue;
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(_message);
+
+            if (state == MessageContentState.Downloading)
             {
                 _message.ClientService.CancelDownloadFile(file);
             }
-            else if (file.Remote.IsUploadingActive || _message.SendingState is MessageSendingStateFailed)
+            else if (state == MessageContentState.Uploading)
             {
                 if (_message.SendingState is MessageSendingStateFailed or MessageSendingStatePending)
                 {
@@ -335,7 +330,7 @@ namespace Telegram.Controls.Messages.Content
                     _message.ClientService.Send(new CancelPreliminaryUploadFile(file.Id));
                 }
             }
-            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingActive && !file.Local.IsDownloadingCompleted)
+            else if (state == MessageContentState.Download)
             {
                 _message.ClientService.DownloadFile(file.Id, 30);
             }

--- a/Telegram/Controls/Messages/Content/AudioContent.xaml.cs
+++ b/Telegram/Controls/Messages/Content/AudioContent.xaml.cs
@@ -262,18 +262,11 @@ namespace Telegram.Controls.Messages.Content
                 return;
             }
 
-            var canBeDownloaded = file.Local.CanBeDownloaded
-                && !file.Local.IsDownloadingCompleted
-                && !file.Local.IsDownloadingActive;
-
             var size = Math.Max(file.Size, file.ExpectedSize);
-            if (file.Local.IsDownloadingActive || (canBeDownloaded && message.Delegate.CanBeDownloaded(audio, file)))
-            {
-                if (canBeDownloaded)
-                {
-                    _message.ClientService.DownloadFile(file.Id, 32);
-                }
+            var state = file.GetFileState(message, audio);
 
+            if (state == MessageContentState.Downloading)
+            {
                 FileButton target;
                 if (AppSettings.IsStreamingEnabled)
                 {
@@ -291,7 +284,7 @@ namespace Telegram.Controls.Messages.Content
 
                 Subtitle.Text = string.Format("{0} / {1}", FileSizeConverter.Convert(file.Local.DownloadedSize, size), FileSizeConverter.Convert(size));
             }
-            else if (file.Remote.IsUploadingActive || message.SendingState is MessageSendingStateFailed || (message.SendingState is MessageSendingStatePending && !file.Remote.IsUploadingCompleted))
+            else if (state == MessageContentState.Uploading)
             {
                 DownloadPanel.Visibility = Visibility.Collapsed;
 
@@ -300,7 +293,7 @@ namespace Telegram.Controls.Messages.Content
 
                 Subtitle.Text = string.Format("{0} / {1}", FileSizeConverter.Convert(file.Remote.UploadedSize, size), FileSizeConverter.Convert(size));
             }
-            else if (canBeDownloaded)
+            else if (state == MessageContentState.Download)
             {
                 FileButton target;
                 if (AppSettings.IsStreamingEnabled)
@@ -363,7 +356,7 @@ namespace Telegram.Controls.Messages.Content
                 Button.SetGlyph(file.Id, MessageContentState.Play);
                 Button.Progress = 1;
 
-                if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingCompleted && !file.Local.IsDownloadingActive && !file.Remote.IsUploadingActive)
+                if (file.GetFileState(message) == MessageContentState.Download)
                 {
                     Subtitle.Text = audio.GetDuration() + " - " + FileSizeConverter.Convert(Math.Max(file.Size, file.ExpectedSize));
                 }
@@ -548,11 +541,13 @@ namespace Telegram.Controls.Messages.Content
             }
 
             var file = audio.AudioValue;
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(_message);
+
+            if (state == MessageContentState.Downloading)
             {
                 _message.ClientService.CancelDownloadFile(file);
             }
-            else if (file.Remote.IsUploadingActive || _message.SendingState is MessageSendingStateFailed)
+            else if (state == MessageContentState.Uploading)
             {
                 if (_message.SendingState is MessageSendingStateFailed or MessageSendingStatePending)
                 {
@@ -563,7 +558,7 @@ namespace Telegram.Controls.Messages.Content
                     _message.ClientService.Send(new CancelPreliminaryUploadFile(file.Id));
                 }
             }
-            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingActive && !file.Local.IsDownloadingCompleted)
+            else if (state == MessageContentState.Download)
             {
                 if (_message.CanBeAddedToDownloads)
                 {

--- a/Telegram/Controls/Messages/Content/DocumentContent.xaml.cs
+++ b/Telegram/Controls/Messages/Content/DocumentContent.xaml.cs
@@ -130,31 +130,24 @@ namespace Telegram.Controls.Messages.Content
                 return;
             }
 
-            var canBeDownloaded = file.Local.CanBeDownloaded
-                && !file.Local.IsDownloadingCompleted
-                && !file.Local.IsDownloadingActive;
-
             var size = Math.Max(file.Size, file.ExpectedSize);
-            if (file.Local.IsDownloadingActive || (canBeDownloaded && message.Delegate.CanBeDownloaded(document, file)))
-            {
-                if (canBeDownloaded)
-                {
-                    _message.ClientService.DownloadFile(file.Id, 32);
-                }
+            var state = file.GetFileState(message, document);
 
+            if (state == MessageContentState.Downloading)
+            {
                 Button.SetGlyph(file.Id, MessageContentState.Downloading);
                 Button.Progress = (double)file.Local.DownloadedSize / size;
 
                 Subtitle.Text = string.Format("{0} / {1}", FileSizeConverter.Convert(file.Local.DownloadedSize, size), FileSizeConverter.Convert(size));
             }
-            else if (file.Remote.IsUploadingActive || message.SendingState is MessageSendingStateFailed || (message.SendingState is MessageSendingStatePending && !file.Remote.IsUploadingCompleted))
+            else if (state == MessageContentState.Uploading)
             {
                 Button.SetGlyph(file.Id, MessageContentState.Uploading);
                 Button.Progress = (double)file.Remote.UploadedSize / size;
 
                 Subtitle.Text = string.Format("{0} / {1}", FileSizeConverter.Convert(file.Remote.UploadedSize, size), FileSizeConverter.Convert(size));
             }
-            else if (canBeDownloaded)
+            else if (state == MessageContentState.Download)
             {
                 Button.SetGlyph(file.Id, MessageContentState.Download);
                 Button.Progress = 0;
@@ -286,11 +279,13 @@ namespace Telegram.Controls.Messages.Content
             }
 
             var file = document.DocumentValue;
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(_message);
+
+            if (state == MessageContentState.Downloading)
             {
                 _message.ClientService.CancelDownloadFile(file);
             }
-            else if (file.Remote.IsUploadingActive || _message.SendingState is MessageSendingStateFailed)
+            else if (state == MessageContentState.Uploading)
             {
                 if (_message.SendingState is MessageSendingStateFailed or MessageSendingStatePending)
                 {
@@ -301,7 +296,7 @@ namespace Telegram.Controls.Messages.Content
                     _message.ClientService.Send(new CancelPreliminaryUploadFile(file.Id));
                 }
             }
-            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingActive && !file.Local.IsDownloadingCompleted)
+            else if (state == MessageContentState.Download)
             {
                 if (_message.CanBeAddedToDownloads)
                 {

--- a/Telegram/Controls/Messages/Content/PhotoContent.xaml.cs
+++ b/Telegram/Controls/Messages/Content/PhotoContent.xaml.cs
@@ -212,18 +212,11 @@ namespace Telegram.Controls.Messages.Content
                 Overlay.Opacity = 0;
             }
 
-            var canBeDownloaded = file.Local.CanBeDownloaded
-                && !file.Local.IsDownloadingCompleted
-                && !file.Local.IsDownloadingActive;
-
             var size = Math.Max(file.Size, file.ExpectedSize);
-            if (file.Local.IsDownloadingActive || (canBeDownloaded && message.Delegate.CanBeDownloaded(photo, file)))
-            {
-                if (canBeDownloaded)
-                {
-                    _message.ClientService.DownloadFile(file.Id, 32);
-                }
+            var state = file.GetFileState(message, photo);
 
+            if (state == MessageContentState.Downloading)
+            {
                 Button.SetGlyph(file.Id, MessageContentState.Downloading);
                 Button.Progress = (double)file.Local.DownloadedSize / size;
 
@@ -231,7 +224,7 @@ namespace Telegram.Controls.Messages.Content
 
                 UpdateTexture(message, null, null);
             }
-            else if (file.Remote.IsUploadingActive || message.SendingState is MessageSendingStateFailed || (message.SendingState is MessageSendingStatePending && !file.Remote.IsUploadingCompleted))
+            else if (state == MessageContentState.Uploading)
             {
                 Button.SetGlyph(file.Id, MessageContentState.Uploading);
                 Button.Progress = (double)file.Remote.UploadedSize / size;
@@ -247,7 +240,7 @@ namespace Telegram.Controls.Messages.Content
                     UpdateTexture(message, big, video);
                 }
             }
-            else if (canBeDownloaded)
+            else if (state == MessageContentState.Download)
             {
                 Button.SetGlyph(file.Id, MessageContentState.Download);
                 Button.Progress = 0;
@@ -517,11 +510,13 @@ namespace Telegram.Controls.Messages.Content
             }
 
             var file = big.Photo;
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(_message);
+
+            if (state == MessageContentState.Downloading)
             {
                 _message.ClientService.CancelDownloadFile(file);
             }
-            else if (file.Remote.IsUploadingActive || _message.SendingState is MessageSendingStateFailed)
+            else if (state == MessageContentState.Uploading)
             {
                 if (_message.SendingState is MessageSendingStateFailed or MessageSendingStatePending)
                 {
@@ -532,7 +527,7 @@ namespace Telegram.Controls.Messages.Content
                     _message.ClientService.Send(new CancelPreliminaryUploadFile(file.Id));
                 }
             }
-            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingActive && !file.Local.IsDownloadingCompleted)
+            else if (state == MessageContentState.Download)
             {
                 _message.ClientService.DownloadFile(file.Id, 30);
             }

--- a/Telegram/Controls/Messages/Content/VideoContent.xaml.cs
+++ b/Telegram/Controls/Messages/Content/VideoContent.xaml.cs
@@ -188,24 +188,17 @@ namespace Telegram.Controls.Messages.Content
             {
                 Overlay.ProgressVisibility = Visibility.Collapsed;
 
-                var canBeDownloaded = file.Local.CanBeDownloaded
-                    && !file.Local.IsDownloadingCompleted
-                    && !file.Local.IsDownloadingActive;
-
                 var size = Math.Max(file.Size, file.ExpectedSize);
-                if (file.Local.IsDownloadingActive || (canBeDownloaded && message.Delegate.CanBeDownloaded(video, file)))
-                {
-                    if (canBeDownloaded)
-                    {
-                        _message.ClientService.DownloadFile(file.Id, 32);
-                    }
+                var state = file.GetFileState(message, video);
 
+                if (state == MessageContentState.Downloading)
+                {
                     Button.SetGlyph(file.Id, MessageContentState.Downloading);
                     Button.Progress = (double)file.Local.DownloadedSize / size;
 
                     Subtitle.Text = string.Format("{0} / {1}", FileSizeConverter.Convert(file.Local.DownloadedSize, size), FileSizeConverter.Convert(size));
                 }
-                else if (file.Remote.IsUploadingActive || message.SendingState is MessageSendingStateFailed || (message.SendingState is MessageSendingStatePending && !file.Remote.IsUploadingCompleted))
+                else if (state == MessageContentState.Uploading)
                 {
                     var generating = file.Local.DownloadedSize < size;
 
@@ -221,7 +214,7 @@ namespace Telegram.Controls.Messages.Content
                         Subtitle.Text = string.Format("{0} / {1}", FileSizeConverter.Convert(file.Remote.UploadedSize, size), FileSizeConverter.Convert(size));
                     }
                 }
-                else if (canBeDownloaded)
+                else if (state == MessageContentState.Download)
                 {
                     Button.SetGlyph(file.Id, MessageContentState.Download);
                     Button.Progress = 0;
@@ -278,7 +271,9 @@ namespace Telegram.Controls.Messages.Content
             else
             {
                 var size = Math.Max(file.Size, file.ExpectedSize);
-                if (file.Local.IsDownloadingActive)
+                var state = file.GetFileState(message);
+
+                if (state == MessageContentState.Downloading)
                 {
                     if (video.SupportsStreaming && !hasSpoiler && message.Delegate.CanBeDownloaded(video, file))
                     {
@@ -300,7 +295,7 @@ namespace Telegram.Controls.Messages.Content
                         Subtitle.Text = GetDuration(video) + string.Format("{0} / {1}", FileSizeConverter.Convert(file.Local.DownloadedSize, size), FileSizeConverter.Convert(size));
                     }
                 }
-                else if (file.Remote.IsUploadingActive || message.SendingState is MessageSendingStateFailed || (message.SendingState is MessageSendingStatePending && !file.Remote.IsUploadingCompleted))
+                else if (state == MessageContentState.Uploading)
                 {
                     var generating = file.Local.DownloadedSize < size;
 
@@ -319,7 +314,7 @@ namespace Telegram.Controls.Messages.Content
                         Subtitle.Text = GetDuration(video) + string.Format("{0} / {1}", FileSizeConverter.Convert(file.Remote.UploadedSize, size), FileSizeConverter.Convert(size));
                     }
                 }
-                else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingCompleted)
+                else if (state == MessageContentState.Download)
                 {
                     Button.SetGlyph(file.Id, MessageContentState.Play);
                     Button.Progress = 0;
@@ -620,11 +615,13 @@ namespace Telegram.Controls.Messages.Content
             }
 
             var file = video.VideoValue;
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(_message);
+
+            if (state == MessageContentState.Downloading)
             {
                 _message.ClientService.CancelDownloadFile(file);
             }
-            else if (file.Remote.IsUploadingActive || _message.SendingState is MessageSendingStateFailed)
+            else if (state == MessageContentState.Uploading)
             {
                 if (_message.SendingState is MessageSendingStateFailed or MessageSendingStatePending)
                 {
@@ -635,7 +632,7 @@ namespace Telegram.Controls.Messages.Content
                     _message.ClientService.Send(new CancelPreliminaryUploadFile(file.Id));
                 }
             }
-            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingActive && !file.Local.IsDownloadingCompleted)
+            else if (state == MessageContentState.Download)
             {
                 if (_message.CanBeAddedToDownloads)
                 {
@@ -681,11 +678,13 @@ namespace Telegram.Controls.Messages.Content
             if (isSecret || !video.SupportsStreaming)
             {
                 var file = video.VideoValue;
-                if (file.Local.IsDownloadingActive)
+                var state = file.GetFileState(_message);
+
+                if (state == MessageContentState.Downloading)
                 {
                     _message.ClientService.CancelDownloadFile(file);
                 }
-                else if (file.Remote.IsUploadingActive || _message.SendingState is MessageSendingStateFailed)
+                else if (state == MessageContentState.Uploading)
                 {
                     if (_message.SendingState is MessageSendingStateFailed or MessageSendingStatePending)
                     {
@@ -696,7 +695,7 @@ namespace Telegram.Controls.Messages.Content
                         _message.ClientService.Send(new CancelPreliminaryUploadFile(file.Id));
                     }
                 }
-                else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingActive && !file.Local.IsDownloadingCompleted)
+                else if (state == MessageContentState.Download)
                 {
                     if (_message.CanBeAddedToDownloads)
                     {

--- a/Telegram/Controls/Messages/Content/VideoNoteContent.xaml.cs
+++ b/Telegram/Controls/Messages/Content/VideoNoteContent.xaml.cs
@@ -283,25 +283,18 @@ namespace Telegram.Controls.Messages.Content
             }
             else
             {
-                var canBeDownloaded = file.Local.CanBeDownloaded
-                    && !file.Local.IsDownloadingCompleted
-                    && !file.Local.IsDownloadingActive;
-
                 var size = Math.Max(file.Size, file.ExpectedSize);
-                if (file.Local.IsDownloadingActive || (canBeDownloaded && message.Delegate.CanBeDownloaded(videoNote, file)))
-                {
-                    if (canBeDownloaded)
-                    {
-                        _message.ClientService.DownloadFile(file.Id, 32);
-                    }
+                var state = file.GetFileState(message, videoNote);
 
+                if (state == MessageContentState.Downloading)
+                {
                     //Button.Glyph = Icons.Cancel;
                     Button.SetGlyph(file.Id, MessageContentState.Downloading);
                     Button.Progress = (double)file.Local.DownloadedSize / size;
 
                     Player.Source = null;
                 }
-                else if (file.Remote.IsUploadingActive || message.SendingState is MessageSendingStateFailed || (message.SendingState is MessageSendingStatePending && !file.Remote.IsUploadingCompleted))
+                else if (state == MessageContentState.Uploading)
                 {
                     //Button.Glyph = Icons.Cancel;
                     Button.SetGlyph(file.Id, MessageContentState.Uploading);
@@ -309,7 +302,7 @@ namespace Telegram.Controls.Messages.Content
 
                     Player.Source = null;
                 }
-                else if (canBeDownloaded)
+                else if (state == MessageContentState.Download)
                 {
                     //Button.Glyph = Icons.Download;
                     Button.SetGlyph(file.Id, MessageContentState.Download);
@@ -475,11 +468,13 @@ namespace Telegram.Controls.Messages.Content
             }
 
             var file = videoNote.Video;
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(_message);
+
+            if (state == MessageContentState.Downloading)
             {
                 _message.ClientService.CancelDownloadFile(file);
             }
-            else if (file.Remote.IsUploadingActive || _message.SendingState is MessageSendingStateFailed)
+            else if (state == MessageContentState.Uploading)
             {
                 if (_message.SendingState is MessageSendingStateFailed or MessageSendingStatePending)
                 {
@@ -502,7 +497,7 @@ namespace Telegram.Controls.Messages.Content
                 }
             }
             // This branch could be likely removed with some tuning
-            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingActive && !file.Local.IsDownloadingCompleted)
+            else if (state == MessageContentState.Download)
             {
                 _message.ClientService.DownloadFile(file.Id, 30);
             }

--- a/Telegram/Controls/Messages/Content/VoiceNoteContent.xaml.cs
+++ b/Telegram/Controls/Messages/Content/VoiceNoteContent.xaml.cs
@@ -416,31 +416,24 @@ namespace Telegram.Controls.Messages.Content
             }
             else
             {
-                var canBeDownloaded = file.Local.CanBeDownloaded
-                    && !file.Local.IsDownloadingCompleted
-                    && !file.Local.IsDownloadingActive;
-
                 var size = Math.Max(file.Size, file.ExpectedSize);
-                if (file.Local.IsDownloadingActive || (canBeDownloaded && message.Delegate.CanBeDownloaded(voiceNote, file)))
-                {
-                    if (canBeDownloaded)
-                    {
-                        _message.ClientService.DownloadFile(file.Id, 32);
-                    }
+                var state = file.GetFileState(message, voiceNote);
 
+                if (state == MessageContentState.Downloading)
+                {
                     Button.SetGlyph(file.Id, MessageContentState.Downloading);
                     Button.Progress = (double)file.Local.DownloadedSize / size;
 
                     UpdateDuration();
                 }
-                else if (file.Remote.IsUploadingActive || message.SendingState is MessageSendingStateFailed || (message.SendingState is MessageSendingStatePending && !file.Remote.IsUploadingCompleted))
+                else if (state == MessageContentState.Uploading)
                 {
                     Button.SetGlyph(file.Id, MessageContentState.Uploading);
                     Button.Progress = (double)file.Remote.UploadedSize / size;
 
                     UpdateDuration();
                 }
-                else if (canBeDownloaded)
+                else if (state == MessageContentState.Download)
                 {
                     Button.SetGlyph(file.Id, MessageContentState.Download);
                     Button.Progress = 0;
@@ -518,11 +511,13 @@ namespace Telegram.Controls.Messages.Content
             }
 
             var file = voiceNote.Voice;
-            if (file.Local.IsDownloadingActive)
+            var state = file.GetFileState(_message);
+
+            if (state == MessageContentState.Downloading)
             {
                 _message.ClientService.CancelDownloadFile(file);
             }
-            else if (file.Remote.IsUploadingActive || _message.SendingState is MessageSendingStateFailed)
+            else if (state == MessageContentState.Uploading)
             {
                 if (_message.SendingState is MessageSendingStateFailed or MessageSendingStatePending)
                 {

--- a/Telegram/Services/ClientService.Files.cs
+++ b/Telegram/Services/ClientService.Files.cs
@@ -137,6 +137,7 @@ namespace Telegram.Services
         private readonly HashSet<int> _canceledDownloads = new();
         private readonly HashSet<string> _completedDownloads = new();
         private readonly HashSet<int> _explicitDownloads = new();
+        private readonly Dictionary<int, int> _streamingFiles = new();
         private readonly object _downloadsLock = new();
 
         /// <summary>
@@ -151,6 +152,7 @@ namespace Telegram.Services
                 _canceledDownloads.Clear();
                 _completedDownloads.Clear();
                 _explicitDownloads.Clear();
+                _streamingFiles.Clear();
             }
         }
 
@@ -405,6 +407,49 @@ namespace Telegram.Services
             lock (_downloadsLock)
             {
                 return _canceledDownloads.Contains(fileId);
+            }
+        }
+
+        /// <summary>
+        /// Whether the file is only downloading to feed a reader that is playing it.
+        ///
+        /// Such a reader asks for the window it is about to need and moves it forwards as
+        /// it plays, so TDLib reports the download as active again every time the window
+        /// moves, and inactive every time one is satisfied. Nothing asked for the file
+        /// itself, so the download buttons must not follow that: they would flicker
+        /// between download and cancel for as long as the media plays.
+        /// </summary>
+        public bool IsDownloadFileImplicit(int fileId)
+        {
+            lock (_downloadsLock)
+            {
+                return _streamingFiles.ContainsKey(fileId) && !_explicitDownloads.Contains(fileId);
+            }
+        }
+
+        /// <param name="streaming">
+        /// Whether a reader started or finished playing the file. Counted rather than set,
+        /// as the same file can be read by more than one at a time: a video playing in the
+        /// gallery over the one autoplaying in the bubble behind it.
+        /// </param>
+        public void TrackStreamingFile(int fileId, bool streaming)
+        {
+            lock (_downloadsLock)
+            {
+                _streamingFiles.TryGetValue(fileId, out int count);
+
+                if (streaming)
+                {
+                    _streamingFiles[fileId] = count + 1;
+                }
+                else if (count > 1)
+                {
+                    _streamingFiles[fileId] = count - 1;
+                }
+                else
+                {
+                    _streamingFiles.Remove(fileId);
+                }
             }
         }
 

--- a/Telegram/Services/ClientService.cs
+++ b/Telegram/Services/ClientService.cs
@@ -50,6 +50,8 @@ namespace Telegram.Services
         void AddFileToDownloads(File file, long chatId, long messageId, int priority = 30);
         void CancelDownloadFile(File file, bool onlyIfPending = false, bool onlyIfStreaming = false);
         bool IsDownloadFileCanceled(int fileId);
+        bool IsDownloadFileImplicit(int fileId);
+        void TrackStreamingFile(int fileId, bool streaming);
 
         void PrepareLogs(int fileId, int verbosityLevel);
 

--- a/Telegram/Streams/RemoteFileSource.cs
+++ b/Telegram/Streams/RemoteFileSource.cs
@@ -37,6 +37,7 @@ namespace Telegram.Streams
         private long _count;
 
         private bool _closed;
+        private bool _tracked;
 
         private long _fileToken;
 
@@ -69,6 +70,8 @@ namespace Telegram.Streams
 
             Format = new StickerFormatWebm();
             UpdateManager.Subscribe(this, clientService, file, ref _fileToken, UpdateFile);
+
+            TrackStreaming(true);
         }
 
         public RemoteFileSource(IClientService clientService, File file/*, int priority = 32*/)
@@ -82,6 +85,8 @@ namespace Telegram.Streams
 
             Format = new StickerFormatWebm();
             UpdateManager.Subscribe(this, clientService, file, ref _fileToken, UpdateFile);
+
+            TrackStreaming(true);
         }
 
         public override void SeekCallback(long offset)
@@ -327,11 +332,30 @@ namespace Telegram.Streams
             }
         }
 
+        /// <summary>
+        /// Marks the file as one that is only being read, rather than downloaded in its
+        /// own right. The download buttons hide a download that exists for a reader alone,
+        /// which would otherwise flicker as the window this source asks for moves along.
+        /// </summary>
+        private void TrackStreaming(bool streaming)
+        {
+            if (_tracked == streaming)
+            {
+                return;
+            }
+
+            _tracked = streaming;
+            _clientService.TrackStreamingFile(_file.Id, streaming);
+        }
+
         public void Open()
         {
             lock (_stateLock)
             {
                 _closed = false;
+
+                // The player opens the media again to replay it, having closed it at the end.
+                TrackStreaming(true);
             }
 
             SeekCallback(0);
@@ -347,6 +371,8 @@ namespace Telegram.Streams
                 }
 
                 _closed = true;
+
+                TrackStreaming(false);
 
                 //Logger.Debug($"Disposing the stream");
                 UpdateManager.Unsubscribe(this, ref _fileToken);

--- a/Telegram/Td/Api/TdExtensions.cs
+++ b/Telegram/Td/Api/TdExtensions.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Numerics;
 using System.Text;
 using Telegram.Common;
+using Telegram.Controls;
 using Telegram.Controls.Chats;
 using Telegram.Converters;
 using Telegram.Native;
@@ -1695,6 +1696,61 @@ namespace Telegram.Td.Api
                 default:
                     return null;
             }
+        }
+
+        /// <summary>
+        /// What the button on a file has to show while the file is being transferred, or
+        /// <see cref="MessageContentState.None"/> when it isn't: the caller then shows
+        /// whatever its own content is, a play button, a document glyph, a photo.
+        /// </summary>
+        public static MessageContentState GetFileState(this File file, IClientService clientService)
+        {
+            return GetFileState(file, clientService, null, null);
+        }
+
+        /// <param name="content">
+        /// The content the file belongs to, passed by callers that want auto-download
+        /// applied to it: the file is then downloaded here if the settings allow it, and
+        /// reported as downloading right away rather than one update later.
+        /// </param>
+        public static MessageContentState GetFileState(this File file, MessageWithOwner message, object content = null)
+        {
+            return GetFileState(file, message.ClientService, message, content);
+        }
+
+        private static MessageContentState GetFileState(File file, IClientService clientService, MessageWithOwner message, object content)
+        {
+            // A download that exists only to feed a reader is not one of these buttons'
+            // business, and following it would make them flicker for as long as the media
+            // plays: see IClientService.IsDownloadFileImplicit.
+            if (file.Local.IsDownloadingActive && !clientService.IsDownloadFileImplicit(file.Id))
+            {
+                return MessageContentState.Downloading;
+            }
+            else if (file.Remote.IsUploadingActive
+                || message?.SendingState is MessageSendingStateFailed
+                || (message?.SendingState is MessageSendingStatePending && !file.Remote.IsUploadingCompleted))
+            {
+                return MessageContentState.Uploading;
+            }
+            else if (file.Local.CanBeDownloaded && !file.Local.IsDownloadingCompleted)
+            {
+                // Asked of the file rather than of the state above: a file that is being
+                // read is downloading as far as TDLib is concerned, and asking for it
+                // again on every update it sends would be pointless.
+                if (content != null
+                    && !file.Local.IsDownloadingActive
+                    && message is MessageViewModel viewModel
+                    && viewModel.Delegate.CanBeDownloaded(content, file))
+                {
+                    clientService.DownloadFile(file.Id, 32);
+                    return MessageContentState.Downloading;
+                }
+
+                return MessageContentState.Download;
+            }
+
+            return MessageContentState.None;
         }
 
         public static (File File, Thumbnail Thumbnail, string FileName) GetFileAndThumbnailAndName(this MessageWithOwner message)


### PR DESCRIPTION
Streamed media re-sends `downloadFile(offset, limit)` on every read, so TDLib reports the download as active again each time the window moves and inactive each time one is satisfied. Every file button derived its glyph from that flag, so they flickered between download and cancel for as long as the media played — worst on audio, where the play button became a cancel button for the whole track.

A download that exists only to feed a reader is now hidden from those buttons. `RemoteFileSource` counts the files it is reading, and `IClientService.IsDownloadFileImplicit` is true while a file is read by one and nothing asked for the file itself. Counting the readers rather than remembering which downloads were explicit avoids a startup gap: a download the manager resumes after a restart is not known to be explicit, and would have shown no progress at all.

Playing a track or a video now shows a steady download button, and clicking it starts a real download. Auto-download and user downloads keep their ring, unchanged.

The four-branch chain that picks the glyph was identical in all twelve controls, so it moved into one method — `file.GetFileState(...)` in `TdExtensions`, returning `Downloading | Uploading | Download | None` — and each control, along with the click handler that chose cancel-vs-start on the same flag, is now a switch over it. Each `None` branch keeps its own content glyph, progress and subtitle.

One behaviour change beyond the flicker: the click handlers now agree with the glyph. A pending message showing a cancel-upload glyph used to *play* on click in several controls, because the display branch included `MessageSendingStatePending` and the click branch did not. Those lists don't hold pending messages, so it is inert in practice.

Left open, deliberately:

- `VideoContent` still starts its own full download beside `UpdateSource`, since that call is conditional on `SupportsStreaming` — non-streamable videos have to keep going to the preloader. While a file is both explicitly downloaded and streamed, the reader keeps overwriting the node's download limit, so `is_downloading_active` still flaps; the fix there is `limit: 0` in `RemoteFileSource.Download` while the file is explicit.
- Inline video previews never `Close()` their source, so one entry per previewed file is never released. Explicit downloads override the gate, so there is no behavioural effect.

Not built or run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
