### PR TITLE
Use the window's XamlRoot to find the share popup

### DIFF
--- a/Telegram/Views/Host/ShareWindow.xaml.cs
+++ b/Telegram/Views/Host/ShareWindow.xaml.cs
@@ -79,7 +79,9 @@ namespace Telegram.Views.Host
 
         private void OnAccountClick(object sender, EventArgs e)
         {
-            foreach (var popup in VisualTreeHelper.GetOpenPopupsForXamlRoot(XamlRoot))
+            // The window's XamlRoot, not this control's: the passcode lock swaps the window
+            // content out, so this root is detached - and its XamlRoot null - while it is up.
+            foreach (var popup in VisualTreeHelper.GetOpenPopupsForXamlRoot(Window.XamlRoot))
             {
                 if (popup.Child is ChooseChatsPopup chooseChats && chooseChats.ViewModel.Configuration is ChooseChatsConfigurationShareOperation shareOperation)
                 {


### PR DESCRIPTION
Reported by crash telemetry on 12.10.2.0.

```
ArgumentException: The parameter is incorrect. xamlRoot

DirectUI::VisualTreeHelper::GetOpenPopupsForXamlRoot
  onecoreuap\windows\dxaml\xcp\dxaml\lib\visualtreehelper.cpp:215
ABI.Windows.UI.Xaml.Media.IVisualTreeHelperStatics3Methods.GetOpenPopupsForXamlRoot
Telegram.Views.Host.ShareWindow.OnAccountClick    Telegram/Views/Host/ShareWindow.xaml.cs:82
Telegram.Views.Popups.ChooseChatsPopup.Account_Click
                                                  Telegram/Views/Popups/ChooseChatsPopup.xaml.cs:2256
DirectUI::MenuFlyoutItem::Invoke
DirectUI::MenuFlyoutItem::OnPointerReleased
CInputServices::RaiseDelayedPointerUpEvent
```

Same message as #3420, different site — that one was `ChatView.FocusText`.

### Cause

`OnAccountClick` passes its own `XamlRoot`, and `ShareWindow` is not in the visual tree when the
handler runs, so it passes null and the framework rejects it with E_INVALIDARG.

The log tail shows why:

```
[…319,150][BootStrapper.cs:467][InitializeFrame] Kind: ShareTarget
[…319,152][WindowContext.cs:1002][Lock] Showing passcode lock
[…319,239][ContentPopup.cs:354][ShowQueuedAsync] ChooseChatsPopup
[…321,002][PasscodeWindow.xaml.cs:79][Field_LosingFocus] canceled
```

`WindowContext.Lock` swaps the window's content for the `PasscodeWindow`
(`_lockedContent = _content?.Content`, then `SetContent(_locked)`). The `ShareWindow` is
therefore detached for as long as the passcode is up, and a detached root has a null `XamlRoot`.
The `ChooseChatsPopup` it opened lives on the window's popup root rather than under the content,
so it stays up and interactive, and tapping an account in its flyout reaches this handler.

`WindowContent` already documents this and holds the reliable handle:

> The window this is the root of. Required at construction rather than resolved from the
> XamlRoot: every root is created with `new` and never reparented, and XamlRoot is null until
> the content is in a tree — which is later than some roots need it.

### Fix

Enumerate the popups on `Window.XamlRoot`. That is the `WindowPresenter`'s root, which stays in
the tree across the content swap, and it is the root the popup was shown on in the first place.
With no passcode the two are the same object, so the only behaviour that changes is the locked
case — which previously always threw.

### Not fixed here

The trace also shows the chat chooser being shown *over* the passcode prompt: `Lock` runs before
`ShareWindow.Activate`, and `Lock` does not close or block popups. That is a separate issue and a
design decision, so it is left alone.

### Testing

Not built or run — no UWP/.NET Native build environment available here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyGPvi6AuhUi8GaDmWAkZ3
