### PR TITLE
Don't block the UI thread on the app service bridge lock

### DIFF
--- a/Telegram/Common/BridgeApplicationContext.cs
+++ b/Telegram/Common/BridgeApplicationContext.cs
@@ -28,6 +28,9 @@ namespace Telegram.Common
 
         private static TaskCompletionSource<bool> _connected = new();
 
+        // Every acquisition must be asynchronous: the lock is held across the app service round
+        // trip below, and the UI thread is an ASTA, so blocking it here would stall the very
+        // continuation that releases the lock. COM reports that as "the application is busy".
         private static readonly DisposableMutex _lock = new();
 
         public static async Task AddLoopbackExemptionAsync()
@@ -80,7 +83,7 @@ namespace Telegram.Common
 
             task.Canceled += OnCanceled;
 
-            using (_lock.Wait())
+            using (await _lock.WaitAsync())
             {
                 _connection = connection;
                 _connection.RequestReceived += OnRequestReceived;
@@ -249,7 +252,7 @@ namespace Telegram.Common
             try
             {
                 AppServiceResponse response = null;
-                using (_lock.Wait())
+                using (await _lock.WaitAsync())
                 {
                     var connection = _connection;
                     if (connection == null)
@@ -334,14 +337,14 @@ namespace Telegram.Common
             Cancel();
         }
 
-        private static void Cancel()
+        private static async void Cancel()
         {
             if (AppSettings.Diagnostics.BridgeDebug)
             {
                 Logger.Info();
             }
 
-            using (_lock.Wait())
+            using (await _lock.WaitAsync())
             {
                 if (_connection != null)
                 {


### PR DESCRIPTION
Reported by crash telemetry on 12.10.3.

**COMException** — `The message filter indicated that the application is busy. A COM call (IID: {2DBDBA9D-20DA-519D-9078-09F835BC5BC7}, method index: 3) to an ASTA appears deadlocked and was timed out.`

The UI thread is blocked in `SemaphoreSlim.Wait`, reached from the app service bridge:

```
  16  SemaphoreSlim.WaitUntilCountOrTimeout
  17  SemaphoreSlim.WaitCore
  18  BridgeApplicationContext.SendMessageAsync         BridgeApplicationContext.cs:252
  20  BridgeApplicationContext.SendMessageAsync
  21  BridgeApplicationContext.CheckAuthenticationPasskeyAsync   BridgeApplicationContext.cs:207
  24  DispatcherQueueProxyHandler.Invoke
  ...
  44  CJupiterWindow::RunCoreWindowMessageLoop
```

Below frame 16 the wait descends into `CoWaitForMultipleHandles`, and COM then fires
`ASTAState::HandleQueuedCallTimeoutsAndRelease` on a call queued to this apartment, which is
where the exception is originated.

## Cause

`BridgeApplicationContext._lock` serialises access to the `AppServiceConnection`, and
`SendMessageAsync` **holds it across an `await`** (the `connection.SendMessageAsync(...)` round
trip to `Telegram.Stub`) whose continuation is marshalled back to the UI thread. But the lock was
acquired with the *synchronous* `DisposableMutex.Wait()`.

So when a second caller reaches it on the UI thread, the thread blocks — and the continuation
that would release the lock is queued to that same thread, behind the block. It is not a slow
wait, it is a permanent one. The UI thread is an ASTA and does not pump on
`CoWaitForMultipleHandles`, so COM eventually declares the queued inbound call deadlocked and
raises `RPC_E_SERVERCALL_RETRYLATER` (0x8001010A).

The passkey path is the one that makes this reachable in practice. `CheckAuthenticationPasskeyAsync`
sends with `timeout: 0`, i.e. no timeout at all, because the stub is showing a Windows Hello
prompt and that legitimately takes as long as the user takes. Every other bridge message uses a
500 ms cap, so the contention window is normally too short to notice; here it is unbounded. The
log tail for this report shows `CheckAuthenticationPasskeyAsync` entered twice, ~2.8 s apart,
during repeated log-in attempts.

The same defect sits on the other two acquisitions of the same lock, both reachable from the UI
thread while a passkey request is in flight:

- `Connect` — from `App.OnBackgroundActivated`.
- `Cancel` — from `OnServiceClosed`, i.e. exactly when the stub goes away mid-request.

## Fix

Acquire the lock with `WaitAsync` at all three sites. `Connect` is already `async void` and
`SendMessageAsync` is already `async Task<...>`; `Cancel` becomes `async void`, matching the
idiom already used in the file. `SemaphoreSlim.WaitAsync` completes synchronously when
uncontended, so the uncontended path is unchanged; when contended, the caller yields instead of
pinning the ASTA.

A comment on the field records the constraint, since it is the reason all four call sites must
stay asynchronous.

Not addressed here, and worth a separate look: `AuthorizationViewModel.LoginWithPasskey` is an
unguarded `async void` command, so the button can be pressed again while an assertion is
outstanding. With this change that queues a second request rather than hanging, but it is still
not the behaviour you would want.

**Not built** — no UWP/.NET Native build environment available. The changed file was parsed with
Roslyn (`CSharpSyntaxTree.ParseText`), which confirms it still parses but checks nothing about
types.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Db23nxzGJuNdwoknkKPCR
