### PR TITLE
Stop retrying a media block the fetch never fills

### DIFF
--- a/Telegram/Collections/Experimental/ItemCacheManager.cs
+++ b/Telegram/Collections/Experimental/ItemCacheManager.cs
@@ -331,6 +331,10 @@ namespace Telegram.Collections
                             }
                         }
 
+                        // Retire the whole block that was asked for, not only what came back:
+                        // a failed or short response covers less than the request, and leaving
+                        // the remainder pending makes the retry below ask for it again forever.
+                        _requests.Subtract(nextRequest);
                         _requests.Subtract(data.Range);
                     }
                 }

--- a/Telegram/Collections/Experimental/MediaDataSource.cs
+++ b/Telegram/Collections/Experimental/MediaDataSource.cs
@@ -357,9 +357,9 @@ namespace Telegram.Collections
                     messages.Add(new MessageWithOwner(_clientService, foundChatMessages.Messages[i]));
                 }
             }
-            else
+            else if (response is Error error)
             {
-                Logger.Info(response);
+                Logger.Info(string.Format("{0} {1}", error.Code, error.Message));
             }
 
             return new ItemCacheRange<MessageWithOwner>(position.FirstIndex, messages.Count, messages);


### PR DESCRIPTION
Reported by crash telemetry on 12.10.3.

**FailFastException — Fail-fast 0xC00000FD** (stack overflow), thrown from `td_send`
with the stack made of thousands of repeats of this cycle:

```
  16  Telegram_Telegram_Td_Client__Send                Telegram/Td/Client.cs:144
  17  Telegram_Telegram_Services_ClientService__SendAsync
                                                       Telegram/Services/ClientService.cs:1064
  18  MediaDataSource__FetchDataCallback__MoveNext     .../MediaDataSource.cs:346
  19  AsyncMethodBuilderCore__Start<FetchDataCallback>
  20  MediaDataSource__FetchDataCallback
  21  ItemCacheManager_1__FetchData__MoveNext          .../ItemCacheManager.cs:308
  22  AsyncMethodBuilderCore__Start
  23  ItemCacheManager_1__FetchData
  24  ItemCacheManager_1__FetchData__MoveNext          .../ItemCacheManager.cs:345
  ...  (frames 24-98 repeat 23/24 to the 99-frame cap)
```

The log tail is the same line over and over, ~20 per millisecond until the stack runs out:

```
[MediaDataSource.cs:362][FetchDataCallback] Telegram.Td.Api.Error
```

### Cause

`ItemCacheManager.FetchData` retires a request block by subtracting *what came back*:

```csharp
data = await _fetchDataCallback(nextRequest, ct);
if (data != null && !ct.IsCancellationRequested)
{
    ...
    _requests.Subtract(data.Range);
}
finally
{
    _requestInProgress = null;
    FetchData();          // start another request if required
}
```

`MediaDataSource.FetchDataCallback` returns `new ItemCacheRange(position.FirstIndex,
messages.Count, messages)`, and when `SearchChatMessages` answers with an `Error` that is
an **empty** range. `ItemIndexRangeList.Subtract` of a zero-length range is a no-op, so the
block stays in `_requests`, `GetFirstRequestBlock` hands back the identical block, and the
`FetchData()` in the `finally` asks for it again — forever, with no bound and no backoff.

The reason it overflows the stack rather than just spinning is that nothing in the loop
actually suspends: TDLib rejects the request on its own thread before the awaiting
continuation gets to check, so `await SendAsync` completes synchronously, and so do the two
awaits before it. Each retry is then a plain nested call — `FetchData` → callback →
`FetchData` — and the stack grows by a cycle per attempt.

A short response has the same shape: any block that the search cannot fill completely keeps
its remainder pending and is requested again on the next pass.

### The change

- `ItemCacheManager.FetchData` now subtracts `nextRequest` as well as `data.Range`, so the
  block that was asked for is retired whatever the response was. A block the search could not
  fill is left with null items — the list shows placeholders there — instead of being retried
  until the stack runs out; it is requested again the next time the tracked ranges change.
- `MediaDataSource.FetchDataCallback` logs the error's code and message instead of
  `Telegram.Td.Api.Error`, which is what the tail carried and which said nothing about *why*
  the search was rejected. That answer would have narrowed this down immediately, and it will
  next time.

Not built or run: this was written against the released source and `develop`, so please
compile before merging.
