### PR TITLE
Skip the auto-download limit bind-back when there is no view model

### DIFF
--- a/Telegram/Views/Settings/Popups/SettingsDataAutoView.xaml.cs
+++ b/Telegram/Views/Settings/Popups/SettingsDataAutoView.xaml.cs
@@ -67,8 +67,10 @@ namespace Telegram.Views.Settings.Popups
 
         private void ConvertLimitBack(double progress)
         {
-            // The slider writes back on any value change, teardown included, and by then the
-            // DataContext can be gone - there is nothing to write to.
+            // The generated bindings null-check ViewModel for every other two-way binding here,
+            // because those write through a path they can see. A BindBack function is opaque to
+            // them, so this one is ours to make. It fires with no view model whenever the page
+            // failed to assign the DataContext - see the E_FAIL out of its Bindings.Loading.
             if (ViewModel == null)
             {
                 return;

--- a/Telegram/Views/Settings/Popups/SettingsDataAutoView.xaml.cs
+++ b/Telegram/Views/Settings/Popups/SettingsDataAutoView.xaml.cs
@@ -67,6 +67,13 @@ namespace Telegram.Views.Settings.Popups
 
         private void ConvertLimitBack(double progress)
         {
+            // The slider writes back on any value change, teardown included, and by then the
+            // DataContext can be gone - there is nothing to write to.
+            if (ViewModel == null)
+            {
+                return;
+            }
+
             int size = 500 * 1024;
             if (progress <= 0.25f)
             {


### PR DESCRIPTION
Reported by crash telemetry on 12.10.1.

```
NullReferenceException: Object reference not set to an instance of an object.

   at Telegram.Views.Settings.Popups.SettingsDataAutoView.ConvertLimitBack(Double)
   at ABI.Windows.UI.Xaml.DependencyPropertyChangedCallback.Do_Abi_Invoke(IntPtr, IntPtr, IntPtr)
```

`ViewModel` is `DataContext as SettingsDataAutoViewModel`, and the only dereference in the method
is the last line, `ViewModel.Limit = size`.

## How the DataContext goes missing

The three `SettingsDataAutoView`s get theirs from the page, through
`DataContext="{x:Bind ViewModel.AutoDownloadPhotos}"`. In the generated bindings that is one
statement inside `SettingsDataAndStoragePage_obj1_Bindings.Update_ViewModel`, and the order in
that method is fixed:

```
Update_ViewModel_HasDownloadFolder(...)        // FindName / UnloadObject on the deferred DownloadFolder
Update_ViewModel_IsStreamingEnabled(...)
Update_ViewModel_IsDownloadFolderEnabled(...)  // set IsChecked on the deferred SettingsRadioButton
...
Update_ViewModel_AutoDownloadDocuments(...)    // <- these three assign the DataContext
Update_ViewModel_AutoDownloadVideos(...)
Update_ViewModel_AutoDownloadPhotos(...)
```

There is no try/catch around any of it, and `Update_ViewModel_IsDownloadFolderEnabled` is exactly
the call that throws in another 12.10.1 group:

```
COMException: Unspecified error (0x80004005)
   at ABI.Windows.UI.Xaml.Controls.Primitives.IToggleButtonMethods.set_IsChecked(IObjectReference, Nullable`1)
   at SettingsDataAndStoragePage_obj1_Bindings.Update_ViewModel_IsDownloadFolderEnabled(Boolean, Int32)
   at SettingsDataAndStoragePage_obj1_Bindings.Update_ViewModel(...)
   at SettingsDataAndStoragePage_obj1_Bindings.Loading(FrameworkElement, Object)
```

When that throws, the three assignments below it never run. `DataContext` then inherits from the
page, so it is a `SettingsDataAndStorageViewModel` and the `as` gives null. (The same state is
reached if the page's own `ViewModel` is null when `Loading` runs - `Update_ViewModel` skips its
whole body. The assignment is not `DATA_CHANGED`-phased, so it is write-once: nothing reassigns
it later.)

The slider is still on screen in that state, and that is the part that turns a dead view into a
crash. `Update_ViewModel` writes nothing when the view model is null, so the Grid around the
slider never gets the `Visibility` its `IsLimitSupported` binding would have given it and keeps
its markup default - visible. The user drags a slider that is bound to nothing.

## Why only this binding throws

Every other two-way binding in the control writes through a path the compiler can see, so it
emits the check itself:

```csharp
private void UpdateTwoWay_2_IsChecked()
{
    if (this.initialized)
        if (this.dataRoot != null)
            if (this.dataRoot.ViewModel != null)          // <- generated
                this.dataRoot.ViewModel.Contacts = (bool)this.obj2.IsChecked;
}

private void UpdateTwoWay_10_Value()
{
    if (this.initialized)
    {
        double p0 = this.obj10.Value;
        if (this.dataRoot != null)                        // no ViewModel check to generate
            this.dataRoot.ConvertLimitBack(p0);
    }
}
```

A `BindBack` function is opaque to the compiler, so the null check is the app's to write. That is
also why this is the only NRE from that page: the four checkboxes quietly do nothing.

Note it is not a teardown case - `StopTracking()`, which clears `initialized`, is never wired up
for a UserControl, but nothing clears the DataContext either.

## Fix

Return early when there is no view model, matching what the compiler emits for the bindings
either side of it.

**This stops the crash, it does not fix the cause.** With the guard, a page that hit the E_FAIL
shows an auto-download section of unchecked boxes and a slider that does nothing, silently. The
real defect is upstream and I have not diagnosed it - `set_IsChecked` returning `E_FAIL` on a
`SettingsRadioButton` that `Update_ViewModel_HasDownloadFolder` has just realized or unloaded
through `x:Load`, with a `GroupName` shared with a sibling that may not be realized yet. Happy to
drop this one if you would rather fix that first.

Not built or run.
