### PR TITLE
Fix crash when a window thumbnail is sized after the window is unrooted

### DIFF
--- a/Telegram.Native/Composition/WindowVisual.cpp
+++ b/Telegram.Native/Composition/WindowVisual.cpp
@@ -301,10 +301,15 @@ namespace winrt::Telegram::Native::Composition::implementation
             return result;
         }
 
-        UIElement content = Window::Current().Content();
-        if (content.XamlRoot())
+        // A consolidated view unroots its tree, so Window.Content is null for as long as
+        // the window is torn down - and the capture picker lives in the popup root, which
+        // outlives that and keeps laying its cells out.
+        if (UIElement content = Window::Current().Content())
         {
-            size->z = content.XamlRoot().RasterizationScale() * 2;
+            if (XamlRoot xamlRoot = content.XamlRoot())
+            {
+                size->z = xamlRoot.RasterizationScale() * 2;
+            }
         }
 
         double ratioX = (size->x * size->z) / windowSize.cx;


### PR DESCRIPTION
`FailFastException` — `Fail-fast 0xC0000005`, reported by crash telemetry on 12.10.3.0 (X64).

```
   8  winrt::impl::abi<winrt::Windows::UI::Xaml::IUIElementOverrides,void>::type::`vcall'{64}'+0x0
   9  winrt::impl::consume_Windows_UI_Xaml_IUIElement10<winrt::Windows::UI::Xaml::UIElement>::XamlRoot+0x99
  10  winrt::Telegram::Native::Composition::implementation::WindowVisual::GetScaledWindowSize+0x111
      Telegram.Native\Composition\WindowVisual.cpp:305
  11  winrt::impl::produce<...WindowVisual,...IWindowVisual>::put_Size+0xd7
  12  Telegram_Telegram_Controls_Cells_CaptureSessionItemCell__OnSizeChanged+0x168
      Telegram\Controls\Cells\CaptureSessionItemCell.xaml.cs:75
  13  Microsoft_Windows_UI_Xaml_ABI_Windows_UI_Xaml_SizeChangedEventHandler__Do_Abi_Invoke+0x6e
  ...
  15  DirectUI::FrameworkElement::OnSizeChanged+0x3a
  17  CLayoutManager::RaiseSizeChangedEvents+0x221
  18  CLayoutManager::UpdateLayout+0x904
```

## Cause

`GetScaledWindowSize` reads the rasterization scale off `Window::Current().Content().XamlRoot()`
without checking that there is any content. `Window.Content` is null while a window is being torn
down: `WindowContext.OnConsolidated` unroots the tree on purpose (`_window.Content = null`, so the
collect in `OnShutdownStarting` has something to hand back), and `ViewLifetimeControl` does the
same before closing a view.

`ChooseCapturePopup` is what keeps calling in after that. Its cells hold a `WindowVisual` whose
`Size` setter runs from `SizeChanged`, and the popup lives in the popup root rather than under
`Window.Content` — so unrooting the window does not take it down. The next layout tick still
raises `SizeChanged` on the cells, `Window::Current().Content()` is null by then, and
`content.XamlRoot()` dereferences it. The report agrees: it has no call in progress, on a stack
only the screen-share picker can reach.

## Fix

Guard the content, and read `XamlRoot` once instead of twice. With no content the scale keeps its
default, which only ever applies to a window on its way out.

**Not built.** There is no UWP/.NET Native build environment here, so this has not been compiled
or run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbbTo8qDByEjQnho3LyBUe
