### PR TITLE
Rebuild the entity splitter as an edge sweep

### DIFF
--- a/Telegram/Common/TextStyleRun.cs
+++ b/Telegram/Common/TextStyleRun.cs
@@ -256,6 +256,15 @@ namespace Telegram.Common
                         }
                         newRun.End = temp;
                     }
+
+                    // Both branches above leave newRun holding whatever of it still extends past
+                    // run, and that remainder is inverted - not empty - when there is none. Carried
+                    // into the next run it is copied into the list as a run whose End precedes its
+                    // Start, and a negative length reaches Run creation as a ~4GB hstring.
+                    if (newRun.Start >= newRun.End)
+                    {
+                        break;
+                    }
                 }
                 if (newRun.Start < newRun.End)
                 {

--- a/Telegram/Common/TextStyleRun.cs
+++ b/Telegram/Common/TextStyleRun.cs
@@ -32,14 +32,6 @@ namespace Telegram.Common
 
         }
 
-        private TextStyleRun(TextStyleRun run)
-        {
-            Flags = run.Flags;
-            Start = run.Start;
-            End = run.End;
-            Type = run.Type;
-        }
-
         #region DateTime
 
         public string FormattedText { get; set; } = string.Empty;
@@ -60,18 +52,6 @@ namespace Telegram.Common
         public bool HasFlag(TextStyle flag)
         {
             return (Flags & flag) != 0;
-        }
-
-        private void Merge(TextStyleRun run)
-        {
-            Flags |= run.Flags;
-            Type ??= run.Type;
-
-            // TODO: probably makes sense to add all entity types that provide some additional value.
-            if (run.Type is TextEntityTypeCustomEmoji)
-            {
-                Type = run.Type;
-            }
         }
 
         // Not Array.Empty: TextStylePart is a WinRT struct and the native side takes an
@@ -137,30 +117,26 @@ namespace Telegram.Common
                 return Array.Empty<TextStyleRun>();
             }
 
-            var runs = new List<TextStyleRun>();
-            var entitiesCopy = new List<TextEntity>(entities);
+            List<TextStyleRun> runs = null;
+            var sorted = true;
 
-            entitiesCopy.Sort((x, y) => x.Offset.CompareTo(y.Offset));
-
-            for (int a = 0, N = entitiesCopy.Count; a < N; a++)
+            for (int i = 0; i < entities.Count; i++)
             {
-                var entity = entitiesCopy[a];
+                var entity = entities[i];
                 if (entity.Length <= 0 || entity.Offset < 0 || entity.Offset >= text.Length)
                 {
                     continue;
                 }
-                else if (entity.Offset + entity.Length > text.Length)
-                {
-                    entity.Length = text.Length - entity.Offset;
-                }
 
-                var newRun = new TextStyleRun
+                var run = new TextStyleRun
                 {
                     Start = entity.Offset,
-                    End = entity.Offset + entity.Length
+                    // Clamped here rather than on the entity: entities belong to the message and
+                    // are rendered again against other text - a paragraph of it, a search preview.
+                    End = Math.Min(entity.Offset + entity.Length, text.Length)
                 };
 
-                (newRun.Flags, newRun.Type) = entity.Type switch
+                (run.Flags, run.Type) = entity.Type switch
                 {
                     TextEntityTypeStrikethrough => (TextStyle.Strikethrough, null),
                     TextEntityTypeUnderline => (TextStyle.Underline, null),
@@ -178,101 +154,115 @@ namespace Telegram.Common
                     TextEntityTypeIcon => (TextStyle.Icon, entity.Type),
                     TextEntityTypeMathematicalExpression => (TextStyle.Math, entity.Type),
                     TextEntityTypeButton => (TextStyle.Button, entity.Type),
-                    // A marker laid over a link, never standing alone. Type stays null so
-                    // the link's own entity survives the merge below — Merge keeps the
-                    // first non-null Type and ORs the flags together.
+                    // A marker laid over a link, never standing alone, so it leaves Type null
+                    // and the link it covers keeps its own.
                     TextEntityTypeCached => (TextStyle.Cached, null),
                     _ => (TextStyle.Url, entity.Type)
                 };
 
-                for (int b = 0, N2 = runs.Count; b < N2; b++)
+                runs ??= new List<TextStyleRun>(entities.Count);
+                sorted = sorted && (runs.Count == 0 || runs[runs.Count - 1].Start <= run.Start);
+                runs.Add(run);
+            }
+
+            if (runs == null)
+            {
+                return Array.Empty<TextStyleRun>();
+            }
+
+            if (!sorted)
+            {
+                runs.Sort((x, y) => x.Start.CompareTo(y.Start));
+            }
+
+            // Nothing overlaps in the overwhelming majority of messages, and then the entities
+            // already are the runs - no splitting, and nothing allocated beyond this list.
+            for (int i = 1; i < runs.Count; i++)
+            {
+                if (runs[i].Start < runs[i - 1].End)
                 {
-                    TextStyleRun run = runs[b];
-
-                    if (newRun.Start > run.Start)
-                    {
-                        if (newRun.Start >= run.End)
-                        {
-                            continue;
-                        }
-
-                        if (newRun.End < run.End)
-                        {
-                            TextStyleRun r = new(newRun);
-                            r.Merge(run);
-                            b++;
-                            N2++;
-                            runs.Insert(b, r);
-
-                            r = new TextStyleRun(run);
-                            r.Start = newRun.End;
-                            b++;
-                            N2++;
-                            runs.Insert(b, r);
-                        }
-                        else if (newRun.End >= run.End)
-                        {
-                            TextStyleRun r = new(newRun);
-                            r.Merge(run);
-                            r.End = run.End;
-                            b++;
-                            N2++;
-                            runs.Insert(b, r);
-                        }
-
-                        (newRun.Start, run.End) = (run.End, newRun.Start);
-                    }
-                    else
-                    {
-                        if (run.Start >= newRun.End)
-                        {
-                            continue;
-                        }
-                        int temp = run.Start;
-                        if (newRun.End == run.End)
-                        {
-                            run.Merge(newRun);
-                        }
-                        else if (newRun.End < run.End)
-                        {
-                            TextStyleRun r = new(run);
-                            r.Merge(newRun);
-                            r.End = newRun.End;
-                            b++;
-                            N2++;
-                            runs.Insert(b, r);
-
-                            run.Start = newRun.End;
-                        }
-                        else
-                        {
-                            TextStyleRun r = new(newRun);
-                            r.Start = run.End;
-                            b++;
-                            N2++;
-                            runs.Insert(b, r);
-
-                            run.Merge(newRun);
-                        }
-                        newRun.End = temp;
-                    }
-
-                    // Both branches above leave newRun holding whatever of it still extends past
-                    // run, and that remainder is inverted - not empty - when there is none. Carried
-                    // into the next run it is copied into the list as a run whose End precedes its
-                    // Start, and a negative length reaches Run creation as a ~4GB hstring.
-                    if (newRun.Start >= newRun.End)
-                    {
-                        break;
-                    }
-                }
-                if (newRun.Start < newRun.End)
-                {
-                    runs.Add(newRun);
+                    return Split(runs);
                 }
             }
 
-            runs.Sort((x, y) => x.Offset.CompareTo(y.Offset));
+            return runs;
+        }
+
+        /// <summary>
+        /// Cuts <paramref name="sources"/> at every entity edge and gives each resulting segment
+        /// the union of the entities covering it, so the result is an ordered partition: no gaps
+        /// invented, no segment empty or inverted, and no two overlapping.
+        /// </summary>
+        private static List<TextStyleRun> Split(List<TextStyleRun> sources)
+        {
+            var bounds = new int[sources.Count * 2];
+
+            for (int i = 0; i < sources.Count; i++)
+            {
+                bounds[i * 2] = sources[i].Start;
+                bounds[i * 2 + 1] = sources[i].End;
+            }
+
+            Array.Sort(bounds);
+
+            var runs = new List<TextStyleRun>(bounds.Length);
+
+            for (int i = 0; i < bounds.Length - 1; i++)
+            {
+                var start = bounds[i];
+                var end = bounds[i + 1];
+
+                if (start == end)
+                {
+                    continue;
+                }
+
+                TextStyleRun merged = null;
+                TextStyleRun owner = null;
+
+                for (int j = 0; j < sources.Count; j++)
+                {
+                    var source = sources[j];
+
+                    // The bounds are consecutive edges, so a source spans the whole segment or
+                    // none of it - there is no partial case to split further.
+                    if (source.Start > start || source.End < end)
+                    {
+                        continue;
+                    }
+
+                    merged ??= new TextStyleRun
+                    {
+                        Start = start,
+                        End = end
+                    };
+
+                    merged.Flags |= source.Flags;
+
+                    if (source.Type == null)
+                    {
+                        continue;
+                    }
+
+                    // A wrapper is longer than what it wraps, so the shortest entity over the
+                    // segment is the content - and the renderer branches on the flags and then
+                    // reads Type expecting the content's. A custom emoji wins outright: it is
+                    // drawn inside its spoiler, not instead of it.
+                    if (owner == null
+                        || source.Type is TextEntityTypeCustomEmoji
+                        || (owner.Type is not TextEntityTypeCustomEmoji && source.Length < owner.Length))
+                    {
+                        owner = source;
+                    }
+                }
+
+                if (merged != null)
+                {
+                    merged.Type = owner?.Type;
+                    runs.Add(merged);
+                }
+            }
+
             return runs;
         }
 

--- a/Telegram/Common/TextStyleRun.cs
+++ b/Telegram/Common/TextStyleRun.cs
@@ -172,7 +172,11 @@ namespace Telegram.Common
 
             if (!sorted)
             {
-                runs.Sort((x, y) => x.Start.CompareTo(y.Start));
+                // Shorter first where two start together, so Split sees a wrapper's content
+                // before the wrapper. List.Sort is unstable, and a RichText flattens to entities
+                // in post-order - inner before outer, frequently at the same offset - so without
+                // the second key which of the two owns the run would come down to the sort.
+                runs.Sort((x, y) => x.Start != y.Start ? x.Start.CompareTo(y.Start) : x.End.CompareTo(y.End));
             }
 
             // Nothing overlaps in the overwhelming majority of messages, and then the entities
@@ -247,7 +251,9 @@ namespace Telegram.Common
                     // A wrapper is longer than what it wraps, so the shortest entity over the
                     // segment is the content - and the renderer branches on the flags and then
                     // reads Type expecting the content's. A custom emoji wins outright: it is
-                    // drawn inside its spoiler, not instead of it.
+                    // drawn inside its spoiler, not instead of it. Two entities over exactly the
+                    // same range cannot be told apart this way and the first wins; the flags of
+                    // both survive either way, and they are what the renderer dispatches on.
                     if (owner == null
                         || source.Type is TextEntityTypeCustomEmoji
                         || (owner.Type is not TextEntityTypeCustomEmoji && source.Length < owner.Length))


### PR DESCRIPTION
### The crash

`ArgumentException` — *"The parameter is incorrect. length"* (`E_INVALIDARG`), reported by crash
telemetry on 12.10.4.

```
  11  winrt::impl::produce<...NativeUtils...>::AddRunToCollection2+0xe6
  12  ABI.Telegram.Native.INativeUtilsStaticsMethods.AddRunToCollection
  13  Telegram.Controls.FormattedTextBlock.GetOrCreateRun          FormattedTextBlock.cs:1221
  14  Telegram.Controls.FormattedTextBlock.SetText                 FormattedTextBlock.cs:2066
  15  Telegram.Controls.Cells.ChatCell.UpdateBriefLabel            ChatCell.xaml.cs:1642
  16  Telegram.Controls.Cells.ChatCell.UpdateMessage               ChatCell.xaml.cs:355
  17  Telegram.Controls.Views.SearchChatsView.OnContainerContentChanging
  19  DirectUI::ListViewBase::BuildTreeImpl
```

The throw is C++/WinRT's own, from `precreate_hstring_on_heap`:

```cpp
if (bytes_required > (std::numeric_limits<std::uint32_t>::max)())
{
    throw std::invalid_argument("length");
}
```

`NativeUtils::AddRunToCollection` slices the run text with `hstring(text.c_str() + offset, length)`,
whose size parameter is `uint32_t`. A **negative** `length` widens to ~4 G, `bytes_required`
overflows the cap, and `to_hresult` turns `std::invalid_argument` into `E_INVALIDARG` — message
`length`.

### Why the length was negative

`TextStyleRun.GetRuns` folded entities in one at a time, walking the runs built so far and
progressively consuming `newRun`. Both split branches ended by trimming it to whatever still
extended past the current run:

```csharp
(newRun.Start, run.End) = (run.End, newRun.Start);   // first branch
newRun.End = temp;                                   // second branch
```

When nothing extended past it, the remainder was not empty — it was **inverted**, `Start > End`. The
closing `if (newRun.Start < newRun.End)` caught that for the last run, but the loop kept going, and
the next overlap copied the inverted `newRun` straight into the list. That run reached
`StyledParagraph.Runs`, and `SetText` bounds-checks a run only from above —

```csharp
if (entity.Length + entity.Offset > text.Length)
```

— which a negative length passes, so it went on to the native call.

Smallest input that produces one: four entities over a five-character text,
`(0,1) (0,5) (0,4) (2,1)`, yielding a run `[4,3)`.

Inverted runs were not the only defect. The same fold also emitted **overlapping** runs from three
or more partially overlapping entities, which renders the overlapped text twice, and it mutated
`entity.Length` on the caller's `TextEntity` when clamping — the entity belongs to the message and
gets rendered again against other text.

### The fix

Rather than guard the symptom, `GetRuns` is rebuilt as an edge sweep. Every entity edge is a cut
point; each segment between two consecutive cuts takes the union of the entities covering it. Being
a partition by construction, it cannot emit an inverted, empty or overlapping run.

`Split` runs only when entities actually overlap. In the common case the entities already are the
runs and nothing is allocated beyond the list itself — the old code allocated a second entity list
and paid repeated `List.Insert` shuffling even when nothing overlapped.

### The bug, demonstrated

Not a replica of the algorithm — the shipped `GetRuns` itself, sliced out of
`git show v12.10.4:Telegram/Common/TextStyleRun.cs` by script and hashed, so the harness cannot
quietly disagree with what shipped:

```
extracted from 46c467caa:Telegram/Common/TextStyleRun.cs
  TextStyleRun members   lines  20-41   sha256:e7da0a51f6196408
  HasFlag + Merge        lines  60-75   sha256:57f743cc5aad306c
  GetRuns                lines 133-268  sha256:89c46988bfe67354
```

Four entities over the five characters of `"Hello"` — bold `H`, italic `Hello`, underline `Hell`,
strikethrough `l`. Every one satisfies `GetRuns`' own entry guard: positive length, in range, not
past the end.

```
1. the shipped GetRuns emits an inverted run
      [0,1)len=1 [1,2)len=1 [1,4)len=3 [2,3)len=1 [3,4)len=1 [3,5)len=2 [4,3)len=-1

2. the renderer's bounds check lets it through
  [PASS] `Length + Offset > text.Length` is -1 + 4 > 5 == false

3. what the native side is handed
      length -1 widens to 4294967295 (0xFFFFFFFF)
      bytes_required = 8 + 2 * 4294967295 = 8589934598
```

And the far end, compiled against the project's own `base.h` — `hstring(text + offset, length)`
with exactly the run above:

```
  the run GetRuns emitted: [4,3), so offset 4, length -1
      hresult 0x80070057
      message "length"
```

`0x80070057` and `length` are what the crash record carries.

**How rare, exhaustively rather than by sampling** — every ordered tuple of up to four entity
ranges over every text length up to 8, through both versions:

| entities | tuples | shipped: inverted run | shipped: not a partition | rewritten |
|---|---|---|---|---|
| 1 | 120 | 0 | 0 | clean |
| 2 | 2,892 | 0 | 0 | clean |
| 3 | 82,488 | 0 | 4,746 | clean |
| 4 | 2,550,756 | 1,560 | 499,896 | clean |

So four overlapping entities is the *minimum* for the crash, which is why it is rare — but the
overlapping-run defect starts at three, and there it silently renders the overlapped text twice
rather than crashing.

The rewritten version is a correct partition on every one of those tuples, and on 3 M random
entity sets carrying `Flags` and `Type` as well. Where the old algorithm was correct, the new one
reproduces its geometry and its flags **exactly** — zero divergences.

### One deliberate behaviour change

The two disagree only on which `Type` a segment carries when **two or more type-bearing entities
cover it**. The old answer was path-dependent: it depended on which geometric branch the fold
happened to take, so a spoiler over a link produced `TextEntityTypeTextUrl` or
`TextEntityTypeSpoiler` depending only on which entity came first.

The new rule is that the **innermost** (shortest) covering entity wins, with a custom emoji winning
outright. A wrapper is by construction longer than what it wraps, so this yields the content's type
— which is what `SetText` reads, since it branches on the flags first and then expects `Type` to
match. Pinned as scenarios:

| | `Type` |
|---|---|
| spoiler wrapping a link | link |
| spoiler wrapping a custom emoji | custom emoji |
| spoiler wrapping code | code |
| bold wrapping a link | link |
| link containing a custom emoji | custom emoji |

Of the three candidate rules this is also the closest to the old behaviour (81.9% identical, against
78.5% for "latest wins" and 75.3% for "earliest wins") — the spread is small because the old rule
was effectively arbitrary.

`TextStyleRun.Merge` and the private copy constructor had no callers left and are removed.

### Build

**Not built or run as the app.** The algorithm itself is compiled and executed above — both
versions, extracted verbatim — and the native half was compiled with MSVC against the project's
`base.h`. What has *not* happened is a build of Telegram.Modern.csproj, so the edited file is only
known to parse (`CSharpSyntaxTree.ParseText(...).GetDiagnostics()` — syntax, not type checking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBBsSBCnGZwAjAKSJ78nvC
