### PR TITLE
Build the dust masks per view, not once for the app

### DIFF
--- a/Telegram/Composition/CompositionDustLayers.cs
+++ b/Telegram/Composition/CompositionDustLayers.cs
@@ -59,12 +59,18 @@ namespace Telegram.Composition
 
         private const int MaskSize = 256;
 
+        // A brush belongs to the compositor that created it and every window has its own, so these
+        // are per view. What is shared is the encoded noise behind them, which is the whole cost.
+        [ThreadStatic]
         private static CompositionSurfaceBrush[] _masks;
+        [ThreadStatic]
         private static int _preparedFor;
+        [ThreadStatic]
         private static bool _preparing;
 
         // The streams have to outlive the call: LoadedImageSurface reads them asynchronously.
-        private static readonly List<InMemoryRandomAccessStream> _streams = new();
+        [ThreadStatic]
+        private static List<IRandomAccessStream> _streams;
 
         public CompositionDustLayers(UIElement host)
             : base(host)
@@ -78,8 +84,8 @@ namespace Telegram.Composition
         public override bool IsReady => _masks != null;
 
         /// <summary>
-        /// The masks are shared by every chat and depend only on the layer count, so this runs once
-        /// per session unless the count is changed from the diagnostics page.
+        /// The masks depend only on the layer count, so this runs once per view unless the count is
+        /// changed from the diagnostics page.
         /// </summary>
         public static void Prepare()
         {
@@ -157,13 +163,68 @@ namespace Telegram.Composition
             }
         }
 
-        // One pass over MaskSize^2, once. Each pixel belongs to exactly one layer, biased towards
-        // that layer's column, so layers leaving in order read as a wave.
         private static async Task PrepareAsync()
         {
             _preparing = true;
 
+            var compositor = BootStrapper.Current.Compositor;
+
             var count = Layers;
+            var streams = await EncodeAsync(count);
+
+            var brushes = new CompositionSurfaceBrush[count];
+            var clones = _streams ??= new List<IRandomAccessStream>();
+
+            for (int i = 0; i < count; i++)
+            {
+                // A clone reads the same bytes through a cursor of its own, so two views loading the
+                // set at the same time do not move each other along.
+                var stream = streams[i].CloneStream();
+                stream.Seek(0);
+
+                clones.Add(stream);
+
+                var brush = compositor.CreateSurfaceBrush(LoadedImageSurface.StartLoadFromStream(stream));
+                brush.Stretch = CompositionStretch.Fill;
+
+                brushes[i] = brush;
+            }
+
+            _masks = brushes;
+            _preparedFor = count;
+            _preparing = false;
+
+            // The count moved again while this was encoding.
+            Prepare();
+        }
+
+        private static readonly object _encodingLock = new();
+        private static Task<IRandomAccessStream[]> _encoding;
+        private static int _encodedFor;
+
+        /// <summary>
+        /// The encoded masks, which are the same for every view and so are produced once per
+        /// session unless the layer count is changed from the diagnostics page.
+        /// </summary>
+        private static Task<IRandomAccessStream[]> EncodeAsync(int count)
+        {
+            // Views run on threads of their own, so two of them can ask for this at once.
+            lock (_encodingLock)
+            {
+                if (_encoding == null || _encodedFor != count)
+                {
+                    _encodedFor = count;
+                    _encoding = EncodeMasksAsync(count);
+                }
+
+                return _encoding;
+            }
+        }
+
+        // One pass over MaskSize^2, once. Each pixel belongs to exactly one layer, biased towards
+        // that layer's column, so layers leaving in order read as a wave.
+        private static async Task<IRandomAccessStream[]> EncodeMasksAsync(int count)
+        {
             var masks = new byte[count][];
 
             for (int i = 0; i < count; i++)
@@ -189,26 +250,17 @@ namespace Telegram.Composition
                 }
             }
 
-            var compositor = BootStrapper.Current.Compositor;
-            var brushes = new CompositionSurfaceBrush[count];
+            var streams = new IRandomAccessStream[count];
 
             for (int i = 0; i < count; i++)
             {
-                var brush = compositor.CreateSurfaceBrush(await CreateSurfaceAsync(masks[i]));
-                brush.Stretch = CompositionStretch.Fill;
-
-                brushes[i] = brush;
+                streams[i] = await EncodeAsync(masks[i]);
             }
 
-            _masks = brushes;
-            _preparedFor = count;
-            _preparing = false;
-
-            // The count moved again while this was encoding.
-            Prepare();
+            return streams;
         }
 
-        private static async Task<LoadedImageSurface> CreateSurfaceAsync(byte[] pixels)
+        private static async Task<IRandomAccessStream> EncodeAsync(byte[] pixels)
         {
             var stream = new InMemoryRandomAccessStream();
 
@@ -216,10 +268,7 @@ namespace Telegram.Composition
             encoder.SetPixelData(BitmapPixelFormat.Bgra8, BitmapAlphaMode.Premultiplied, MaskSize, MaskSize, 96, 96, pixels);
             await encoder.FlushAsync();
 
-            stream.Seek(0);
-            _streams.Add(stream);
-
-            return LoadedImageSurface.StartLoadFromStream(stream);
+            return stream;
         }
     }
 }


### PR DESCRIPTION
Reported by crash telemetry on 12.10.2.0.

```
ArgumentException
The parameter is incorrect. Invalid argument to parameter value. Unsupported source brush type.

Windows::UI::Composition::CompositionMaskBrush::Validate_Mask
Windows::UI::Composition::CompositionMaskBrushT<...>::Api::put_Mask
ABI.Windows.UI.Composition.ICompositionMaskBrushMethods.set_Mask
Telegram.Composition.CompositionDustLayers.Build      CompositionDustLayers.cs:110
Telegram.Composition.CompositionDustVisual.Play       CompositionDustVisual.cs:153
Telegram.Views.ChatView.Captured                      ChatView.xaml.cs:588
Telegram.Collections.SynchronizedList`1.Flush         SynchronizedList.cs:154
```

### Cause

`CompositionDustLayers._masks` was `static`, so one set of `CompositionSurfaceBrush` served the
whole app. They are built in `PrepareAsync` from `BootStrapper.Current.Compositor`, which is
`Window.Current.Compositor` — a *per-view* object. The first `ChatView` to be constructed decides
which view's compositor the masks belong to, and that is the main window.

Open a chat in its own window (`createNewWindow`, which goes through
`CoreApplication.CreateNewView`) and its `ChatView` gets a compositor of its own. `Build` then
creates the mask brush on that compositor and assigns a mask that belongs to another one, and
composition rejects it. Deleting a message there — or deleting the chat, which flushes the whole
history through `SynchronizedList` — kills the window every time.

The validation message does not name the compositor, but a wrong *type* is not reachable: the
only thing ever assigned is `compositor.CreateSurfaceBrush(...)`, which `Mask` accepts, and the
array is fully populated before it is published, so no element can be null. What is left is the
object's origin.

### Fix

Split the two halves that were sharing a lifetime.

The expensive part — the scatter pass over the noise and the PNG encode — has nothing to do with
any compositor, so it stays shared: `EncodeAsync(count)` produces the streams once per session
(behind a lock, since views are threads and two can ask at once) and hands the same array to
every caller.

The brushes are now `[ThreadStatic]`, which under UWP is one set per view, and each view loads
them from a `CloneStream()` of the shared stream so two views loading at the same time do not
move each other's cursor.

Not built or run; the file parses clean under Roslyn.

Adjacent and left alone: `CompositionDustVisual._random` is a shared `Random` read from `Build`
on every view's thread. It could not be reached from a second view before this change; now it
can, and concurrent bursts in two windows could scramble it. The failure is cosmetic rather than
a crash, so it is not folded in here.
