### PR TITLE
Keep the topic list from taking input once its chat is cleared

### DIFF
--- a/Telegram/Views/MainPage.xaml.cs
+++ b/Telegram/Views/MainPage.xaml.cs
@@ -3733,6 +3733,10 @@ namespace Telegram.Views
             _topicListCollapsed = !show;
             TopicListPresenter.Visibility = Visibility.Visible;
 
+            // Hiding clears the model below while the presenter stays visible for the
+            // animation, so input has to stop now: a click landing in between finds a null Chat.
+            TopicListPresenter.IsHitTestVisible = show;
+
             MasterDetail.CornerRadius = new CornerRadius(show ? 0 : 8, 0, 0, 0);
             Canvas.SetZIndex(ChatsRoot, show ? 1 : 0);
 


### PR DESCRIPTION
`NullReferenceException` — *Object reference not set to an instance of an object.*
Reported by crash telemetry on 12.10.4.0 (X64).

```
NullReferenceException
   7  Telegram_Telegram_Controls_Views_ForumView__Profile_Click+0x7e
      Telegram/Controls/Views/ForumView.xaml.cs:182
   9  DirectUI::CRoutedEventSourceBase<...>::Raise+0x495
  10  DirectUI::ButtonBase::OnClick+0x98
  12  DirectUI::ButtonBase::PerformPointerUpAction+0x52
  13  DirectUI::ButtonBase::OnPointerReleased+0x23c
  32  CInputServices::RaiseDelayedPointerUpEvent+0x14f
  33  CInputServices::ProcessGestureInput+0x131
  34  CInputServices::ProcessTouchInteractionCallback+0x47
```

## Which pointer

`ForumView.xaml.cs:182` is

```csharp
ViewModel.NavigationService.Navigate(typeof(ProfilePage), ViewModel.Chat.Id);
```

three dereferences on one line, so the line alone does not say which one died.
Disassembling `+0x7e` in the shipped image settles it — the faulting instruction is

```
+0x65  mov  rcx,[rax+78h]          ; ViewModel.Items
+0x69  cmp  dword ptr [rcx],ecx    ; null check on Items — passed
+0x6b  mov  rbx,[rcx+98h]          ; Items.Chat
+0x79  call RhpNewFast             ; box the Int64 parameter
+0x7e  mov  r8,[rbx+0B0h]          ; <-- Chat.Id, rbx == null
```

So `ViewModel` and `NavigationService` were both fine; `TopicListViewModel.Chat` was null.

## Why it was null

`MainPage.ShowHideTopicList(false)` clears the model at the *start* of the dismissal:

```csharp
_topicListCollapsed = !show;
TopicListPresenter.Visibility = Visibility.Visible;   // stays visible
...
else
{
    ViewModel.Topics.SetChat(null);                   // Chat is gone from here on
}
```

`SetChat(null)` runs immediately, but the presenter is only collapsed later, from the
`Completed` handler of the slide-out animation's scoped batch. For the whole of that
`Constants.FastAnimation` (167 ms) the `ForumView` is visible, on top, and hit-testable,
with `Chat == null` — and if the batch never completes (the compositor is not animating,
e.g. the window is occluded) it stays that way indefinitely.

Every handler in `ForumView` dereferences the model without a guard —
`Profile_Click` and `Menu_ContextRequested` both go through `ViewModel.Chat` — so a click
anywhere in the header during that window crashes. The touch frames in the stack are
consistent with it: XAML holds the pointer-up back for the gesture engine
(`RaiseDelayedPointerUpEvent`), which widens the window a tap has to land in.

## The fix

Stop the presenter taking input at the same moment its model is cleared, rather than when
it is finally collapsed. One line, symmetric with the `Visibility` assignment next to it,
and it closes the whole class rather than just `Profile_Click`.

Deferring `SetChat(null)` to the batch instead was the other option, but it changes
behaviour: `ChatsList`'s toggle compares `ViewModel.Topics.Chat?.Id` against the selected
chat, so keeping the old chat alive through the animation turns a re-tap during the
dismissal into a no-op instead of a re-open.

## Build

Not built — a NativeAOT/UWP build was not available here. The change is three lines inside
an existing method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oYFzWyw4jzvAzYE8Zpgai
