### PR TITLE
Don't let XamlRoot.Content take down the chat background lookup

### DIFF
--- a/Telegram/Common/Extensions.cs
+++ b/Telegram/Common/Extensions.cs
@@ -1153,8 +1153,10 @@ namespace Telegram.Common
             }
             catch
             {
-                // XamlRoot.Content seems to throw a NullReferenceException
-                // whenever corresponding window has been already closed.
+                // A XamlRoot with no content root fails the call with E_POINTER rather than
+                // returning null, and CsWinRT surfaces that as a NullReferenceException. The
+                // window may have been closed, or not have gone live yet: an activation that
+                // runs under WaitForViewReady reaches the tree before its root exists.
             }
 
             content = default;

--- a/Telegram/Views/ChatView.xaml.cs
+++ b/Telegram/Views/ChatView.xaml.cs
@@ -397,10 +397,15 @@ namespace Telegram.Views
 
         private ChatBackgroundControl FindBackgroundControl()
         {
-            var masterDetailPanel = XamlRoot?.Content?.GetChild<MasterDetailPanel>();
-            if (masterDetailPanel != null)
+            if (XamlRoot.TryGetContent(out UIElement content))
             {
-                return masterDetailPanel.GetChild<ChatBackgroundControl>();
+                // Both callers cache through ??=, so a window that has no content root yet is
+                // retried on the next update rather than left without a background for good.
+                var masterDetailPanel = content.GetChild<MasterDetailPanel>();
+                if (masterDetailPanel != null)
+                {
+                    return masterDetailPanel.GetChild<ChatBackgroundControl>();
+                }
             }
 
             return null;


### PR DESCRIPTION
`NullReferenceException: Invalid pointer (0x80004003)`, reported by crash telemetry on 12.10.1.0 and 12.10.0.0 (X64).

```
   at WinRT.ExceptionHelpers.<ThrowExceptionForHR>g__Throw|41_0(Int32) + 0x42
   at ABI.Windows.UI.Xaml.IXamlRootMethods.get_Content(IObjectReference) + 0x7d
   at Telegram.Views.ChatView.FindBackgroundControl() + 0x35
   at Telegram.Views.ChatView.UpdateChatTheme(Chat, ChatTheme) + 0x1da
   at Telegram.Views.ChatView.<UpdateChatTheme>d__274.MoveNext() + 0xe4
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__124_0(Object) + 0x1a
   at ABI.Windows.System.DispatcherQueueProxyHandler.Impl.Invoke(DispatcherQueueProxyHandler*) + 0x52
```

## Cause

`XamlRoot.Content` does not return `null` when the `XamlRoot` has no content root — it fails
the call with `E_POINTER`, which CsWinRT surfaces as a `NullReferenceException`. The `?.` in
`FindBackgroundControl` therefore never gets a chance to run, and because `UpdateChatTheme` is
`async void` the exception is posted to the dispatcher and takes the process with it.

Both reports come from the same startup shape, visible in the log tail: the app had been
running headless for five minutes as the notification bridge, a toast activation created the
first window, and `MainPage` → `ChatPage` → `ChatView.Activate` ran within 200 ms of
`OnWindowCreated`. The whole dispatch sits under
`CoreApplicationViewAgileContainer::WaitForViewReady` in the native frames, so the view is
still being made ready while `UpdateChat` calls `UpdateChatTheme`. `ChatHistoryView` logs
`ScrollToItem: ScrollingHost == null` a few lines earlier, from the same not-yet-live tree.

## Fix

Go through `XamlRoot.TryGetContent`, which already exists for exactly this and swallows the
failure. Both call sites assign through `_backgroundControl ??=`, so the lookup is retried on
the next theme update or the next outgoing message, and the background is picked up then.

`TryGetContent`'s comment attributed the throw to the window having been closed; it also
happens before a window goes live, so it now names the HRESULT and both cases.

Not built or run — UWP/.NET Native isn't available here.
