### PR TITLE
Attach the managed exception's own frames to a stowed crash report

### DIFF
--- a/Telegram.Native/FatalError.h
+++ b/Telegram.Native/FatalError.h
@@ -51,6 +51,16 @@ namespace winrt::Telegram::Native::implementation
             return m_frames;
         }
 
+        uint32_t ThreadId()
+        {
+            return m_threadId;
+        }
+
+        void ThreadId(uint32_t value)
+        {
+            m_threadId = value;
+        }
+
         winrt::Telegram::Native::FatalError InnerException()
         {
             return m_innerException;
@@ -66,6 +76,7 @@ namespace winrt::Telegram::Native::implementation
         hstring m_message;
         hstring m_stackTrace;
         winrt::Windows::Foundation::Collections::IVector<FatalErrorFrame> m_frames;
+        uint32_t m_threadId{ 0 };
 
         winrt::Telegram::Native::FatalError m_innerException;
     };

--- a/Telegram.Native/FatalError.idl
+++ b/Telegram.Native/FatalError.idl
@@ -15,6 +15,11 @@ namespace Telegram.Native
         String StackTrace;
         Windows.Foundation.Collections.IVector<FatalErrorFrame> Frames{ get; };
 
+        // The thread the record was stowed on. Zero when it came back across an RPC boundary from
+        // another process, which is the tell for a record that has nothing to do with the failure
+        // being reported.
+        UInt32 ThreadId;
+
         FatalError InnerException;
     }
 }

--- a/Telegram.Native/NativeUtils.cpp
+++ b/Telegram.Native/NativeUtils.cpp
@@ -594,6 +594,10 @@ namespace winrt::Telegram::Native::implementation
         // keeping on their own, and used to be dropped along with them.
         auto error = winrt::Telegram::Native::FatalError(L"", L"", hstring(detail), frames);
 
+        // Also a property, not only text in the trace: the caller has to be able to tell a record
+        // stowed on this thread from one that came back over RPC, which reports zero.
+        error.ThreadId(stowed->ThreadId);
+
         if (stowed->NestedExceptionType == STOWED_EXCEPTION_NESTED_TYPE_STOWED)
         {
             error.InnerException(GetStowedException2((STOWED_EXCEPTION_INFORMATION_V2*)stowed->NestedException));
@@ -663,7 +667,25 @@ namespace winrt::Telegram::Native::implementation
         }
 
         auto error = winrt::make_self<FatalError>(type, message, hstring(trace), frames);
+
+        // A backtrace is always this thread's, by construction. Filling it in anyway keeps the
+        // property meaningful whichever of the two sources a record came from.
+        error->ThreadId(::GetCurrentThreadId());
+
         return error.as<winrt::Telegram::Native::FatalError>();
+    }
+
+    winrt::Telegram::Native::FatalError NativeUtils::CreateError(hstring type, hstring message, hstring stackTrace)
+    {
+        auto error = winrt::make_self<FatalError>(type, message, stackTrace, winrt::single_threaded_vector<FatalErrorFrame>());
+        error->ThreadId(::GetCurrentThreadId());
+
+        return error.as<winrt::Telegram::Native::FatalError>();
+    }
+
+    uint32_t NativeUtils::GetCurrentThreadId()
+    {
+        return ::GetCurrentThreadId();
     }
 
     bool NativeUtils::FileExists(hstring path)

--- a/Telegram.Native/NativeUtils.h
+++ b/Telegram.Native/NativeUtils.h
@@ -69,6 +69,8 @@ namespace winrt::Telegram::Native::implementation
         static void LogMessageCallback(int verbosity_level, const char* message);
         static winrt::Telegram::Native::FatalError GetStowedException();
         static winrt::Telegram::Native::FatalError GetBackTrace(hstring type, hstring message);
+        static winrt::Telegram::Native::FatalError CreateError(hstring type, hstring message, hstring stackTrace);
+        static uint32_t GetCurrentThreadId();
 
         static void Log(int32_t level, hstring message, hstring member, hstring filePath, int32_t line);
 

--- a/Telegram.Native/NativeUtils.idl
+++ b/Telegram.Native/NativeUtils.idl
@@ -95,6 +95,12 @@ namespace Telegram.Native
         static FatalError GetStowedException();
         static FatalError GetBackTrace(String type, String message);
 
+        // An empty record for frames the managed side collected. Made here so the vector behind
+        // Frames is a native one: handing a managed list across the ABI would need a CCW that only
+        // an entry in CsWinRT.cs provides.
+        static FatalError CreateError(String type, String message, String stackTrace);
+        static UInt32 GetCurrentThreadId();
+
         static String GetLogMessage(Int64 format, Int64 args);
 
         static void Crash();

--- a/Telegram/Common/WatchDog.cs
+++ b/Telegram/Common/WatchDog.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -173,12 +174,78 @@ namespace Telegram
                         ? ex.StackTrace
                         : stowed.StackTrace + "\n" + ex.StackTrace;
 
+                    // The two carry different stacks and either can be the useful one. The record
+                    // is combase's capture at the ABI boundary, so for anything that reached here
+                    // through an async rethrow it shows the rethrow and not the origin; ex still
+                    // holds the origin, because the runtime accumulates frames into the exception
+                    // across every rethrow. The other way round, ex is often nothing but Propagate
+                    // rethrowing a bare E_FAIL, and then the record is all there is.
+                    //
+                    // So attach both and let the dashboard see the pair, rather than picking.
+                    AttachManagedFrames(stowed, ex);
+
                     Supersede(ProcessException(stowed, defer: true), stowed.Type, stowed.Message);
                 }
                 else
                 {
                     Supersede(ProcessException(ex, defer: true), ex.GetType().Name, ex.Message);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Hangs the managed exception's own frames off <paramref name="stowed"/> as an inner
+        /// record, so a report carries both stacks instead of whichever one happened to be reached
+        /// first.
+        /// </summary>
+        /// <remarks>
+        /// Under NativeAOT the frames on an exception have no method behind them - there is no
+        /// reflection metadata - but they do have an image base and an address, which is exactly
+        /// what the symbolicator resolves. That is the same shape the stowed records carry, so the
+        /// two travel through the report as one chain.
+        ///
+        /// The innermost record is where the reader looks first, so put the managed frames there
+        /// only when the stowed ones cannot be the origin: a text-form record has no frames at all,
+        /// and a record raised on another thread - zero, for one marshalled back over RPC - belongs
+        /// to a different failure. Anything else keeps the record's own order.
+        /// </remarks>
+        private static void AttachManagedFrames(FatalError stowed, Exception ex)
+        {
+            var frames = new StackTrace(ex, true).GetFrames();
+            if (frames == null || frames.Length == 0 || !frames[0].HasNativeImage())
+            {
+                return;
+            }
+
+            var managed = NativeUtils.CreateError(ex.GetType().Name, ex.Message, ex.StackTrace);
+
+            foreach (var frame in frames)
+            {
+                managed.Frames.Add(new FatalErrorFrame
+                {
+                    NativeIP = frame.GetNativeIP().ToInt64(),
+                    NativeImageBase = frame.GetNativeImageBase().ToInt64()
+                });
+            }
+
+            var suspect = stowed.Frames.Count == 0 || stowed.ThreadId != NativeUtils.GetCurrentThreadId();
+            if (suspect)
+            {
+                // First of the record's inner exceptions, ahead of whatever it already nested.
+                // The outer stays the record either way - its type and message were replaced with
+                // the exception's a moment ago, so only the frames are in question here.
+                managed.InnerException = stowed.InnerException;
+                stowed.InnerException = managed;
+            }
+            else
+            {
+                var last = stowed;
+                while (last.InnerException != null)
+                {
+                    last = last.InnerException;
+                }
+
+                last.InnerException = managed;
             }
         }
 


### PR DESCRIPTION
A crash report that goes through `UnhandledErrorDetected` currently carries only one of the two
stacks it has access to, and it is often the wrong one.

## What happens today

`OnUnhandledExceptionDetected` recovers the stowed record, then `Propagate()` gives it the managed
exception. When a record exists it wins: the report's frames are the record's, and the exception
contributes only its `StackTrace` **string**, appended to the record's own.

Those two stacks are captured at different moments. The record is combase's capture at the ABI
boundary, so for anything that reached the handler through an async rethrow it shows the rethrow
and not the origin - the origin unwound long before. The exception still has the origin, because
the runtime accumulates frames into the exception object across every rethrow.

A report from 12.10.1 with both, side by side. The frames:

```
0  RoOriginateLanguageException
1  WinRT.ExceptionHelpers.SetErrorInfo
2  WinRT.ExceptionHelpers.ReportUnhandledError
3  ABI.Windows.System.DispatcherQueueProxyHandler.Invoke
...
8  System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw
9  System.Threading.Tasks.Task.<>c.<ThrowAsync>b__124_0
```

and the string, which is the part that says anything:

```
at ABI.Windows.UI.Xaml.Controls.IItemsControlMethods.set_ItemsSource(IObjectReference, Object)
at Telegram.Views.Premium.Popups.FeaturesPopup..ctor(...)
at Telegram.Controls.Stories.StoriesWindow.<ContinuePopupAsync>d__45.MoveNext()
--- End of stack trace from previous location ---
at Telegram.Controls.Stories.StoriesWindow.<StealthStory>d__60.MoveNext()
```

A string is not symbolicatable, and it is not in the group hash the way frames are.

The reverse case is just as real, which is why this does not simply swap them: `Propagate()` often
throws a bare E_FAIL whose stack is nothing but itself and the watchdog, and then the record is the
only thing that knows anything. `GetStowedException`'s comment already says so.

## The change

Attach both, as an inner record, so neither is thrown away.

Verified on the shipping toolchain before writing it - under .NET 10 and NativeAOT,
`new StackTrace(exception, true).GetFrames()` really does return frames with `HasNativeImage()`
true and a usable `GetNativeIP()`/`GetNativeImageBase()`, even though `GetMethod()` is null because
there is no reflection metadata. That is the same `{NativeIP, NativeImageBase}` shape the stowed
records already carry, so the two travel through the report as one chain and the symbolicator
resolves both.

Ordering, since the innermost record is where a reader looks first: the managed frames go first
only when the record's cannot be the origin, and that is decidable rather than guessed -

- a **text-form** record (`ExceptionForm == 2`) has no frames at all, only a description;
- a record whose `ThreadId` is not this thread belongs to a different failure. Zero is the value a
  record marshalled back from another process over RPC reports, and there is at least one 12.10.1
  group where a stale `RuntimeBroker.exe` record was the only "origin" the report offered.

`ThreadId` was only ever formatted into the trace text, so it is now a property on `FatalError`
too - that is the whole of the native change, plus `CreateError`, which exists so the vector behind
`Frames` is made natively: handing a managed list across the ABI would need a CCW that only an
entry in `CsWinRT.cs` provides.

## Consequences

**Group hashes change for every report of this shape.** The new inner record contributes its frames
to the hash, so these groups will re-form after the release rather than continue. That is the cost
of the frames being in the hash at all, and it seems worth paying once.

Not built or run: the C# half cannot compile until `Telegram.Native` is rebuilt, since the new
members reach it through the generated projection.
