### PR TITLE
Stop the reaction list asking for more items forever

### DIFF
--- a/Telegram/Controls/Views/InteractionsView.xaml.cs
+++ b/Telegram/Controls/Views/InteractionsView.xaml.cs
@@ -213,19 +213,26 @@ namespace Telegram.Controls.Views
                     _nextOffset = null;
                 }
             }
-            else if (_viewers != null)
+            else
             {
+                // Nothing left to page. HasMoreItems has to say so even when there are no
+                // viewers to append: the list view keeps asking as long as it is true, and
+                // a request that adds nothing and completes without awaiting brings it
+                // straight back on the same stack, forever.
                 HasMoreItems = false;
 
-                foreach (var item in _viewers.Viewers)
+                if (_viewers != null)
                 {
-                    if (_users.Contains(item.UserId))
+                    foreach (var item in _viewers.Viewers)
                     {
-                        continue;
-                    }
+                        if (_users.Contains(item.UserId))
+                        {
+                            continue;
+                        }
 
-                    totalCount++;
-                    _items.Add(item);
+                        totalCount++;
+                        _items.Add(item);
+                    }
                 }
             }
 


### PR DESCRIPTION
Reported by crash telemetry on 12.10.1.

```
COMException: The application called an interface that was marshalled for a different thread.

  20  Microsoft::WRL::ErrorPropagationPolicyTraits<-1>::FireCompletionErrorPropagationPolicyFilter
        onecore\internal\sdk\inc\wrl\internalasync.h:87
  21  Microsoft::WRL::AsyncBase<IAsyncOperationCompletedHandler<LoadMoreItemsResult>,...>::FireCompletion
        onecore\external\sdk\inc\wrl\async.h:849
  22  DirectUI::LoadMoreItemsOperation::RaisedCompleteWithResult
        onecoreuap\windows\dxaml\xcp\dxaml\lib\incrementalloading.cpp:221
  23  DirectUI::IncrementalLoadAsyncCompleteHandler::Invoke
        onecoreuap\windows\dxaml\xcp\dxaml\lib\incrementalloading.cpp:69
  24  ABI.Windows.Foundation.AsyncOperationCompletedHandler`1.NativeDelegateWrapper.Invoke
  25  System.Threading.Tasks.TaskToAsyncInfoAdapter`4.OnCompletedInvoker
  26  System.Threading.Tasks.TaskToAsyncInfoAdapter`4.TaskCompleted
  27  System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop
  28  System.Threading.Tasks.Task.ExecuteWithThreadLocal
  29  System.Threading.ThreadPoolWorkQueue.Dispatch
```

The log tail is thousands of these, all inside the same millisecond, right up to the crash:

```
[IncrementalCollection.cs:35][LoadMoreItemsAsync]
[InteractionsView.xaml.cs:188][LoadMoreItemsAsync]
[IncrementalCollection.cs:35][LoadMoreItemsAsync]
[InteractionsView.xaml.cs:188][LoadMoreItemsAsync]
...
```

## Cause

`InteractionsView` pages the reaction list on `_nextOffset` and appends the message viewers
once the offset runs out. Constructed for a single reaction type there are no viewers -
`_viewers` is null - so once `_nextOffset` reaches null neither branch runs: the method adds
nothing, returns `Count = 0`, and leaves `HasMoreItems` at its initial `true`. The list view
asks again, nothing about the state has changed, and it asks forever.

Nothing on that terminal path awaits, so each request completes on the thread that made it and
the list view issues the next one on the same stack. A few thousand frames in,
`TaskToAsyncInfoAdapter`'s `ContinueWith(..., ExecuteSynchronously, TaskScheduler.Default)` can
no longer inline the completion and queues it to the thread pool instead - frames 26-29 above.
XAML's `IncrementalLoadAsyncCompleteHandler` is thread-affine, so invoking it from a pool thread
returns `RPC_E_WRONG_THREAD`, which `CoreApplication` forwards as an unhandled error.

## Fix

Clear `HasMoreItems` whenever the offset has run out, viewers or not. The viewers loop keeps its
existing behaviour; it just no longer decides whether the collection is finished.

Not built or run.
