### PR TITLE
Fix crash when a window thumbnail is sized after the window is unrooted

### DIFF
--- a/Telegram.Native/Composition/WindowVisual.cpp
+++ b/Telegram.Native/Composition/WindowVisual.cpp
@@ -291,6 +291,11 @@ namespace winrt::Telegram::Native::Composition::implementation
     {
         const static auto lDwmpQueryWindowThumbnailSourceSize = (DwmpQueryWindowThumbnailSourceSize)GetProcAddress(GetDwmApi(), MAKEINTRESOURCEA(162));
 
+        // Both callers hand thumb straight to DWM without looking at the result, so it has
+        // to be safe to pass on when this returns early - a minimized or cloaked window
+        // reports no size at all.
+        thumb = {};
+
         SIZE windowSize{};
         HRESULT result = lDwmpQueryWindowThumbnailSourceSize(window, false, &windowSize);
 
@@ -308,7 +313,6 @@ namespace winrt::Telegram::Native::Composition::implementation
         long width = windowSize.cx * ratio;
         long height = windowSize.cy * ratio;
 
-        thumb = {};
         thumb.dwFlags = DWM_TNP_VISIBLE | DWM_TNP_RECTDESTINATION | DWM_TNP_OPACITY | DWM_TNP_ENABLE3D;
         thumb.opacity = 255;
         thumb.fVisible = TRUE;

--- a/Telegram.Native/Composition/WindowVisual.cpp
+++ b/Telegram.Native/Composition/WindowVisual.cpp
@@ -203,7 +203,7 @@ namespace winrt::Telegram::Native::Composition::implementation
         return windowId;
     }
 
-    winrt::Telegram::Native::Composition::WindowVisual WindowVisual::Create(WindowId windowId)
+    winrt::Telegram::Native::Composition::WindowVisual WindowVisual::Create(WindowId windowId, float rasterizationScale)
     {
         const static auto lDwmpQueryWindowThumbnailSourceSize = (DwmpQueryWindowThumbnailSourceSize)GetProcAddress(GetDwmApi(), MAKEINTRESOURCEA(162));
         const static auto lDwmpCreateSharedThumbnailVisual = (DwmpCreateSharedThumbnailVisual)GetProcAddress(GetDwmApi(), MAKEINTRESOURCEA(147));
@@ -223,7 +223,7 @@ namespace winrt::Telegram::Native::Composition::implementation
         winrt::com_ptr<IDCompositionDevice3> dcompDevice = compositor.as<IDCompositionDevice3>();
         winrt::com_ptr<IDCompositionVisual2> windowVisual;
 
-        float3 size(320, 320, 1);
+        float3 size(320, 320, rasterizationScale);
         DWM_THUMBNAIL_PROPERTIES thumb;
         result = GetScaledWindowSize(destination, &size, thumb);
 
@@ -236,16 +236,17 @@ namespace winrt::Telegram::Native::Composition::implementation
         }
 
         auto visual = windowVisual.as<Visual>();
-        auto window = winrt::make_self<WindowVisual>(source, thumbnail, visual, size);
+        auto window = winrt::make_self<WindowVisual>(source, thumbnail, visual, size, rasterizationScale);
 
         return window.as<winrt::Telegram::Native::Composition::WindowVisual>();
     }
 
-    WindowVisual::WindowVisual(HWND window, HTHUMBNAIL thumbnail, Visual visual, float3 size)
+    WindowVisual::WindowVisual(HWND window, HTHUMBNAIL thumbnail, Visual visual, float3 size, float scale)
         : m_window(window)
         , m_thumbnail(thumbnail)
         , m_visual(visual)
         , m_size(float2(size.x, size.y))
+        , m_scale(scale)
     {
         m_visual.Scale(float3(size.z));
     }
@@ -266,16 +267,17 @@ namespace winrt::Telegram::Native::Composition::implementation
         return m_visual;
     }
 
-    float2 WindowVisual::Size()
+    float3 WindowVisual::Size()
     {
-        return m_size;
+        return float3(m_size, m_scale);
     }
 
-    void WindowVisual::Size(float2 value)
+    void WindowVisual::Size(float3 value)
     {
         const static auto lDwmUpdateThumbnailProperties = (DwmUpdateThumbnailProperties)GetProcAddress(GetDwmApi(), "DwmUpdateThumbnailProperties");
 
-        float3 size(value.x, value.y, 1);
+        float2 available(value.x, value.y);
+        float3 size = value;
 
         DWM_THUMBNAIL_PROPERTIES thumb;
         HRESULT result = GetScaledWindowSize(m_window, &size, thumb);
@@ -284,11 +286,14 @@ namespace winrt::Telegram::Native::Composition::implementation
         if (result == S_OK)
         {
             m_size = float2(size.x, size.y);
-            m_visual.Offset(float3((value - m_size) / 2, 0));
+            m_scale = value.z;
+            m_visual.Offset(float3((available - m_size) / 2, 0));
             m_visual.Scale(float3(size.z));
         }
     }
 
+    // size->z carries the rasterization scale of whatever shows the thumbnail on the way in,
+    // and the reciprocal of the factor it was rasterized at on the way out.
     HRESULT WindowVisual::GetScaledWindowSize(HWND window, float3* size, DWM_THUMBNAIL_PROPERTIES& thumb)
     {
         const static auto lDwmpQueryWindowThumbnailSourceSize = (DwmpQueryWindowThumbnailSourceSize)GetProcAddress(GetDwmApi(), MAKEINTRESOURCEA(162));
@@ -301,11 +306,7 @@ namespace winrt::Telegram::Native::Composition::implementation
             return result;
         }
 
-        UIElement content = Window::Current().Content();
-        if (content.XamlRoot())
-        {
-            size->z = content.XamlRoot().RasterizationScale() * 2;
-        }
+        size->z *= 2;
 
         double ratioX = (size->x * size->z) / windowSize.cx;
         double ratioY = (size->y * size->z) / windowSize.cy;

--- a/Telegram.Native/Composition/WindowVisual.cpp
+++ b/Telegram.Native/Composition/WindowVisual.cpp
@@ -203,20 +203,13 @@ namespace winrt::Telegram::Native::Composition::implementation
         return windowId;
     }
 
-    winrt::Telegram::Native::Composition::WindowVisual WindowVisual::Create(WindowId windowId, float rasterizationScale)
+    winrt::Telegram::Native::Composition::WindowVisual WindowVisual::Create(WindowId windowId, WindowId destinationId, Compositor compositor, float rasterizationScale)
     {
-        const static auto lDwmpQueryWindowThumbnailSourceSize = (DwmpQueryWindowThumbnailSourceSize)GetProcAddress(GetDwmApi(), MAKEINTRESOURCEA(162));
         const static auto lDwmpCreateSharedThumbnailVisual = (DwmpCreateSharedThumbnailVisual)GetProcAddress(GetDwmApi(), MAKEINTRESOURCEA(147));
         const static auto GetParent = (pGetParent)GetProcAddress(GetUser32(), "GetParent");
 
-        Compositor compositor = Window::Current().Compositor();
-        CoreWindow coreWnd = Window::Current().CoreWindow();
-
-        winrt::com_ptr<ICoreWindowInterop> interop = coreWnd.as<ICoreWindowInterop>();
-
-        HWND destination;
         HWND source = (HWND)windowId.Value;
-        interop->get_WindowHandle(&destination);
+        HWND destination = (HWND)destinationId.Value;
 
         HRESULT result;
 

--- a/Telegram.Native/Composition/WindowVisual.h
+++ b/Telegram.Native/Composition/WindowVisual.h
@@ -16,18 +16,18 @@ namespace winrt::Telegram::Native::Composition::implementation
     struct WindowVisual : WindowVisualT<WindowVisual>
     {
         static bool IsValid(WindowId windowId, hstring& title);
-        static winrt::Telegram::Native::Composition::WindowVisual Create(WindowId windowId);
+        static winrt::Telegram::Native::Composition::WindowVisual Create(WindowId windowId, float rasterizationScale);
 
         static uint32_t GetWindowProcessId(WindowId windowId);
         static WindowId GetCurrentWindowId();
 
-        WindowVisual(HWND window, HTHUMBNAIL thumbnail, Visual visual, float3 size);
+        WindowVisual(HWND window, HTHUMBNAIL thumbnail, Visual visual, float3 size, float scale);
         ~WindowVisual();
 
         Visual Child();
 
-        float2 Size();
-        void Size(float2 value);
+        float3 Size();
+        void Size(float3 value);
 
     private:
         static HRESULT GetScaledWindowSize(HWND window, float3* size, DWM_THUMBNAIL_PROPERTIES& thumb);
@@ -36,6 +36,7 @@ namespace winrt::Telegram::Native::Composition::implementation
         HTHUMBNAIL m_thumbnail;
 
         float2 m_size;
+        float m_scale;
         Visual m_visual;
     };
 }

--- a/Telegram.Native/Composition/WindowVisual.h
+++ b/Telegram.Native/Composition/WindowVisual.h
@@ -16,7 +16,7 @@ namespace winrt::Telegram::Native::Composition::implementation
     struct WindowVisual : WindowVisualT<WindowVisual>
     {
         static bool IsValid(WindowId windowId, hstring& title);
-        static winrt::Telegram::Native::Composition::WindowVisual Create(WindowId windowId, float rasterizationScale);
+        static winrt::Telegram::Native::Composition::WindowVisual Create(WindowId windowId, WindowId destinationId, Compositor compositor, float rasterizationScale);
 
         static uint32_t GetWindowProcessId(WindowId windowId);
         static WindowId GetCurrentWindowId();

--- a/Telegram.Native/Composition/WindowVisual.idl
+++ b/Telegram.Native/Composition/WindowVisual.idl
@@ -4,7 +4,7 @@ namespace Telegram.Native.Composition
     runtimeclass WindowVisual
     {
         static Boolean IsValid(Windows.UI.WindowId windowId, out String title);
-        static WindowVisual Create(Windows.UI.WindowId windowId, Single rasterizationScale);
+        static WindowVisual Create(Windows.UI.WindowId windowId, Windows.UI.WindowId destinationId, Windows.UI.Composition.Compositor compositor, Single rasterizationScale);
 
         static UInt32 GetWindowProcessId(Windows.UI.WindowId windowId);
         static Windows.UI.WindowId GetCurrentWindowId();

--- a/Telegram.Native/Composition/WindowVisual.idl
+++ b/Telegram.Native/Composition/WindowVisual.idl
@@ -4,12 +4,14 @@ namespace Telegram.Native.Composition
     runtimeclass WindowVisual
     {
         static Boolean IsValid(Windows.UI.WindowId windowId, out String title);
-        static WindowVisual Create(Windows.UI.WindowId windowId);
+        static WindowVisual Create(Windows.UI.WindowId windowId, Single rasterizationScale);
 
         static UInt32 GetWindowProcessId(Windows.UI.WindowId windowId);
         static Windows.UI.WindowId GetCurrentWindowId();
 
         Windows.UI.Composition.Visual Child{ get; };
-        Windows.Foundation.Numerics.Vector2 Size;
+        // Z carries the rasterization scale of the element showing the thumbnail: DWM
+        // rasterizes it in physical pixels, and the visual has no way of asking.
+        Windows.Foundation.Numerics.Vector3 Size;
     }
 }

--- a/Telegram/Controls/Cells/CaptureSessionItemCell.xaml.cs
+++ b/Telegram/Controls/Cells/CaptureSessionItemCell.xaml.cs
@@ -41,7 +41,9 @@ namespace Telegram.Controls.Cells
 
                 if (item is WindowCaptureSessionItem window)
                 {
-                    _windowVisual = WindowVisual.Create(window.WindowId, (float)XamlRoot.RasterizationScale);
+                    var destination = new WindowId { Value = (ulong)WindowContext.GetWindowHandle(XamlRoot).ToInt64() };
+
+                    _windowVisual = WindowVisual.Create(window.WindowId, destination, BootStrapper.Current.Compositor, (float)XamlRoot.RasterizationScale);
                     _displayVisual = null;
 
                     if (_windowVisual != null)

--- a/Telegram/Controls/Cells/CaptureSessionItemCell.xaml.cs
+++ b/Telegram/Controls/Cells/CaptureSessionItemCell.xaml.cs
@@ -41,7 +41,7 @@ namespace Telegram.Controls.Cells
 
                 if (item is WindowCaptureSessionItem window)
                 {
-                    _windowVisual = WindowVisual.Create(window.WindowId);
+                    _windowVisual = WindowVisual.Create(window.WindowId, (float)XamlRoot.RasterizationScale);
                     _displayVisual = null;
 
                     if (_windowVisual != null)
@@ -72,7 +72,13 @@ namespace Telegram.Controls.Cells
         {
             if (_windowVisual != null)
             {
-                _windowVisual.Size = e.NewSize.ToVector2();
+                // DWM rasterizes the thumbnail in physical pixels, so the visual needs the scale
+                // handed to it. An element that has left the tree has no XamlRoot to ask, and
+                // nothing to show it in either.
+                if (XamlRoot is XamlRoot xamlRoot)
+                {
+                    _windowVisual.Size = new Vector3(e.NewSize.ToVector2(), (float)xamlRoot.RasterizationScale);
+                }
             }
             else
             {


### PR DESCRIPTION
`FailFastException` — `Fail-fast 0xC0000005`, reported by crash telemetry on 12.10.3.0 (X64).

```
   8  winrt::impl::abi<winrt::Windows::UI::Xaml::IUIElementOverrides,void>::type::`vcall'{64}'+0x0
   9  winrt::impl::consume_Windows_UI_Xaml_IUIElement10<winrt::Windows::UI::Xaml::UIElement>::XamlRoot+0x99
  10  winrt::Telegram::Native::Composition::implementation::WindowVisual::GetScaledWindowSize+0x111
      Telegram.Native\Composition\WindowVisual.cpp:305
  11  winrt::impl::produce<...WindowVisual,...IWindowVisual>::put_Size+0xd7
  12  Telegram_Telegram_Controls_Cells_CaptureSessionItemCell__OnSizeChanged+0x168
      Telegram\Controls\Cells\CaptureSessionItemCell.xaml.cs:75
  13  Microsoft_Windows_UI_Xaml_ABI_Windows_UI_Xaml_SizeChangedEventHandler__Do_Abi_Invoke+0x6e
  ...
  15  DirectUI::FrameworkElement::OnSizeChanged+0x3a
  17  CLayoutManager::RaiseSizeChangedEvents+0x221
  18  CLayoutManager::UpdateLayout+0x904
```

## Cause

`GetScaledWindowSize` went and found a rasterization scale for itself, through
`Window::Current().Content().XamlRoot()`, without checking that there was any content to ask.
`Window.Content` is null while a window is torn down: `WindowContext.OnConsolidated` unroots the
tree on purpose (`_window.Content = null`, so the collect in `OnShutdownStarting` has something to
hand back), and `ViewLifetimeControl` does the same before closing a view.

`ChooseCapturePopup` is what keeps calling in after that. Its cells own a `WindowVisual` driven
from `SizeChanged`, and the popup lives in the popup root rather than under `Window.Content`, so
unrooting the window does not take it down. The next layout tick still raises `SizeChanged` on the
cells, `Content()` is null by then, and `content.XamlRoot()` dereferences it. The report agrees: it
has no call in progress, on a stack only the screen-share picker can reach.

## Fix

The scale comes from the caller now. `WindowVisual.Size` is a `Vector3` whose Z is the rasterization
scale of the element showing the thumbnail, `Create` takes it as an argument, and
`GetScaledWindowSize` just doubles what it was handed. `CaptureSessionItemCell` reads it off its own
`XamlRoot` — which is the right window's scale rather than the current thread's, and is null exactly
when the cell has left the tree and has nothing to show anyway.

`Create` is plumbed the same way: it takes the host window and the compositor as arguments instead
of finding them itself, and `CaptureSessionItemCell` resolves the handle through
`WindowContext.GetWindowHandle(XamlRoot)` — the same CoreWindow HWND `Create` used to reach for, and
the one belonging to the window the cell is actually in.

One `Window::Current()` is left in the file, in `GetCurrentWindowId`, which
`CaptureSessionService.FindAllTopLevelWindowIds` uses to skip our own window. That one needs a
XamlRoot threaded down through `FindAll` and into `ChooseCapturePopup`'s constructor, which has none
at the point it builds the list; it is a separate change and is not attempted here.

The last commit is unrelated to the crash but sits in the same function: `GetScaledWindowSize` filled
`thumb` in only on its success path, and both callers hand it to DWM regardless of the HRESULT, so a
minimized or cloaked window meant a stack-garbage `DWM_THUMBNAIL_PROPERTIES` going over the wire.
Zeroing it up front makes the early returns a no-op instead. Happy to drop that commit if you would
rather keep this to the crash.

Supersedes #3422, which guarded the null instead of removing the lookup.

**Not built.** There is no UWP/.NET Native build environment here, so this has not been compiled or
run — and it changes the IDL, so it needs one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbbTo8qDByEjQnho3LyBUe
