### PR TITLE
Don't assume EnsureCoreWebView2Async created a CoreWebView2

### DIFF
--- a/Telegram/Views/Host/RichTextWindow.xaml
+++ b/Telegram/Views/Host/RichTextWindow.xaml
@@ -168,7 +168,7 @@
 
     </controls:WindowContent.Resources>
 
-    <Grid>
+    <Grid x:Name="LayoutRoot">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition />

--- a/Telegram/Views/Host/RichTextWindow.xaml.cs
+++ b/Telegram/Views/Host/RichTextWindow.xaml.cs
@@ -118,6 +118,24 @@ namespace Telegram.Views.Host
         {
             await View.EnsureCoreWebView2Async();
 
+            // EnsureCoreWebView2Async doesn't throw when the environment can't be created - the WebView2
+            // runtime being absent is the usual reason: WebView2 swallows the error, reports it through
+            // CoreWebView2Initialized and leaves CoreWebView2 null, having put its own "download the
+            // runtime" message in the control. Nothing below can work, so uncover that message and stop:
+            // the chrome would otherwise sit over it with every button reaching a null CoreWebView2.
+            if (View.CoreWebView2 == null)
+            {
+                foreach (var child in LayoutRoot.Children)
+                {
+                    if (child != View)
+                    {
+                        child.Visibility = Visibility.Collapsed;
+                    }
+                }
+
+                return;
+            }
+
             _state = new RichEditorState();
             _commands = new RichEditorCommands(View.CoreWebView2);
 


### PR DESCRIPTION
`NullReferenceException` — "Object reference not set to an instance of an object.", reported by crash telemetry on 12.10.2.0 (X64). Fatal: it comes out of an `async void`, so it reaches `WatchDog` and takes the app down.

```
--- Inner exception: NullReferenceException ---
   0  Telegram_Telegram_Views_Host_RichTextWindow__Initialize_d__13__MoveNext+0x12b
      Telegram\Views\Host\RichTextWindow.xaml.cs:125
   1  System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw
   2  System.Threading.Tasks.Task.<>c.<ThrowAsync>b__124_0
   3  Microsoft.Windows.UI.Xaml.ABI.Windows.System.DispatcherQueueProxyHandler.Invoke
```

Line 125 is `View.CoreWebView2.SetVirtualHostNameToFolderMapping(...)`, the first dereference after `await View.EnsureCoreWebView2Async()`. The log tail shows the crash right after `ViewService.OpenAsyncInternal` created the editor's window,.

## Cause

`EnsureCoreWebView2Async()` completing does **not** mean a `CoreWebView2` exists. WinUI 2's `WebView2` swallows environment-creation failures — `CreateCoreEnvironment` is a `noexcept` coroutine whose `catch (hresult_error)` only records the HRESULT and calls `FireCoreWebView2Initialized(hr)`; `CreateCoreObjects` then skips creating the controller because `m_coreWebViewEnvironment` is null, and `EnsureCoreWebView2Async` returns normally with `CoreWebView2 == null`. When the HRESULT is `ERROR_FILE_NOT_FOUND` — no WebView2 runtime installed — it also replaces the control's content with its own "no suitable WebView2 found / download the runtime" message.

So the failure is reported through `CoreWebView2Initialized`'s `Exception` and through a null `CoreWebView2`, never as a thrown await. `ChromiumWebPresenter.OnApplyTemplate` in `WebViewer.cs` already accounts for this (`if (View.CoreWebView2 != null) … else Initialize(false)`, which falls back to `EdgeWebPresenter`); `RichTextWindow.Initialize` did not.

## Fix

Guard the call site. There's no fallback for this window — the rich editor is ProseMirror in the WebView2, and `SetVirtualHostNameToFolderMapping` is WebView2-only — so it collapses the editor chrome and returns, leaving WebView2's own runtime-missing message visible.

Collapsing matters: returning alone would leave the toolbars sitting over that message with a null `_commands`, so the first button press would be the same crash again. Everything else that can run without `Initialize` completing (`OnWindowCloseRequested`, `UpdateSendLock`, `UpdateTheme`) is already null-safe, and nothing subscribes to the core's events or navigates, so no web messages arrive.

## Build

Not built — no UWP/.NET Native build environment here. `CSharpSyntaxTree.ParseText` on the changed file reports no diagnostics and the XAML parses; that catches syntax, not type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9Xkx3hChHMVbhUC7vsE1c
