### PR TITLE
Don't update the detail header before the template is applied

### DIFF
--- a/Telegram/Controls/MasterDetailView.cs
+++ b/Telegram/Controls/MasterDetailView.cs
@@ -774,6 +774,13 @@ namespace Telegram.Controls
 
         private void OnBackStackChanged(object sender, EventArgs e)
         {
+            // The template parts do not exist yet, and OnApplyTemplate replays the current
+            // content once they do.
+            if (!_templateApplied)
+            {
+                return;
+            }
+
             if (DetailFrame.Content is HostedPage hosted && hosted.ShowHeader && !string.IsNullOrEmpty(hosted.Title))
             {
                 DetailHeaderPresenter.Text = hosted.Title;


### PR DESCRIPTION
`NullReferenceException` — "Object reference not set to an instance of an object.", reported by crash telemetry on 12.10.3.0.

```
   0  Telegram.Controls.MasterDetailView.OnBackStackChanged
      Telegram/Controls/MasterDetailView.cs:783
   1  Telegram.Views.MainPage.<ProcessChatCommands>d__102.MoveNext
      Telegram/Views/MainPage.xaml.cs:1634
```

## Cause

`MasterDetailView.OnBackStackChanged` writes `DetailHeaderPresenter.Text`, and
`DetailHeaderPresenter` is a template part — it is null until `OnApplyTemplate` runs.
`OnNavigated` already knows this and returns early when `!_templateApplied`, because
`OnApplyTemplate` replays the current content itself once the parts exist.
`OnBackStackChanged` was never given the same guard, so anything that changes the back
stack before the template is applied crashes.

That window is reachable: the passcode lock replaces the window content with
`PasscodeWindow`, so `RootWindow` — and the `MainPage` in its frame — is never in the live
tree and `MasterDetailView` never gets a template. Keyboard shortcuts keep being
dispatched to that detached `MainPage` all the same (`RootWindow.OnShortcutInvoked` only
checks `Frame.Content is MainPage`), so Ctrl+0 on the passcode screen runs the `ChatSelf`
branch, which navigates and then calls `GoBackAt(0, false)` — and `GoBackAt` raises
`BackStackChanged` on the non-back path.

The log tail matches: "Showing passcode lock" before `MainPage` is created, a navigation to
`ChatPage` two seconds later, and `ChatHistoryView` reporting `ScrollingHost == null` —
that view has no template either.

## Fix

Give `OnBackStackChanged` the same `_templateApplied` guard as `OnNavigated`. Nothing is
lost by skipping it: `OnApplyTemplate` re-invokes `OnNavigated` with the frame's current
content, which sets the header text.

Not addressed here: that shortcuts act on the hidden session while the passcode lock is up
is a separate bug.

Not compiled — no UWP/.NET Native build environment available.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Fc8jHG7EH6fKFrKEag2Gs
