### PR TITLE
Fix a crash when a MoreButton is disabled

### DIFF
--- a/Telegram/Themes/Generic.xaml
+++ b/Telegram/Themes/Generic.xaml
@@ -5779,13 +5779,10 @@
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Disabled">
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
-                                                                       Storyboard.TargetName="ContentPresenter">
-                                            <DiscreteObjectKeyFrame KeyTime="0"
-                                                                    Value="{ThemeResource SystemControlForegroundBaseLowBrush}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
+                                    <VisualState.Setters>
+                                        <Setter Target="Icon.Foreground"
+                                                Value="{ThemeResource SystemControlForegroundBaseLowBrush}" />
+                                    </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>


### PR DESCRIPTION
`System.Runtime.InteropServices.COMException (0x800F1000): No installed components were detected. Cannot resolve TargetName ContentPresenter.`

Reported by crash telemetry on 12.10.1.0 (X64).

```
   0  CTimeline::ResolveLocalTarget            animation\timeline.cpp:549
   2  CAnimation::OnBegin                      animation\animation.cpp:529
   3  CStoryboard::BeginPrivate                animation\storyboard.cpp:502
   4  VisualStateManagerActuator::AttemptStartStoryboard
   5  VisualStateManagerActuator::ChangeVisualState
   7  CVisualStateManager::GoToState           elements\visualstatemanager.cpp:82
  12  DirectUI::Control::GoToState             control_partial.cpp:1134
  13  DirectUI::Button::ChangeVisualState      button_partial.cpp:39
  14  DirectUI::Control::UpdateVisualState     control_partial.cpp:849
  15  DirectUI::ButtonBase::OnApplyTemplate    buttonbase_partial.cpp:886
  20  CFrameworkElement::InvokeApplyTemplate   elements\framework.cpp:1289
  25  CGrid::MeasureOverride                   elements\grid.cpp:1184
  33  Telegram.Controls.HeaderedControlPanel.MeasureOverride   HeaderedControl.cs:254
  60  Telegram.Controls.HeaderedControl.MeasureOverride        HeaderedControl.cs:146
  69  Telegram.Controls.SettingsPanel.MeasureOverride          SettingsPanel.cs:41
```

The log tail ends on `Navigate: Telegram.Views.Chats.ChatInviteLinksPage`, 240 ms before the crash — the page's first layout pass.

## Cause

`MoreButton`'s template in `Themes/Generic.xaml` has no element named `ContentPresenter` — only `RootGrid` (a `Border`) and `Icon` (an `AnimatedIcon`). Its `Disabled` visual state nevertheless drives a storyboard at `Storyboard.TargetName="ContentPresenter"`, left over from the `SettingsButton` template it was derived from, which does have that part.

`ButtonBase::OnApplyTemplate` calls `UpdateVisualState`, so the first state change happens as soon as the template is applied. When `IsEnabled` is true that picks `Normal`, which is empty — nothing to resolve, no failure. When it is false it picks `Disabled`, the storyboard starts, `ResolveLocalTarget` cannot find the name, and the failure propagates out of measure as an unhandled `COMException`.

Every other `MoreButton` in the app is permanently enabled, so the state is never entered. The one on `ChatInviteLinksPage` is the exception:

```xml
IsEnabled="{x:Bind ConvertHasInviteLink(ViewModel.InviteLink), Mode=OneWay}"
```

`ViewModel.InviteLink` is still `null` while the link is being fetched, so the button is disabled on the page's first layout and the crash is reachable there — and only there.

## Fix

Point the state at `Icon`, using the same `VisualState.Setters` mechanism the `PointerOver` and `Pressed` states in that template already use for it. `More` is generated as an `IAnimatedVisualSource2` with a `Foreground` theme property, so the icon does recolour — the intent of the original storyboard is preserved rather than dropped.

Not built or run; the file parses as XML.
