### PR TITLE
Translate fifteen more system error messages

### DIFF
--- a/Telegram/Common/ExceptionSerializer.cs
+++ b/Telegram/Common/ExceptionSerializer.cs
@@ -628,6 +628,16 @@ namespace Telegram.Common
             return false;
         }
 
+        /// <summary>
+        /// Maps a localised system sentence onto the English one the same fault produces.
+        /// </summary>
+        /// <remarks>
+        /// The English target is never invented: it comes from an English report for the same
+        /// fault, or from the canonical set already here. A plausible translation merges the group
+        /// under text Windows never emits, and nothing afterwards distinguishes it from a real one.
+        /// Sentences still waiting for an English counterpart are parked in
+        /// notes/untranslated-error-messages.md rather than guessed at.
+        /// </remarks>
         private static string TranslateText(string text)
         {
             switch (text)

--- a/Telegram/Common/ExceptionSerializer.cs
+++ b/Telegram/Common/ExceptionSerializer.cs
@@ -774,6 +774,9 @@ namespace Telegram.Common
                 case "Programmet kaldte en grænseflade, der var arrangeret for en anden tråd.":
                 case "Приложение обратилось к интерфейсу, относящемуся к другому потоку.":
                 case "应用程序调用一个已为另一线程整理的接口。":
+                case "應用程式所呼叫了整理給不同執行緒的介面。":
+                case "응용 프로그램이 다른 스레드를 위해 배열된 인터페이스를 호출했습니다.":
+                case "Η εφαρμογή κάλεσε μια διασύνδεση που είχε παραταχθεί για διαφορετικό νήμα.":
                     return "The application called an interface that was marshalled for a different thread.";
 
                 case "Les ressources mémoire disponibles sont insuffisantes pour exécuter cette opération.":
@@ -791,6 +794,7 @@ namespace Telegram.Common
                 case "記憶體資源不足，無法完成此作業。":
                 case "系统资源不足，无法完成请求的服务。":
                 case "Zur Verarbeitung dieses Befehls sind nicht genügend Speicherressourcen verfügbar.":
+                case "Les ressources mémoire disponibles sont insuffisantes pour traiter cette commande.":
                     return "Not enough memory resources are available to process this command.";
 
                 case "Le serveur RPC n’est pas disponible.":
@@ -912,6 +916,9 @@ namespace Telegram.Common
                 case "De bron is gerealiseerd op het verkeerde renderdoel.":
                 case "リソースが誤ったレンダー ターゲットで認識されました。":
                 case "在错误的呈现器目标上实现资源。":
+                case "리소스가 잘못된 렌더링 대상에서 실현되었습니다.":
+                case "Az erőforrás nem a megfelelő képalkotási célhoz lett hozzárendelve.":
+                case "Resursen realiserades på fel renderingsmål.":
                     return "The resource was realized on the wrong render target.";
 
                 case "Un fichier de polices n’a pas pu être ouvert car le fichier, répertoire, remplacement réseau, lecteur ou autre emplacement de stockage n’existe pas ou n’est pas disponible.":
@@ -975,9 +982,11 @@ namespace Telegram.Common
 
                 case "L’identificateur d’opération n’est pas valide.":
                 case "Неверный идентификатор операции.":
+                case "El identificador de operación no es válido.":
                     return "The operation identifier is not valid.";
 
                 case "La operación intentó tener acceso a datos fuera del rango válido":
+                case "Tentativo di accesso a dati esterni all'intervallo di validità":
                     return "The operation attempted to access data outside the valid range";
 
                 case "Cette interface n’est pas prise en charge":
@@ -985,6 +994,11 @@ namespace Telegram.Common
                 case "Não há suporte para esta interface":
                 case "Böyle bir arabirim desteklenmiyor":
                 case "Интерфейс не поддерживается":
+                case "Schnittstelle nicht unterstützt":
+                case "Gränssnittet stöds inte":
+                case "Neznámé rozhraní":
+                case "Taki interfejs nie jest obsługiwany.":
+                case "不支援此種介面":
                     return "No such interface supported";
 
                 case "Интерфейс не зарегистрирован":
@@ -998,6 +1012,7 @@ namespace Telegram.Common
 
                 case "Недопустимый дескриптор окна.":
                 case "Handle de fenêtre non valide.":
+                case "El identificador de la ventana no es válido.":
                     return "Invalid window handle.";
 
                 case "메모리 리소스가 부족하기 때문에 이 작업을 완료할 수 없습니다.":

--- a/notes/untranslated-error-messages.md
+++ b/notes/untranslated-error-messages.md
@@ -1,0 +1,97 @@
+# Untranslated system error messages
+
+Windows returns system error text in the user's language, and the crash grouping hash includes
+the message, so one fault splits into a group per locale and every one of them looks small.
+`ExceptionSerializer.TranslateText` undoes this by mapping each localised sentence onto the
+English one the same fault produces in an English install.
+
+The rule that governs that switch is that **the English target is never invented**. It has to be
+a wording the same fault actually produces — taken from an English report for the same fault, or
+from the file's own canonical set. A plausible-looking translation is worse than no entry: it
+merges the group under text that Windows never emits, and the next person has no way to tell the
+invented string from a real one.
+
+The messages below are the ones where no English counterpart exists yet, so there is nothing to
+map them onto. They are parked here rather than guessed at. When an English report for one of
+them turns up, add the `case` beside its siblings and delete its section here, in the same
+commit.
+
+## How to check whether the English has landed
+
+```
+crashctl list --days 28 --status all --limit 5000 --json
+```
+
+and search the messages for the suggested English fragment under each entry. That fragment is a
+search term, not a proposed target: what goes in the `case` is whatever wording a real English
+report carries.
+
+Two things to get right when adding one:
+
+- The `case` text is the sentence **with the HRESULT suffix stripped**, the way `_hresultSuffix`
+  strips it — `(0x…)` on the CsWinRT build, `(Exception from HRESULT: 0x…)` on .NET Native.
+- A report often carries an outer message and an originating description. Those are separate
+  lines and are translated separately, so the `case` is the localised line on its own, not the
+  pair the dashboard shows joined together.
+
+## Pending
+
+### Portuguese — OLE clipboard
+
+```
+Falha na inicialização da área de transferência OLE.
+```
+
+Seen on 12.8.1 as `Exception`, arriving as the originating description under an outer
+`Unspecified error`, so it carries no HRESULT of its own. Search for: `clipboard`.
+
+### German — DirectWrite font cache
+
+```
+Der Schriftartcache beinhaltet ungültige Daten.
+```
+
+Seen on 12.8.1 as `Exception`, with `(Exception from HRESULT: 0x88985007)` attached. The code is
+known, but it is a DirectWrite one, and the remarks on `TranslateHResult` explain why that family
+must not be keyed on the number: `UnhandledErrorDetected` flattens the propagated exception to
+`E_FAIL` while the message keeps the original wording, so these have to be matched as sentences.
+Search for: `font cache`.
+
+### French — missing procedure
+
+```
+La procédure spécifiée est introuvable.
+```
+
+Seen on 12.9.1 as `Exception`, no HRESULT attached. Search for: `specified procedure`.
+
+### Russian — invalid object state
+
+```
+Объект находился в состоянии, недопустимом для обработки метода.
+```
+
+Seen on 12.9.1 as `Exception`, no HRESULT attached. Search for: `state` together with `method`.
+
+### Russian — XAML property value type
+
+```
+Недопустимый тип значения oldValue для этого свойства
+```
+
+Seen on 12.8.1 as `Exception`, as the originating description under an outer
+`The application called an interface that was marshalled for a different thread.` — the outer
+half is already handled. Note there is no full stop at the end; the `case` has to match that.
+This is XAML's own wording rather than a system error, so the English may only ever appear in a
+report from an English install hitting the same XAML failure. Search for: `oldValue`.
+
+## Not fixable by translation
+
+```
+Unspecified error ��� ��Ƽ����Ʈ �ڵ��������� �����ڵ� ������ ������ �����ϴ�.
+```
+
+Seen on 12.8.1 as `Exception`. The Korean text was already mojibake when the report was built —
+the bytes are destroyed, not merely localised — so no `case` can match it and no English target
+would help. It is recorded only so it is not mistaken for a missing translation. If these become
+frequent it is an encoding bug on the reporting path, which is a different change.


### PR DESCRIPTION
Follow-up to #3407. Windows returns system error text in the user's language, and the
grouping hash includes the message, so one fault splits into a group per locale and every
one of them looks small.

Fifteen more sentences, all taken verbatim from reports on 12.8.1 through 12.10.2:

| canonical | added |
|---|---|
| `No such interface supported` | de, sv, cs, pl, zh-TW |
| `The application called an interface that was marshalled for a different thread.` | ko, zh-TW, el |
| `The resource was realized on the wrong render target.` | ko, hu, sv |
| `Invalid window handle.` | es |
| `The operation identifier is not valid.` | es |
| `The operation attempted to access data outside the valid range` | it |
| `Not enough memory resources are available to process this command.` | fr |

The `No such interface supported` ones arrive as `InvalidCastException`, which
`TryTranslateHResult` deliberately declines to rewrite, so they can only be caught by the
sentence. The wrong-thread ones arrive through the `FatalError` path, which passes no
HRESULT and appends none to the message, so the sentence is likewise the only handle on
them.

No English wording was invented. Each target is one the file already emits, and every
added sentence is the exact text a report carried, with the HRESULT suffix stripped the
way `_hresultSuffix` strips it.

### Deliberately not translated

Five more localised sentences are still unmatched, and none of them should be guessed at: a
Portuguese OLE-clipboard message, a German DirectWrite font-cache one (`0x88985007`), a French
"specified procedure" one, a Russian invalid-state one, and a Russian XAML originating
description about `oldValue`. No English report exists for any of them, so there is nothing to
map them onto without making the wording up. One further Korean message arrives mojibake and
cannot be matched at all.

Rather than lose that, they are parked in `notes/untranslated-error-messages.md` with the exact
text to paste, the exception type and version each was seen on, the HRESULT where one was
attached, and the search term to check whether the English has since landed. Adding one is then
a `case` plus deleting its section. `TranslateText` now carries a remarks block pointing at the
note and stating the rule the switch runs on, which was previously only implicit.

Separately, the remaining fragmentation is not localisation: `TdException` SQLite failures embed
the database path, and a path contains the account name, so each is its own group. That needs the
path normalised, which is a different change.

### Verified

I emulated `TranslateMessage` against every distinct message currently on the dashboard.
This takes the untranslatable sentence count from 31 to 17, and of those 17, six are
artifacts of the dashboard joining an exception chain into one line - the leading sentence
in each is already covered.

Not built: no UWP toolchain here. `CSharpSyntaxTree.ParseText` reports no syntax errors,
and I checked separately that none of the added labels duplicate an existing `case`, since
that is a semantic error the parse would not catch.
