### PR TITLE
Fix operator precedence in the FocusText XamlRoot guard

### DIFF
--- a/Telegram/Views/ChatView.xaml.cs
+++ b/Telegram/Views/ChatView.xaml.cs
@@ -295,7 +295,7 @@ namespace Telegram.Views
 
         private void FocusText(FocusState state)
         {
-            if (XamlRoot != null && state == FocusState.Keyboard || state == FocusState.Programmatic)
+            if (XamlRoot != null && (state == FocusState.Keyboard || state == FocusState.Programmatic))
             {
                 var popups = VisualTreeHelper.GetOpenPopupsForXamlRoot(XamlRoot);
                 if (popups.Count > 0)


### PR DESCRIPTION
Reported by crash telemetry on 12.10.3.0.

```
ArgumentException: The parameter is incorrect. xamlRoot

DirectUI::VisualTreeHelper::GetOpenPopupsForXamlRoot
  onecoreuap\windows\dxaml\xcp\dxaml\lib\visualtreehelper.cpp:215
ABI.Windows.UI.Xaml.Media.IVisualTreeHelperStatics3Methods.GetOpenPopupsForXamlRoot
Telegram.Views.ChatView.FocusText            Telegram/Views/ChatView.xaml.cs:300
Telegram.Common.DebouncedProperty`1.OnTick   Telegram/Common/DebouncedProperty.cs:82
```

### Cause

`FocusText` guards the `GetOpenPopupsForXamlRoot` call with

```csharp
if (XamlRoot != null && state == FocusState.Keyboard || state == FocusState.Programmatic)
```

`&&` binds tighter than `||`, so this is `(XamlRoot != null && Keyboard) || Programmatic`: the
null check only ever applies to the keyboard case. A `Programmatic` request reaches
`GetOpenPopupsForXamlRoot(null)`, which the framework rejects with E_INVALIDARG.

The guard was added in 58088ca3f together with the call it protects — it was prefixed onto the
existing `Keyboard || Programmatic` condition without parentheses, so it has never applied to
the state that all of the internal focus requests use.

### How the XamlRoot ends up null

The log tail ends with the chat-list hover preview:

```
[…285.867][ChatCell.xaml.cs:2086][ShowPreview]
[…286.400][ChatView.xaml.cs:723][Activate]
[…286.520][ChatCell.xaml.cs:2129][ShowPreview] Closed
```

`ChatCell.ShowPreview` builds a throwaway `ChatView` and hosts it in a `MenuFlyout`.
`Activate` ends at `TrySetFocusState(FocusState.Programmatic, false)`, which arms the 100 ms
debounce; the flyout closed 120 ms later, and `Deactivate` does not cancel the timer. The tick
therefore runs on a `ChatView` that is in no visual tree, so `XamlRoot` is null.

While the flyout is still open the existing `popups.Count > 0` check already stops the focus
call, so the null window is the only case left uncovered — which is exactly what the guard was
written for.

### Fix

Parenthesise the condition so the null check applies to both states.

### Testing

Not built or run — no UWP/.NET Native build environment available here. The change is a single
pair of parentheses on one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyGPvi6AuhUi8GaDmWAkZ3
