### PR TITLE
Pass the projected sender vector to VideoChatAliasesPopup

### DIFF
--- a/Telegram/Services/Calls/VoipGroupCall.cs
+++ b/Telegram/Services/Calls/VoipGroupCall.cs
@@ -590,7 +590,11 @@ namespace Telegram.Services.Calls
             var available = await CanChooseAliasAsyncInternal(_chat.Id);
             if (available != null)
             {
-                var popup = new VideoChatAliasesPopup(ClientService, _chat, false, _availableAliases.Senders.ToArray());
+                // The list goes on to be an ItemsSource, and a managed array does not survive
+                // that under CsWinRT: the wrapper it builds exposes no collection interface
+                // XAML recognises, so the setter fails with E_INVALIDARG. Pass the projected
+                // vector along, as the other two call sites do.
+                var popup = new VideoChatAliasesPopup(ClientService, _chat, false, available.Senders);
                 popup.RequestedTheme = ElementTheme.Dark;
 
                 var confirm = await popup.ShowQueuedAsync(xamlRoot);


### PR DESCRIPTION
Reported by crash telemetry on 12.10.1.

```
ArgumentException: The parameter is incorrect. (0x80070057)

   at WinRT.ExceptionHelpers.<ThrowExceptionForHR>g__Throw|41_0(Int32)
   at ABI.Windows.UI.Xaml.Controls.IItemsControlMethods.set_ItemsSource(IObjectReference, Object)
   at Telegram.Views.Calls.Popups.VideoChatAliasesPopup..ctor(IClientService, Chat, Boolean, IList`1)
   at Telegram.Services.Calls.VoipGroupCall.<RejoinAsync>d__97.MoveNext()
   at Telegram.Views.Calls.GroupCallWindow.<<Menu_ContextRequested>b__60_0>d.MoveNext()
```

## Cause

The failure itself is the one `CsWinRT.cs` already documents: a concrete array or constructed
generic boxed into a WinRT `object` gets no CCW vtable of its own, XAML fails the QI for
`IBindableIterable`, and `set_ItemsSource` returns `E_INVALIDARG`. `TG1001` is the analyzer for it
and the registration list is its output.

What is missing here is not a registration. `VideoChatAliasesPopup` assigns its `senders` argument
straight to `ScrollingHost.ItemsSource`, and two of its three call sites hand it
`MessageSenders.Senders` - a `List<MessageSender>`, whose instantiation the schema already exposes
through `TdDotNetApi.WinRT.g.cs`. `RejoinAsync` is the odd one out: it calls `.ToArray()` first, so
XAML is handed a `MessageSender[]`, and that is a `Telegram.Td.Api` array.

`CsWinRT.cs` deliberately no longer carries any of those:

> The `Telegram.Td.Api` arrays that used to be here are gone: both parsers materialise a vector as a
> `List<T>`, never an array, so nothing could reach these.

This call site is the one thing still manufacturing one.

## Fix

Pass `available.Senders` - the vector the awaited call just returned, which is also what
`_availableAliases` was set to a line earlier - instead of copying it into an array. That makes the
third call site identical to the other two and restores the invariant the comment describes, rather
than adding a `Td.Api` array back to the registration list as an exception to it.

`EmojiSkinFlyout` and `GiftPopup` also assign array literals to `ItemsSource` and are fine, because
`EmojiSkinData[]` and `PremiumGiftPaymentOption[]` are both registered - neither is a `Td.Api`
array. Worth rerunning `TG1001` after this rather than trusting my reading.

Not built or run.
