### PR TITLE
Make AsyncMediaPlayer teardown thread-safe

### DIFF
--- a/Telegram.Native/Media/AsyncMediaPlayer.cpp
+++ b/Telegram.Native/Media/AsyncMediaPlayer.cpp
@@ -504,21 +504,35 @@ namespace winrt::Telegram::Native::Media::implementation
 
         MediaDevice::DefaultAudioRenderDeviceChanged(m_defaultAudioRenderDeviceChanged);
 
-        libvlc_media_player_set_pause(m_player, true);
-
-        libvlc_log_unset(m_instance);
-
-        if (m_context)
-        {
-            m_context.Detach();
-        }
-
+        // First, because it is what lets a parked read fail so libvlc's input thread can finish.
+        // Everything else here waits on that thread one way or another, and the pause this used
+        // to issue waited on it for the whole of RemoteFileSource's read timeout: set_pause takes
+        // the lock libvlc_media_player_stop holds across the join. Nothing pauses now -- the
+        // player is stopped a moment later by CleanupManager, on a thread that may block.
         if (m_stream)
         {
             m_stream.Close();
         }
 
         m_stream = nullptr;
+
+        // Stays here rather than moving into CleanupManager: the log callback is registered with
+        // a raw this, and this object can be gone before the cleanup runs.
+        libvlc_log_unset(m_instance);
+
+        // Detaching from the SwapChainPanel is a XAML call, and Close runs on whichever thread
+        // dropped the last reference, which is not necessarily the one that owns the panel.
+        if (m_context)
+        {
+            if (m_dispatcherQueue && !m_dispatcherQueue.HasThreadAccess())
+            {
+                m_dispatcherQueue.TryEnqueue([context = m_context] { context.Detach(); });
+            }
+            else
+            {
+                m_context.Detach();
+            }
+        }
 
         {
             std::lock_guard<std::mutex> lock(work_lock_);

--- a/Telegram.Native/Media/AsyncMediaPlayer.cpp
+++ b/Telegram.Native/Media/AsyncMediaPlayer.cpp
@@ -135,7 +135,7 @@ namespace winrt::Telegram::Native::Media::implementation
         libvlc_audio_set_mute(m_player, options.Mute());
         libvlc_media_player_set_rate(m_player, options.Rate());
 
-        m_events = new EventContext(m_player, get_weak());
+        m_events = new EventContext(m_player, get_weak(), m_dispatcherQueue, m_state);
         // MediaDevice::DefaultAudioRenderDeviceChanged is a static (app-lifetime) event that can
         // fire on a system thread; a raw 'this' would dangle if it races teardown. get_weak()
         // makes it a no-op once the player is gone (it is also detached in Close()).
@@ -327,8 +327,8 @@ namespace winrt::Telegram::Native::Media::implementation
 
     void AsyncMediaPlayer::Play(IAsyncMediaPlayerSource stream, double position)
     {
-        m_position = position;
-        m_duration = 0;
+        m_state->position = position;
+        m_state->duration = 0;
 
         Write([this, stream, position]() {
             if (m_stream)
@@ -364,8 +364,8 @@ namespace winrt::Telegram::Native::Media::implementation
 
     void AsyncMediaPlayer::Play(winrt::Windows::Foundation::Uri uri, double position)
     {
-        m_position = position;
-        m_duration = 0;
+        m_state->position = position;
+        m_state->duration = 0;
 
         Write([this, uri, position]() {
             if (m_stream)
@@ -434,7 +434,7 @@ namespace winrt::Telegram::Native::Media::implementation
             }
 
             libvlc_media_player_stop(m_player);
-            m_position = 0;
+            m_state->position = 0;
             });
     }
 
@@ -458,7 +458,7 @@ namespace winrt::Telegram::Native::Media::implementation
             // pause itself is issued either way, as it always was.
             if (state == libvlc_Playing)
             {
-                m_canPause = libvlc_media_player_can_pause(m_player) != 0;
+                m_state->canPause = libvlc_media_player_can_pause(m_player) != 0;
             }
 
             libvlc_media_player_set_pause(m_player, pause);
@@ -556,17 +556,17 @@ namespace winrt::Telegram::Native::Media::implementation
 
     bool AsyncMediaPlayer::CanPause()
     {
-        return m_canPause.load();
+        return m_state->canPause.load();
     }
 
     double AsyncMediaPlayer::Duration()
     {
-        return m_duration.load();
+        return m_state->duration.load();
     }
 
     double AsyncMediaPlayer::Position()
     {
-        return m_position.load();
+        return m_state->position.load();
     }
 
     static inline void libvlc_media_player_set_time_aware(libvlc_media_player_t* p_mi, libvlc_time_t i_time)
@@ -586,7 +586,7 @@ namespace winrt::Telegram::Native::Media::implementation
         // Recorded here rather than on the worker: the caller reads Position back to decide
         // what to do next -- PlaybackService compares against it to spot a backward seek --
         // and the queued call may not have run by then.
-        m_position = std::clamp(value, 0.0, 922337203685.0);
+        m_state->position = std::clamp(value, 0.0, 922337203685.0);
 
         auto time = static_cast<libvlc_time_t>(value * 1000);
         Set(libvlc_media_player_set_time_aware, time);
@@ -600,17 +600,17 @@ namespace winrt::Telegram::Native::Media::implementation
         {
             // Moved by the same amount here so a reader sees it at once, and corrected to
             // what libvlc actually seeked to once the worker knows.
-            m_position = std::clamp(m_position.load() + value, 0.0, 922337203685.0);
+            m_state->position = std::clamp(m_state->position.load() + value, 0.0, 922337203685.0);
 
             Write([this, time] {
                 auto seeked = libvlc_media_player_get_time(m_player) + time;
                 libvlc_media_player_set_time_aware(m_player, seeked);
-                m_position = std::clamp(seeked / 1000.0, 0.0, 922337203685.0);
+                m_state->position = std::clamp(seeked / 1000.0, 0.0, 922337203685.0);
                 });
         }
         else
         {
-            m_position = std::clamp(value, 0.0, 922337203685.0);
+            m_state->position = std::clamp(value, 0.0, 922337203685.0);
             Set(libvlc_media_player_set_time_aware, time);
         }
     }
@@ -719,7 +719,7 @@ namespace winrt::Telegram::Native::Media::implementation
         }
     }
 
-    void AsyncMediaPlayer::HandleEvent(const libvlc_event_t* event)
+    void AsyncMediaPlayer::EventContext::HandleEvent(const libvlc_event_t* event)
     {
         switch (event->type)
         {
@@ -727,7 +727,7 @@ namespace winrt::Telegram::Native::Media::implementation
         {
             auto trackId = event->u.media_player_es_changed.i_id;
             auto trackType = event->u.media_player_es_changed.i_type;
-            TryEnqueue([weakThis{ get_weak() }, trackId, trackType]() {
+            TryEnqueue([weakThis{ m_weak }, trackId, trackType]() {
                 if (auto strongThis = weakThis.get())
                 {
                     int width = 0;
@@ -744,7 +744,7 @@ namespace winrt::Telegram::Native::Media::implementation
         }
         break;
         case libvlc_MediaPlayerVout:
-            TryEnqueue([weakThis{ get_weak() }]() {
+            TryEnqueue([weakThis{ m_weak }]() {
                 if (auto strongThis = weakThis.get())
                 {
                     strongThis->m_videoOut(*strongThis, nullptr);
@@ -754,7 +754,7 @@ namespace winrt::Telegram::Native::Media::implementation
         case libvlc_MediaPlayerBuffering:
         {
             auto cache = event->u.media_player_buffering.new_cache;
-            TryEnqueue([weakThis{ get_weak() }, cache]() {
+            TryEnqueue([weakThis{ m_weak }, cache]() {
                 if (auto strongThis = weakThis.get())
                 {
                     //strongThis->m_stateChangedEventArgs.State(AsyncMediaPlayerState::Buffering);
@@ -770,8 +770,8 @@ namespace winrt::Telegram::Native::Media::implementation
             // Position used to answer with the length once the state was Ended, which is
             // what the transport controls draw at the end of a track. Nothing else updates
             // it from here on.
-            m_position = m_duration.load();
-            TryEnqueue([weakThis{ get_weak() }]() {
+            m_state->position = m_state->duration.load();
+            TryEnqueue([weakThis{ m_weak }]() {
                 if (auto strongThis = weakThis.get())
                 {
                     strongThis->m_stateChangedEventArgs.State(AsyncMediaPlayerState::Ended);
@@ -785,8 +785,8 @@ namespace winrt::Telegram::Native::Media::implementation
         case libvlc_MediaPlayerTimeChanged:
         {
             auto position = std::clamp(event->u.media_player_time_changed.new_time / 1000.0, 0.0, 922337203685.0);
-            m_position = position;
-            TryEnqueue([weakThis{ get_weak() }, position]() {
+            m_state->position = position;
+            TryEnqueue([weakThis{ m_weak }, position]() {
                 if (auto strongThis = weakThis.get())
                 {
                     strongThis->m_positionChangedEventArgs.Position(position);
@@ -798,8 +798,8 @@ namespace winrt::Telegram::Native::Media::implementation
         case libvlc_MediaPlayerLengthChanged:
         {
             auto duration = std::clamp(event->u.media_player_length_changed.new_length / 1000.0, 0.0, 922337203685.0);
-            m_duration = duration;
-            TryEnqueue([weakThis{ get_weak() }, duration]() {
+            m_state->duration = duration;
+            TryEnqueue([weakThis{ m_weak }, duration]() {
                 if (auto strongThis = weakThis.get())
                 {
                     strongThis->m_durationChangedEventArgs.Duration(duration);
@@ -809,7 +809,7 @@ namespace winrt::Telegram::Native::Media::implementation
         }
         break;
         case libvlc_MediaPlayerPlaying:
-            TryEnqueue([weakThis{ get_weak() }]() {
+            TryEnqueue([weakThis{ m_weak }]() {
                 if (auto strongThis = weakThis.get())
                 {
                     strongThis->m_stateChangedEventArgs.State(AsyncMediaPlayerState::Playing);
@@ -820,7 +820,7 @@ namespace winrt::Telegram::Native::Media::implementation
                 });
             break;
         case libvlc_MediaPlayerPaused:
-            TryEnqueue([weakThis{ get_weak() }]() {
+            TryEnqueue([weakThis{ m_weak }]() {
                 if (auto strongThis = weakThis.get())
                 {
                     strongThis->m_stateChangedEventArgs.State(AsyncMediaPlayerState::Paused);
@@ -831,8 +831,8 @@ namespace winrt::Telegram::Native::Media::implementation
                 });
             break;
         case libvlc_MediaPlayerStopped:
-            m_position = 0;
-            TryEnqueue([weakThis{ get_weak() }]() {
+            m_state->position = 0;
+            TryEnqueue([weakThis{ m_weak }]() {
                 if (auto strongThis = weakThis.get())
                 {
                     strongThis->m_stateChangedEventArgs.State(AsyncMediaPlayerState::Stopped);
@@ -843,7 +843,7 @@ namespace winrt::Telegram::Native::Media::implementation
                 });
             break;
         case libvlc_MediaPlayerAudioVolume:
-            TryEnqueue([weakThis{ get_weak() }]() {
+            TryEnqueue([weakThis{ m_weak }]() {
                 if (auto strongThis = weakThis.get())
                 {
                     strongThis->m_volumeChanged(*strongThis, nullptr);
@@ -851,7 +851,7 @@ namespace winrt::Telegram::Native::Media::implementation
                 });
             break;
         case libvlc_MediaPlayerEncounteredError:
-            TryEnqueue([weakThis{ get_weak() }]() {
+            TryEnqueue([weakThis{ m_weak }]() {
                 if (auto strongThis = weakThis.get())
                 {
                     strongThis->m_stateChangedEventArgs.State(AsyncMediaPlayerState::Error);
@@ -861,7 +861,7 @@ namespace winrt::Telegram::Native::Media::implementation
                 });
             break;
         case libvlc_MediaPlayerNothingSpecial:
-            TryEnqueue([weakThis{ get_weak() }]() {
+            TryEnqueue([weakThis{ m_weak }]() {
                 if (auto strongThis = weakThis.get())
                 {
                     strongThis->m_stateChangedEventArgs.State(AsyncMediaPlayerState::NothingSpecial);
@@ -870,7 +870,7 @@ namespace winrt::Telegram::Native::Media::implementation
                 });
             break;
         case libvlc_MediaPlayerOpening:
-            TryEnqueue([weakThis{ get_weak() }]() {
+            TryEnqueue([weakThis{ m_weak }]() {
                 if (auto strongThis = weakThis.get())
                 {
                     strongThis->m_stateChangedEventArgs.State(AsyncMediaPlayerState::Opening);
@@ -881,7 +881,7 @@ namespace winrt::Telegram::Native::Media::implementation
         }
     }
 
-    void AsyncMediaPlayer::TryEnqueue(DispatcherQueueHandler const& callback) const
+    void AsyncMediaPlayer::EventContext::TryEnqueue(DispatcherQueueHandler const& callback) const
     {
         try
         {

--- a/Telegram.Native/Media/AsyncMediaPlayer.h
+++ b/Telegram.Native/Media/AsyncMediaPlayer.h
@@ -37,6 +37,15 @@ inline void post_to_threadpool(Func&& func)
         nullptr
     );
 
+    // Submitting a null work item is an access violation. Dropping the work instead leaks
+    // whatever it was going to release, which for the teardown path is one player and one
+    // libvlc instance -- the better outcome of the two, in a process already out of memory.
+    if (work == nullptr)
+    {
+        delete heapFunc;
+        return;
+    }
+
     SubmitThreadpoolWork(work);
     CloseThreadpoolWork(work);
 }

--- a/Telegram.Native/Media/AsyncMediaPlayer.h
+++ b/Telegram.Native/Media/AsyncMediaPlayer.h
@@ -5,6 +5,7 @@
 #include <vlc/vlc.h>
 
 #include <thread>
+#include <iterator>
 #include <mutex>
 #include <condition_variable>
 #include <queue>
@@ -222,44 +223,60 @@ namespace winrt::Telegram::Native::Media::implementation
     private:
         struct EventContext
         {
+            static constexpr libvlc_event_e s_events[] =
+            {
+                libvlc_MediaPlayerESSelected,
+                libvlc_MediaPlayerVout,
+                libvlc_MediaPlayerBuffering,
+                libvlc_MediaPlayerEndReached,
+                libvlc_MediaPlayerTimeChanged,
+                libvlc_MediaPlayerLengthChanged,
+                libvlc_MediaPlayerPlaying,
+                libvlc_MediaPlayerPaused,
+                libvlc_MediaPlayerStopped,
+                libvlc_MediaPlayerAudioVolume,
+                libvlc_MediaPlayerEncounteredError,
+                libvlc_MediaPlayerNothingSpecial,
+                libvlc_MediaPlayerOpening,
+            };
+
+            static_assert(std::size(s_events) <= 32);
+
             EventContext(libvlc_media_player_t* player, winrt::weak_ref<AsyncMediaPlayer> weak)
                 : m_weak(weak)
             {
                 libvlc_event_manager_t* em = libvlc_media_player_event_manager(player);
-                libvlc_event_attach(em, libvlc_MediaPlayerESSelected, &EventCallback, this);
-                libvlc_event_attach(em, libvlc_MediaPlayerVout, &EventCallback, this);
-                libvlc_event_attach(em, libvlc_MediaPlayerBuffering, &EventCallback, this);
-                libvlc_event_attach(em, libvlc_MediaPlayerEndReached, &EventCallback, this);
-                libvlc_event_attach(em, libvlc_MediaPlayerTimeChanged, &EventCallback, this);
-                libvlc_event_attach(em, libvlc_MediaPlayerLengthChanged, &EventCallback, this);
-                libvlc_event_attach(em, libvlc_MediaPlayerPlaying, &EventCallback, this);
-                libvlc_event_attach(em, libvlc_MediaPlayerPaused, &EventCallback, this);
-                libvlc_event_attach(em, libvlc_MediaPlayerStopped, &EventCallback, this);
-                libvlc_event_attach(em, libvlc_MediaPlayerAudioVolume, &EventCallback, this);
-                libvlc_event_attach(em, libvlc_MediaPlayerEncounteredError, &EventCallback, this);
-                libvlc_event_attach(em, libvlc_MediaPlayerNothingSpecial, &EventCallback, this);
-                libvlc_event_attach(em, libvlc_MediaPlayerOpening, &EventCallback, this);
+
+                for (uint32_t i = 0; i < std::size(s_events); i++)
+                {
+                    // libvlc_event_attach fails on a failed allocation, and libvlc_event_detach
+                    // ends in a bare abort() when it cannot find the listener -- in release too.
+                    // So the successes have to be remembered, or one allocation lost under memory
+                    // pressure kills the process at teardown, with nothing to show for it.
+                    if (libvlc_event_attach(em, s_events[i], &EventCallback, this) == 0)
+                    {
+                        m_attached |= 1u << i;
+                    }
+                }
             }
 
             void Detach(libvlc_media_player_t* player)
             {
                 libvlc_event_manager_t* em = libvlc_media_player_event_manager(player);
-                libvlc_event_detach(em, libvlc_MediaPlayerESSelected, &EventCallback, this);
-                libvlc_event_detach(em, libvlc_MediaPlayerVout, &EventCallback, this);
-                libvlc_event_detach(em, libvlc_MediaPlayerBuffering, &EventCallback, this);
-                libvlc_event_detach(em, libvlc_MediaPlayerEndReached, &EventCallback, this);
-                libvlc_event_detach(em, libvlc_MediaPlayerTimeChanged, &EventCallback, this);
-                libvlc_event_detach(em, libvlc_MediaPlayerLengthChanged, &EventCallback, this);
-                libvlc_event_detach(em, libvlc_MediaPlayerPlaying, &EventCallback, this);
-                libvlc_event_detach(em, libvlc_MediaPlayerPaused, &EventCallback, this);
-                libvlc_event_detach(em, libvlc_MediaPlayerStopped, &EventCallback, this);
-                libvlc_event_detach(em, libvlc_MediaPlayerAudioVolume, &EventCallback, this);
-                libvlc_event_detach(em, libvlc_MediaPlayerEncounteredError, &EventCallback, this);
-                libvlc_event_detach(em, libvlc_MediaPlayerNothingSpecial, &EventCallback, this);
-                libvlc_event_detach(em, libvlc_MediaPlayerOpening, &EventCallback, this);
+
+                for (uint32_t i = 0; i < std::size(s_events); i++)
+                {
+                    if (m_attached & (1u << i))
+                    {
+                        libvlc_event_detach(em, s_events[i], &EventCallback, this);
+                    }
+                }
+
+                m_attached = 0;
             }
 
             winrt::weak_ref<AsyncMediaPlayer> m_weak;
+            uint32_t m_attached = 0;
 
             static void EventCallback(const libvlc_event_t* event, void* user_data)
             {

--- a/Telegram.Native/Media/AsyncMediaPlayer.h
+++ b/Telegram.Native/Media/AsyncMediaPlayer.h
@@ -282,17 +282,24 @@ namespace winrt::Telegram::Native::Media::implementation
                     {
                         workerThread.join();
                     }
-                    // Then we release all objects
+                    // Then we release all objects, the listeners first: stop sends
+                    // MediaPlayerStopped synchronously, and by now there is nobody left to hear
+                    // it. Detach is what makes the delete safe -- libvlc_event_send invokes a
+                    // callback with the event manager's lock held and detach takes that same
+                    // lock, so it cannot return while one is running.
+                    if (events)
+                    {
+                        if (player)
+                        {
+                            events->Detach(player);
+                        }
+
+                        delete events;
+                    }
+
                     if (player)
                     {
                         libvlc_media_player_stop(player);
-
-                        if (events)
-                        {
-                            events->Detach(player);
-                            delete events;
-                        }
-
                         libvlc_media_player_set_media(player, nullptr);
                         libvlc_media_player_release(player);
                     }

--- a/Telegram.Native/Media/AsyncMediaPlayer.h
+++ b/Telegram.Native/Media/AsyncMediaPlayer.h
@@ -230,6 +230,24 @@ namespace winrt::Telegram::Native::Media::implementation
         void Log(winrt::event_token const& token);
 
     private:
+        // Position, duration and can-pause are answered from here instead of from libvlc.
+        // libvlc_media_player_stop holds the same lock that get_time, get_length and
+        // can_pause take, and it holds it across the join of the input thread -- which can
+        // be parked in a read for as long as the network takes. A UI thread asking for the
+        // position would wait on that lock for just as long.
+        //
+        // Nothing is lost by not asking: libvlc reports each of these through an event, or
+        // we are the one setting it. Written from the event thread and the worker.
+        //
+        // Shared with EventContext rather than reached through the player, so that a libvlc
+        // callback can record what it was told without holding a reference to the player.
+        struct PlayerState
+        {
+            std::atomic<double> position{ 0 };
+            std::atomic<double> duration{ 0 };
+            std::atomic<bool> canPause{ true };
+        };
+
         struct EventContext
         {
             static constexpr libvlc_event_e s_events[] =
@@ -251,8 +269,10 @@ namespace winrt::Telegram::Native::Media::implementation
 
             static_assert(std::size(s_events) <= 32);
 
-            EventContext(libvlc_media_player_t* player, winrt::weak_ref<AsyncMediaPlayer> weak)
+            EventContext(libvlc_media_player_t* player, winrt::weak_ref<AsyncMediaPlayer> weak, DispatcherQueue dispatcherQueue, std::shared_ptr<PlayerState> state)
                 : m_weak(weak)
+                , m_dispatcherQueue(dispatcherQueue)
+                , m_state(state)
             {
                 libvlc_event_manager_t* em = libvlc_media_player_event_manager(player);
 
@@ -285,16 +305,22 @@ namespace winrt::Telegram::Native::Media::implementation
             }
 
             winrt::weak_ref<AsyncMediaPlayer> m_weak;
+            DispatcherQueue m_dispatcherQueue{ nullptr };
+            std::shared_ptr<PlayerState> m_state;
             uint32_t m_attached = 0;
 
             static void EventCallback(const libvlc_event_t* event, void* user_data)
             {
-                auto* ctx = static_cast<EventContext*>(user_data);
-                if (auto strong = ctx->m_weak.get())
-                {
-                    strong->HandleEvent(event);
-                }
+                // Deliberately not resolving m_weak here. A strong reference taken on libvlc's
+                // thread can turn out to be the last one, and then ~AsyncMediaPlayer runs on
+                // that thread: inside the event manager's lock, and re-entering the source the
+                // very same thread may be parked in. The player is reached only from the
+                // dispatcher, where dropping the last reference is safe.
+                static_cast<EventContext*>(user_data)->HandleEvent(event);
             }
+
+            void HandleEvent(const libvlc_event_t* event);
+            void TryEnqueue(DispatcherQueueHandler const& callback) const;
         };
 
         class CleanupManager
@@ -366,17 +392,7 @@ namespace winrt::Telegram::Native::Media::implementation
         // worker may still be inside Play.
         std::atomic<void*> m_streamAbi{ nullptr };
 
-        // Position, duration and can-pause are answered from here instead of from libvlc.
-        // libvlc_media_player_stop holds the same lock that get_time, get_length and
-        // can_pause take, and it holds it across the join of the input thread -- which can
-        // be parked in a read for as long as the network takes. A UI thread asking for the
-        // position would wait on that lock for just as long.
-        //
-        // Nothing is lost by not asking: libvlc reports each of these through an event, or
-        // we are the one setting it. Written from the event thread and the worker.
-        std::atomic<double> m_position{ 0 };
-        std::atomic<double> m_duration{ 0 };
-        std::atomic<bool> m_canPause{ true };
+        std::shared_ptr<PlayerState> m_state{ std::make_shared<PlayerState>() };
 
         void OnDefaultAudioRenderDeviceChanged(winrt::Windows::Foundation::IInspectable const& sender, DefaultAudioRenderDeviceChangedEventArgs const& args);
 
@@ -385,9 +401,6 @@ namespace winrt::Telegram::Native::Media::implementation
         static void LogCallback(void* data, int level, const libvlc_log_t* ctx, const char* fmt, va_list args) noexcept;
 
         void HandleLog(int level, const libvlc_log_t* ctx, const char* fmt, va_list args);
-
-        void HandleEvent(const libvlc_event_t* event);
-        void TryEnqueue(DispatcherQueueHandler const& callback) const;
 
         void GetVideoTrackInfo(int32_t trackId, int32_t& width, int32_t& height);
 

--- a/Telegram.Native/Media/AsyncMediaPlayer.h
+++ b/Telegram.Native/Media/AsyncMediaPlayer.h
@@ -407,7 +407,9 @@ namespace winrt::Telegram::Native::Media::implementation
 
     private:
         mutable std::mutex close_lock_;
-        bool closed_ = false;
+        // Written under close_lock_, but read without it where taking that lock would invert the
+        // close_lock_ -> work_lock_ order Close() holds them in.
+        std::atomic<bool> closed_{ false };
 
         std::atomic<bool> work_started_{ false };
         std::unique_ptr<std::thread> work_thread_;
@@ -438,6 +440,15 @@ namespace winrt::Telegram::Native::Media::implementation
             work_queue_.push(work_item);
 
             std::lock_guard<std::mutex> lock(work_lock_);
+
+            // Checked again, because the close_lock_ above was given up before the queue push:
+            // Close() can have run in between, taken the thread away and left nobody to join
+            // the one started here -- and destroying a joinable thread terminates the process.
+            if (closed_.load())
+            {
+                return;
+            }
+
             if (!work_started_.load())
             {
                 if (work_thread_ && work_thread_->joinable())


### PR DESCRIPTION
Teardown fixes for `AsyncMediaPlayer`, found reviewing `EventContext` and `CleanupManager::Close`. Verified against VLC 3.0.x `lib/event.c` and `lib/media_player.c` — the port pins 3.0.23; I could not check whether the `UnigramDev/vlc` fork patched either file, since there is no VLC checkout on this machine.

One commit per fix, ordered cheapest first.

**Close the media source before anything that waits on libvlc.** `Close()` called `libvlc_media_player_set_pause` on the caller's thread three statements before closing the source. `set_pause` takes the player's input lock; `libvlc_media_player_stop` holds that lock across the join of the input thread, and that thread can be parked in `RemoteFileSource.ReadCallback` for the whole read timeout. Closing the source is what ends the read, so the UI thread could block for that long. The pause is gone rather than moved — `CleanupManager` stops the player a moment later on a thread that is allowed to block. The swap-chain detach is now posted to the dispatcher, since it is a XAML call and `Close()` runs wherever the last reference was dropped.

**Detach the player events before stopping the player.** `stop` sends `MediaPlayerStopped` synchronously, so a `Stopped` was still raised after `Close()` returned. Both real callers unsubscribe before closing, so nothing observable is lost. It also closes the window where a callback resolves the last strong reference and runs `~AsyncMediaPlayer` on libvlc's input thread.

**Don't start the worker thread once the player is closed.** `Write` checked `closed_`, gave up `close_lock_`, then took `work_lock_` and could spawn a worker that `Close()` had already stopped waiting for. Nobody joined it, and destroying a joinable thread terminates the process. `closed_` is now atomic and rechecked under `work_lock_` — it cannot be taken under it, as `Close()` holds the two the other way round.

**Detach only the libvlc listeners that actually attached.** `libvlc_event_attach` can fail on an allocation and `libvlc_event_detach` ends in a bare `abort()` when it cannot find the listener, in release too. One lost allocation under memory pressure killed the process at teardown with nothing in the log. The two hand-written lists became one table plus a bitmask.

**Don't submit a null threadpool work item.** `CreateThreadpoolWork` returns null on failure and `SubmitThreadpoolWork(nullptr)` is an access violation, with the whole teardown in that lambda.

**Keep strong references to the player off libvlc's threads.** `EventCallback` resolved a strong reference on every event just to reach `HandleEvent`. If the client's release raced it, the last release landed on libvlc's thread and ran the destructor there — inside the event manager's lock, re-entering the source that thread may itself be parked in. The cached position/duration/can-pause move into a small `PlayerState` shared with `EventContext`, which now owns `HandleEvent` and `TryEnqueue` and reaches the player only from the dispatcher. Also drops a refcount round trip per `TimeChanged`.

**Not built.** No `.idl`, C# or behaviour change beyond the `Stopped` above.

`notes/architecture.md` is deliberately untouched: the media section on local `develop` already carries a longer trap paragraph that is not on `origin/develop`, and editing it here would hand you a conflict. The two new invariants — no libvlc or XAML call on `Close()`'s thread, and no strong reference on a libvlc thread — belong in that paragraph once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrNzuXYRXqNPGy3s1sj68J
