### PR TITLE
Read the emoji status once in IdentityIcon

### DIFF
--- a/Telegram/Controls/IdentityIcon.cs
+++ b/Telegram/Controls/IdentityIcon.cs
@@ -107,15 +107,19 @@ namespace Telegram.Controls
             {
                 var status = supergroup.VerificationStatus;
 
-                if (clientService.IsPremiumAvailable && chat.EmojiStatus != null && status.IsFalse())
+                // The cached chat is mutated in place from the TDLib update thread, so the status is
+                // read once: re-reading it after the null check below can hand back null.
+                var emojiStatus = chat.EmojiStatus;
+
+                if (clientService.IsPremiumAvailable && emojiStatus != null && status.IsFalse())
                 {
                     CurrentType = IdentityIconType.None;
                     UnloadTemplateChild(ref Icon);
 
                     LoadTemplateChild(ref Status);
-                    Status.Source = new CustomEmojiFileSource(clientService, chat.EmojiStatus.Type);
+                    Status.Source = new CustomEmojiFileSource(clientService, emojiStatus.Type);
 
-                    if (chat.EmojiStatus.Type is EmojiStatusTypeUpgradedGift upgraded)
+                    if (emojiStatus.Type is EmojiStatusTypeUpgradedGift upgraded)
                     {
                         LoadTemplateChild(ref Particles);
                         Particles.Source = new ParticlesImageSource(upgraded.BackdropColors);
@@ -151,15 +155,19 @@ namespace Telegram.Controls
 
             var status = user.VerificationStatus;
 
-            if (clientService.IsPremiumAvailable && user.EmojiStatus != null && status.IsFalse() && (!chatList || user.Id != clientService.Options.MyId))
+            // The cached user is mutated in place from the TDLib update thread, so the status is
+            // read once: re-reading it after the null check below can hand back null.
+            var emojiStatus = user.EmojiStatus;
+
+            if (clientService.IsPremiumAvailable && emojiStatus != null && status.IsFalse() && (!chatList || user.Id != clientService.Options.MyId))
             {
                 CurrentType = IdentityIconType.Premium;
                 UnloadTemplateChild(ref Icon);
 
                 LoadTemplateChild(ref Status);
-                Status.Source = new CustomEmojiFileSource(clientService, user.EmojiStatus.Type);
+                Status.Source = new CustomEmojiFileSource(clientService, emojiStatus.Type);
 
-                if (user.EmojiStatus.Type is EmojiStatusTypeUpgradedGift upgraded)
+                if (emojiStatus.Type is EmojiStatusTypeUpgradedGift upgraded)
                 {
                     LoadTemplateChild(ref Particles);
                     Particles.Source = new ParticlesImageSource(upgraded.BackdropColors);


### PR DESCRIPTION
`FailFastException` — `Fail-fast with HRESULT 0x80004003`, managed exit point
`Object reference not set to an instance of an object.` Reported by crash telemetry on
12.10.3.0 (X64).

```
   5  S_P_CoreLib_System_Runtime_EH__RhThrowHwEx+0xf6
   6  RhpThrowHwEx2+0x0
   7  Telegram_Telegram_Controls_IdentityIcon__SetStatus_1+0x2b5
      Telegram/Controls/IdentityIcon.cs:162
   8  Telegram_Telegram_Controls_Cells_ChatCell__UpdateChatEmojiStatus+0x140
      Telegram/Controls/Cells/ChatCell.xaml.cs:943
   9  Telegram_Telegram_Views_MainPage__Handle_25+0x23d
      Telegram/Views/MainPage.xaml.cs:629
  10  Telegram_Telegram_Collections_DispatcherDrain_1<...UpdateChatCell>__Drain+0x103
      Telegram/Collections/DispatcherDrain.cs:96
  11  Microsoft_Windows_SDK_NET_ABI_Windows_System_DispatcherQueueHandler__Do_Abi_Invoke+0x46
```

All 41 frames resolved. The fail-fast is only the NRE escaping the
`DispatcherQueueHandler` ABI boundary in `DispatcherDrain.Drain`; the fault itself is
frame 7, a hardware null dereference.

## Cause

`IdentityIcon.SetStatus` reads `user.EmojiStatus` three times — once for the null check,
then twice for `.Type`:

```csharp
if (clientService.IsPremiumAvailable && user.EmojiStatus != null && status.IsFalse() && ...)
{
    ...
    Status.Source = new CustomEmojiFileSource(clientService, user.EmojiStatus.Type);

    if (user.EmojiStatus.Type is EmojiStatusTypeUpgradedGift upgraded)
```

Cached `User` and `Chat` objects are **mutated in place**, not replaced —
`ClientService.OnResult` does `value.Update(updateUser.User)` (which assigns
`EmojiStatus`) for `updateUser`, and `value.EmojiStatus = ...` for
`updateChatEmojiStatus`. `OnResult` runs on the dedicated TDLib receive thread
(`Client.Run`), while `SetStatus` runs on the UI thread.

So the reads are not repeatable. The calls between them stop the compiler caching the
field, and if the user clears or changes their emoji status in that window the last read
returns null and the dereference faults — which is exactly the reported line.

That also fits the shape of the reports: it is rare and non-deterministic, whereas this
path runs constantly.

## Fix

Read the status once into a local, the way `VerificationStatus` already is in the same
methods, in both the `Chat` and the `User` overload.

Not built or run — a UWP/.NET Native build was not available here. Roslyn parses the file
with no syntax diagnostics; that does not check types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyGPvi6AuhUi8GaDmWAkZ3
