### PR TITLE
Read the animated frame from the presenter, not from ImageBrush.ImageSource

### DIFF
--- a/Telegram/Controls/AnimatedImage.cs
+++ b/Telegram/Controls/AnimatedImage.cs
@@ -76,6 +76,16 @@ namespace Telegram.Controls
 
         protected bool _clean = false;
 
+        // The frame the presenter last handed over, and its rotation. Deliberately cached
+        // rather than read back off the brush: ImageBrush.ImageSource resolves the bitmap's
+        // framework peer, and nothing managed roots that peer - PixelBuffer holds the
+        // WriteableBitmap as a plain COM reference from C++, which keeps it alive but not
+        // reachable, so the reference tracker collects it and the getter then fails with
+        // E_FAIL. The brush outlives the presenter whenever CleanOnSourceChanged is false,
+        // so there is no root that lives long enough to fix it the other way round.
+        private PixelBuffer _frame;
+        private double _frameRotation;
+
         public AnimatedImage()
         {
             DefaultStyleKey = typeof(AnimatedImage);
@@ -88,7 +98,10 @@ namespace Telegram.Controls
                 Load();
             }
 
-            UpdateRotation(LayoutRoot.Background as ImageBrush);
+            if (_frameRotation != 0)
+            {
+                UpdateRotation(LayoutRoot.Background as ImageBrush);
+            }
         }
 
         public event EventHandler Ready;
@@ -583,12 +596,15 @@ namespace Telegram.Controls
             _state = PlayingState.Paused;
         }
 
-        public virtual void Invalidate(ImageBrush source)
+        public virtual void Invalidate(ImageBrush source, PixelBuffer frame)
         {
             if (IsDisconnected)
             {
                 return;
             }
+
+            _frame = frame;
+            _frameRotation = source?.Transform is CompositeTransform composite ? composite.Rotation : 0;
 
             if (source != null || CleanOnSourceChanged)
             {
@@ -601,7 +617,7 @@ namespace Telegram.Controls
 
                 if (DominantColor is SolidColorBrush dominantColor)
                 {
-                    dominantColor.Color = GetDominantColor(source.ImageSource as WriteableBitmap);
+                    dominantColor.Color = GetDominantColor(frame?.Source);
                 }
 
                 if (UpdateRotation(source))
@@ -668,36 +684,36 @@ namespace Telegram.Controls
 
         private bool UpdateRotation(ImageBrush source)
         {
-            if (source?.ImageSource is WriteableBitmap bitmap && source?.Transform is CompositeTransform composite)
+            if (_frame == null || source?.Transform is not CompositeTransform composite)
             {
-                double pixelWidth;
-                double pixelHeight;
-
-                if (composite.Rotation is 90 or 270)
-                {
-                    pixelWidth = bitmap.PixelHeight;
-                    pixelHeight = bitmap.PixelWidth;
-                }
-                else
-                {
-                    pixelWidth = bitmap.PixelWidth;
-                    pixelHeight = bitmap.PixelHeight;
-                }
-
-                var scaleX = ActualWidth / pixelWidth;
-                var scaleY = ActualHeight / pixelHeight;
-                var scale = Math.Max(scaleX, scaleY);
-
-                composite.ScaleX = scale;
-                composite.ScaleY = scale;
-
-                composite.CenterX = ActualWidth / 2;
-                composite.CenterY = ActualHeight / 2;
-
-                return true;
+                return false;
             }
 
-            return false;
+            double pixelWidth;
+            double pixelHeight;
+
+            if (_frameRotation is 90 or 270)
+            {
+                pixelWidth = _frame.PixelHeight;
+                pixelHeight = _frame.PixelWidth;
+            }
+            else
+            {
+                pixelWidth = _frame.PixelWidth;
+                pixelHeight = _frame.PixelHeight;
+            }
+
+            var scaleX = ActualWidth / pixelWidth;
+            var scaleY = ActualHeight / pixelHeight;
+            var scale = Math.Max(scaleX, scaleY);
+
+            composite.ScaleX = scale;
+            composite.ScaleY = scale;
+
+            composite.CenterX = ActualWidth / 2;
+            composite.CenterY = ActualHeight / 2;
+
+            return true;
         }
 
         public bool CleanOnSourceChanged { get; set; } = true;
@@ -976,7 +992,7 @@ namespace Telegram.Controls
 
             if (_dirty)
             {
-                canvas.Invalidate(_imageBrush);
+                canvas.Invalidate(_imageBrush, _foregroundPrev);
             }
         }
 
@@ -985,7 +1001,7 @@ namespace Telegram.Controls
             _images.Remove(canvas);
             UnloadImpl(playing);
 
-            canvas.Invalidate(null);
+            canvas.Invalidate(null, null);
         }
 
         private void LoadImpl()
@@ -1065,7 +1081,7 @@ namespace Telegram.Controls
 
             if (_dirty)
             {
-                canvas.Invalidate(_imageBrush);
+                canvas.Invalidate(_imageBrush, _foregroundPrev);
             }
         }
 
@@ -1526,7 +1542,7 @@ namespace Telegram.Controls
                 {
                     foreach (var image in _images)
                     {
-                        image.Invalidate(_imageBrush);
+                        image.Invalidate(_imageBrush, next);
                     }
                 }
 

--- a/Telegram/Controls/AnimatedImage.cs
+++ b/Telegram/Controls/AnimatedImage.cs
@@ -76,15 +76,17 @@ namespace Telegram.Controls
 
         protected bool _clean = false;
 
-        // The frame the presenter last handed over, and its rotation. Deliberately cached
-        // rather than read back off the brush: ImageBrush.ImageSource resolves the bitmap's
-        // framework peer, and nothing managed roots that peer - PixelBuffer holds the
-        // WriteableBitmap as a plain COM reference from C++, which keeps it alive but not
-        // reachable, so the reference tracker collects it and the getter then fails with
-        // E_FAIL. The brush outlives the presenter whenever CleanOnSourceChanged is false,
-        // so there is no root that lives long enough to fix it the other way round.
-        private PixelBuffer _frame;
-        private double _frameRotation;
+        // The geometry of the frames the presenter is rendering, handed over rather than read
+        // back off the brush: ImageBrush.ImageSource resolves the bitmap's framework peer, and
+        // nothing managed roots that peer - PixelBuffer holds the WriteableBitmap as a plain COM
+        // reference from C++, which keeps it alive but not reachable, so the reference tracker
+        // collects it and the getter then fails with E_FAIL. The brush outlives the presenter
+        // whenever CleanOnSourceChanged is false, so there is no root that lives long enough to
+        // fix it the other way round. Numbers rather than the buffer: they are fixed for the
+        // presentation, and the buffers are recycled between threads.
+        private int _frameWidth;
+        private int _frameHeight;
+        private int _frameRotation;
 
         public AnimatedImage()
         {
@@ -596,15 +598,16 @@ namespace Telegram.Controls
             _state = PlayingState.Paused;
         }
 
-        public virtual void Invalidate(ImageBrush source, PixelBuffer frame)
+        public virtual void Invalidate(ImageBrush source, WriteableBitmap bitmap, int pixelWidth, int pixelHeight, int rotation)
         {
             if (IsDisconnected)
             {
                 return;
             }
 
-            _frame = frame;
-            _frameRotation = source?.Transform is CompositeTransform composite ? composite.Rotation : 0;
+            _frameWidth = pixelWidth;
+            _frameHeight = pixelHeight;
+            _frameRotation = rotation;
 
             if (source != null || CleanOnSourceChanged)
             {
@@ -617,7 +620,7 @@ namespace Telegram.Controls
 
                 if (DominantColor is SolidColorBrush dominantColor)
                 {
-                    dominantColor.Color = GetDominantColor(frame?.Source);
+                    dominantColor.Color = GetDominantColor(bitmap);
                 }
 
                 if (UpdateRotation(source))
@@ -684,7 +687,7 @@ namespace Telegram.Controls
 
         private bool UpdateRotation(ImageBrush source)
         {
-            if (_frame == null || source?.Transform is not CompositeTransform composite)
+            if (_frameWidth == 0 || _frameHeight == 0 || source?.Transform is not CompositeTransform composite)
             {
                 return false;
             }
@@ -694,13 +697,13 @@ namespace Telegram.Controls
 
             if (_frameRotation is 90 or 270)
             {
-                pixelWidth = _frame.PixelHeight;
-                pixelHeight = _frame.PixelWidth;
+                pixelWidth = _frameHeight;
+                pixelHeight = _frameWidth;
             }
             else
             {
-                pixelWidth = _frame.PixelWidth;
-                pixelHeight = _frame.PixelHeight;
+                pixelWidth = _frameWidth;
+                pixelHeight = _frameHeight;
             }
 
             var scaleX = ActualWidth / pixelWidth;
@@ -990,9 +993,14 @@ namespace Telegram.Controls
             _images.Add(canvas);
             LoadImpl();
 
-            if (_dirty)
+            // The buffer is read only to sample the dominant colour from it, never held: it is
+            // recycled between this thread and the worker queue, which is why Dispose swaps it.
+            var task = Volatile.Read(ref _task);
+            var frame = Volatile.Read(ref _foregroundPrev);
+
+            if (_dirty && task != null)
             {
-                canvas.Invalidate(_imageBrush, _foregroundPrev);
+                canvas.Invalidate(_imageBrush, frame?.Source, task.PixelWidth, task.PixelHeight, task.Rotation);
             }
         }
 
@@ -1001,7 +1009,7 @@ namespace Telegram.Controls
             _images.Remove(canvas);
             UnloadImpl(playing);
 
-            canvas.Invalidate(null, null);
+            canvas.Invalidate(null, null, 0, 0, 0);
         }
 
         private void LoadImpl()
@@ -1079,9 +1087,14 @@ namespace Telegram.Controls
         {
             PlayImpl();
 
-            if (_dirty)
+            // The buffer is read only to sample the dominant colour from it, never held: it is
+            // recycled between this thread and the worker queue, which is why Dispose swaps it.
+            var task = Volatile.Read(ref _task);
+            var frame = Volatile.Read(ref _foregroundPrev);
+
+            if (_dirty && task != null)
             {
-                canvas.Invalidate(_imageBrush, _foregroundPrev);
+                canvas.Invalidate(_imageBrush, frame?.Source, task.PixelWidth, task.PixelHeight, task.Rotation);
             }
         }
 
@@ -1517,6 +1530,10 @@ namespace Telegram.Controls
 
                 next.Source.Invalidate();
 
+                // Dispose clears _task from the worker queue after this frame was taken, so the
+                // read can come back null; a missing task only means no rotation to apply.
+                var task = Volatile.Read(ref _task);
+
                 if (_imageBrush == null)
                 {
                     _imageBrush = new ImageBrush
@@ -1526,8 +1543,7 @@ namespace Telegram.Controls
                         AlignmentY = AlignmentY.Center,
                     };
 
-                    var task = Volatile.Read(ref _task);
-                    if (task.Rotation != 0)
+                    if (task is { Rotation: not 0 })
                     {
                         _imageBrush.Transform = new CompositeTransform
                         {
@@ -1542,7 +1558,7 @@ namespace Telegram.Controls
                 {
                     foreach (var image in _images)
                     {
-                        image.Invalidate(_imageBrush, next);
+                        image.Invalidate(_imageBrush, next.Source, task?.PixelWidth ?? 0, task?.PixelHeight ?? 0, task?.Rotation ?? 0);
                     }
                 }
 


### PR DESCRIPTION
Reported by crash telemetry on 12.10.0.0.

```
COMException: Unspecified error (0x80004005)

   7  WinRT_Runtime_WinRT_ExceptionHelpers___ThrowExceptionForHR_g__Throw_41_0+0x42
      src\WinRT.Runtime\ExceptionHelpers.cs:121
   8  Microsoft_Windows_UI_Xaml_ABI_Windows_UI_Xaml_Media_IImageBrushMethods__get_ImageSource+0x7d
   9  Telegram_Telegram_Controls_AnimatedImage__UpdateRotation+0x29
      Telegram\Controls\AnimatedImage.cs:671
  10  Telegram_Telegram_Controls_AnimatedImage__Invalidate+0xd9
      Telegram\Controls\AnimatedImage.cs:607
  11  Telegram_Telegram_Controls_AnimatedImage__Load+0x28e
      Telegram\Controls\AnimatedImage.cs:525
  12  Telegram_Telegram_Controls_AnimatedImage__OnLoaded+0x12
      Telegram\Controls\AnimatedImage.cs:124
  13  Telegram_ABI_Telegram_Native_Controls_IAnimatedImageBaseOverrides__Do_Abi_OnLoaded_0+0x49
  14  FrameworkElementEx<...AnimatedImageBase...>::HandleChanged+0xdd
      Telegram.Native\Controls\FrameworkElementEx.h:42
  15  winrt::impl::delegate<winrt::Windows::UI::Xaml::SizeChangedEventHandler,...>::Invoke+0x35
```

## Cause

`ImageBrush.get_ImageSource` has exactly two `E_FAIL` exits in the XAML source, both in
`DXamlCore::GetPeerPrivate`. One is "this core type has no framework peer", which cannot
apply to a `WriteableBitmap`. The other is this:

```cpp
// Don't allow peers to be resolved that are no longer reachable. ...
if (pDONoRef->IsReachable())            { ctl::addref_interface(pDONoRef); }
else if (pDONoRef->AllowResurrection()) { pDONoRef->Resurrect(); ... }
else {
    *ppObject = NULL;
    if (createMode == GetPeerPrivateCreateMode::CreateIfNecessary) IFC(E_FAIL);
}
```

So the getter is being asked for a peer the reference tracker has already written off, and
`CImageSource::ParticipatesInManagedTreeInternal` returns `PARTICIPATES_IN_MANAGED_TREE`
("protected from GC, and cannot be resurrected, because the state would be lost"), so there
is no fallback — the call just fails.

Nothing roots that peer. The bitmaps are created in `AnimatedImagePresenter.CreateResources`
and handed straight to `PixelBuffer`, which holds each as a plain `winrt::WriteableBitmap`
(`Telegram.Native/PixelBuffer.h`). A C++ COM reference keeps the object *alive* but not
*reachable*, so the tracker is free to collect the managed peer while rendering carries on
perfectly well — and the next `ImageSource` read throws.

There is no root that lives long enough to fix it from the other side, either:
`Invalidate(null)` only clears `LayoutRoot.Background` when `CleanOnSourceChanged` is true,
and four templates in `Generic.xaml` plus `SendMessagesView.xaml` set it `False` on purpose,
so the brush deliberately outlives the presenter that owns the bitmaps.

## Fix

Stop reading the bitmap back out of XAML. The presenter already holds the `PixelBuffer` at
every call site, and it carries the pixel size natively; `PixelBuffer.Source` is a plain RCW
lookup rather than a peer resolution, so `GetDominantColor` can take it safely. `Invalidate`
now receives the frame and caches it together with the rotation.

That also takes the resize path down to nothing for unrotated content, which is nearly all
of it: `OnSizeChanged` used to spend four interop calls — `Background`, `ImageSource`,
`Transform`, `Rotation` — only to discover there was no transform to update. It now compares
an `int` and returns. As the stack above shows, that is the same path the crash arrives on.

## Not addressed here

`UpdateRotation` writes `ScaleX`/`ScaleY`/`CenterX`/`CenterY` into a `CompositeTransform`
that is shared by every `AnimatedImage` bound to the presenter, each using its own
`ActualWidth`/`ActualHeight`. Two differently sized controls showing the same rotated
animation will fight over it. Pre-existing and unrelated to this crash.

## Testing

Not built and not run — the change is `AnimatedImage.cs` only and parses clean under Roslyn,
which catches typos and not type errors.
